### PR TITLE
Bug 92325: This Static Web App already has the maximum number of staging environments

### DIFF
--- a/.github/workflows/azure-static-web-apps-test.yml
+++ b/.github/workflows/azure-static-web-apps-test.yml
@@ -55,11 +55,27 @@ jobs:
           output_location: 'build' # Built app content directory - optional
           ###### End of Repository/Build Configurations ######
 
+      - name: Install Azure CLI
+        run: |
+          curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+
+      - name: Azure Login
+        run: az login --service-principal -u ${{ secrets.AZURE_CLIENT_ID }} -p ${{ secrets.AZURE_CLIENT_SECRET }} --tenant ${{ secrets.TENANT_ID }}
+
+      - name: Add Redirect URI
+        if: github.event_name == 'pull_request'
+        run: |
+          az ad app update --id 9b80eb43-d75a-43e3-8104-0d6d0f0b41ec --add web.redirectUris ${{ steps.builddeploy.outputs.deploymentUrl }}
+
   close_pull_request_job:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     runs-on: ubuntu-latest
     name: Close Pull Request Job
     steps:
+      - name: Remove Redirect URI
+        run: |
+          az ad app update --id 9b80eb43-d75a-43e3-8104-0d6d0f0b41ec --remove web.redirectUris ${{ steps.builddeploy.outputs.deploymentUrl }}
+
       - name: Close Pull Request
         id: closepullrequest
         uses: Azure/static-web-apps-deploy@v1

--- a/.github/workflows/azure-static-web-apps-test.yml
+++ b/.github/workflows/azure-static-web-apps-test.yml
@@ -13,6 +13,9 @@ jobs:
   build_and_deploy_job:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     environment: Test
     name: Build and Deploy Job
     steps:
@@ -64,5 +67,3 @@ jobs:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
           action: 'close'
           app_location: '/tabs'
-          api_location: ''
-          output_location: 'build'

--- a/.github/workflows/azure-static-web-apps-test.yml
+++ b/.github/workflows/azure-static-web-apps-test.yml
@@ -60,7 +60,7 @@ jobs:
           curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
 
       - name: Azure Login
-        run: az login --service-principal -u ${{ secrets.AZURE_CLIENT_ID }} -p ${{ secrets.AZURE_CLIENT_SECRET }} --tenant ${{ secrets.TENANT_ID }}
+        run: az login --service-principal -u ${{ secrets.AZURE_CLIENT_ID }} -p ${{ secrets.AZURE_CLIENT_SECRET }} --tenant ${{ secrets.AZURE_TENANT_ID }}
 
       - name: Add Redirect URI
         if: github.event_name == 'pull_request'

--- a/.github/workflows/azure-static-web-apps-test.yml
+++ b/.github/workflows/azure-static-web-apps-test.yml
@@ -16,10 +16,18 @@ jobs:
     environment: Test
     name: Build and Deploy Job
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v3
         with:
           submodules: true
           lfs: false
+
+      - name: Run preinstall script
+        run: npx npm-force-resolutions
+
+      - name: Install dependencies
+        run: npm install
+
       - name: Build And Deploy
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1
@@ -29,19 +37,19 @@ jobs:
           REACT_APP_LNBITS_USERNAME: ${{ secrets.LNBITS_USERNAME }}
           REACT_APP_LNBITS_PASSWORD: ${{ secrets.LNBITS_PASSWORD }}
           REACT_APP_LNBITS_ADMINKEY: ${{ secrets.LNBITS_ADMINKEY }}
-          REACT_APP_LNBITS_STORE_ID: ${{ secrets.LNBITS_STORE_ID }} 
-          REACT_APP_TENANT_ID:  ${{ secrets.TENANT_ID }}
-          REACT_APP_AAD_CLIENT_ID:  ${{ secrets.AAD_CLIENT_ID }}
+          REACT_APP_LNBITS_STORE_ID: ${{ secrets.LNBITS_STORE_ID }}
+          REACT_APP_TENANT_ID: ${{ secrets.TENANT_ID }}
+          REACT_APP_AAD_CLIENT_ID: ${{ secrets.AAD_CLIENT_ID }}
           REACT_APP_LNBITS_STORE_OWNER_EMAIL: ${{ secrets.LNBITS_STORE_OWNER_EMAIL }}
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
           repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
-          action: "upload"
+          action: 'upload'
           ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
-          app_location: "/tabs" # App source code path
-          api_location: "" # Api source code path - optional
-          output_location: "build" # Built app content directory - optional
+          app_location: '/tabs' # App source code path
+          api_location: '' # Api source code path - optional
+          output_location: 'build' # Built app content directory - optional
           ###### End of Repository/Build Configurations ######
 
   close_pull_request_job:
@@ -54,4 +62,7 @@ jobs:
         uses: Azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
-          action: "close"
+          action: 'close'
+          app_location: '/tabs'
+          api_location: ''
+          output_location: 'build'


### PR DESCRIPTION
This PR fixes:

- [Bug 92325](https://dev.azure.com/EvrosPowerPlatformTeam/Default/_workitems/edit/92325): This Static Web App already has the maximum number of staging environments
- Adds required field to remove the staging web app when the PR is closed

To confirm each PR, we deploy a staging version of the web app to Azure. We can therefore, test the web app part of the solution without needing to necessarily checkout the PR locally. Will make it easier for Preppers / Designers / Testers to validate PRs.

Some were previously failing, as we only have 3 staging environments for the Free tier. I have therefore increased this to the Standard tier so we can have up to 10 staging environments. I.e. 10 PRs that are ready for review.

To test this PR @EdiWeeks:

1. Confirm on this page it says "All checks have passed"
1. Click "Details" next to "React App Tabs to Test / Build and Deploy Job (pull_request)"
1. Expand "Build and Deploy" section
1. Click on "Visit your site at: https://aaaaaaaaaaaaaaaa.centralus.5.azurestaticapps.net/"

Update: I have amended permissions so the GitHub workflow can write a simple comment to this PR as follows:

![image](https://github.com/user-attachments/assets/6e36f999-f438-4b0c-8f6c-5dfd71a6a2bf)

FYI @desousamario85 @akash2017sky 
