### PR TITLE
Bug 91961: 100000000 Sats was converted to 10000 when hit Send Zap button

### DIFF
--- a/src/commands/sendZapCommand.ts
+++ b/src/commands/sendZapCommand.ts
@@ -147,12 +147,11 @@ async function createZapCard() {
       errorMessage: 'You should tell them why you are zapping them',
     },
     {
-      type: 'Input.Number',
+      type: 'Input.Text',
       id: 'zapAmount',
       placeholder: '100',
       label: 'Amount (Sats)',
-      min: 1,
-      max: 10000,
+      regex: '^(?:10000|[1-9][0-9]{0,3}|0)$',
       isRequired: true,
       errorMessage: 'You must specify an amount between 1 and 10,000 Sats',
     },
@@ -186,7 +185,7 @@ async function createZapCard() {
       },
     ],
     $schema: 'http://adaptivecards.io/schemas/adaptive-card.json',
-    version: '1.2',
+    version: '1.5',
   };
 }
 

--- a/src/commands/sendZapCommand.ts
+++ b/src/commands/sendZapCommand.ts
@@ -151,7 +151,7 @@ async function createZapCard() {
       id: 'zapAmount',
       placeholder: '100',
       label: 'Amount (Sats)',
-      regex: '^(?:10000|[1-9][0-9]{0,3}|0)$',
+      regex: '^(?:10000|[1-9][0-9]{0,3})$',
       isRequired: true,
       errorMessage: 'You must specify an amount between 1 and 10,000 Sats',
     },


### PR DESCRIPTION
### Description

To overcome the limitation within Adaptive Card for Microsoft Teams, the Zap Amount field has been changed to a Input.Text.
This allows us to add better validation rules and confirm the value is less than 10000. 
Input.Number doesn't allow for the feature and any number enter over 10000 automatically converts to 10000 to sumbit the request.

The Regex expression ```^(?:10000|[1-9][0-9]{0,3})$``` makes sure the value entered in =<10000. The only drawback is users can enter text but the card will not send due to the regex validation in place.


### Screenshot/video

![image](https://github.com/user-attachments/assets/df83c422-5aab-4a2b-b952-f1a34cc6ea5d)

### Related workitems

- [Bug 91961](https://dev.azure.com/EvrosPowerPlatformTeam/Default/_workitems/edit/91961): 100000000 Sats was converted to 10000 when hit Send Zap button

Fixes # (issue)

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Test Instructions

To test this PR:

1. Run clone the PR to your local machine
1. Ensure all environment variables are populated.
1. Run Zapp.ie and Enter or select the **Send Zap** prompt.
2. Try enter a value over 10000 and confirm the error message appears.
3. Try enter a any text into the box and confirm the error message appears
4. Enter a value under 10000 and confirm the zaps are sent to the user.

### Checklist:

- [x] My code follows the style guidelines of this project (see "Contribute" in the wiki)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New and existing unit tests pass locally with my changes