### PR TITLE
Bug 91953: Average per day to exclude allowance top up

### DIFF
--- a/tabs/src/components/TotalZapsComponent.tsx
+++ b/tabs/src/components/TotalZapsComponent.tsx
@@ -12,6 +12,8 @@ import { getUserName } from '../utils/walletUtilities';
 
 export interface ZapSent {
   totalZaps: number;
+  numberOfDays: number;
+  numberOfUsers: number;
   averagePerUser: number;
   averagePerDay: number;
   biggestZap: number;
@@ -22,27 +24,27 @@ export interface ZapSent {
 const adminKey = process.env.REACT_APP_LNBITS_ADMINKEY as string;
 
 const TotalZapsComponent: FunctionComponent = () => {
-  const [activePeriod, setActivePeriod] = useState<number | null>(null);
   const [zaps, setZaps] = useState<Transaction[]>([]);
   const [users, setUsers] = useState<User[]>([]);
   const [totalZaps, setTotalZaps] = useState<number>(0);
-  const [totalUsers, setTotalUsers] = useState<number>(0);
-  const [averagePerDay, setAveragePerDay] = useState<number>(0); // State for average per day
-  const [biggestZap, setBiggestZap] = useState<number>(0); // State for biggest zap
-  const [averagePerUser, setAveragePerUser] = useState<number>(0); // State for average per user
+  const [numberOfDays, setNumberOfDays] = useState<number>(0);
+  const [numberOfUsers, setNumberOfUsers] = useState<number>(0);
+  const [averagePerDay, setAveragePerDay] = useState<number>(0);
+  const [averagePerUser, setAveragePerUser] = useState<number>(0);
+  const [biggestZap, setBiggestZap] = useState<number>(0);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
 
   const zapsSent: ZapSent = {
     totalZaps: totalZaps,
+    numberOfDays: numberOfDays,
+    numberOfUsers: numberOfUsers,
     averagePerUser: averagePerUser,
     averagePerDay: averagePerDay,
     biggestZap: biggestZap,
     zapsFromCopilots: 0,
     zapsToCopilots: 0,
   };
-
-  const today = new Date();
 
   useEffect(() => {
     const fetchZaps = async () => {
@@ -109,15 +111,23 @@ const TotalZapsComponent: FunctionComponent = () => {
           .reduce((sum, zap) => sum + zap.amount, 0) / 1000;
       setTotalZaps(Math.floor(Math.abs(total))); // Convert to positive
 
+      // Calculate the number of users
+      const numUsers = users.length;
+      setNumberOfUsers(numUsers);
+
       // Calculate the number of days since the first zap
       const currentTime = Date.now() / 1000;
       const firstZapTime = Math.min(...zaps.map(zap => zap.time));
-      const numberOfDays = (currentTime - firstZapTime) / (24 * 60 * 60);
-      const averagePerDay = total / numberOfDays;
-      setAveragePerDay(Math.floor(Math.abs(averagePerDay)));
+      const numDays = (currentTime - firstZapTime) / (24 * 60 * 60);
+      setNumberOfDays(Math.floor(numDays));
 
-      const averagePerUser = total / users.length;
-      setAveragePerUser(Math.floor(Math.abs(averagePerUser)));
+      // Calculate the average per user
+      const avPerUser = totalZaps / numUsers;
+      setAveragePerUser(Math.floor(Math.abs(avPerUser)));
+
+      // Calculate the average per day
+      const avPerDay = Math.abs(total) / Math.floor(numDays);
+      setAveragePerDay(Math.floor(Math.abs(avPerDay)));
 
       // Calculate the biggest zap considering only negative values
       const negativeZaps = zaps.filter(zap => zap.amount < 0);
@@ -147,6 +157,36 @@ const TotalZapsComponent: FunctionComponent = () => {
         <div className={styles.zapStats}>
           <table width="100%" className={`${styles.statsTable} `}>
             <tbody>
+              <tr>
+                <td className={styles.tdWidth}>Number of users</td>
+                <td className={`${styles.statValue}`}>
+                  {loading ? (
+                    'Loading ...'
+                  ) : (
+                    <>
+                      <span className={`${styles.zapValues}`}>
+                        {zapsSent.numberOfUsers.toLocaleString()}
+                      </span>{' '}
+                      Users
+                    </>
+                  )}
+                </td>
+              </tr>
+              <tr>
+                <td className={styles.tdWidth}>Number of days</td>
+                <td className={`${styles.statValue}`}>
+                  {loading ? (
+                    'Loading ...'
+                  ) : (
+                    <>
+                      <span className={`${styles.zapValues}`}>
+                        {zapsSent.numberOfDays.toLocaleString()}
+                      </span>{' '}
+                      Days
+                    </>
+                  )}
+                </td>
+              </tr>
               <tr>
                 <td className={styles.tdWidth}>Average per user</td>
                 <td className={`${styles.statValue}`}>


### PR DESCRIPTION
- [Bug 91953](https://dev.azure.com/EvrosPowerPlatformTeam/Default/_workitems/edit/91953): Average per day to exclude allowance top up (actually seemed fixed already)
- Fixed average not being total Sats / number of days
- Added additional metrics for easier qualification

![image](https://github.com/user-attachments/assets/4910dfd9-9f37-4aee-879e-c29668b7a979)

To test @EdiWeeks, run:

```
rm -rf node_modules
npm install
npm start
```

Then:

- Switch to 60-days, add up all the zaps in the feed, and confirm it matches to the Total zaps sent
- Switch to 60-days, confirm how many days ago the first days was for "Number of Days"
- Go to "Users" to confirm the "Number of days"
- Divide the total Sats by the number of users to get "Average per user"
- Divide the total Sats by the number of days to get "Average per day"
- Switch to 60-days, confirm the biggest zap for the "Biggest Zap"