### PR TITLE
Bug 91952: CreateUser must be running for users who already exist

### DIFF
--- a/src/services/lnbitsService.ts
+++ b/src/services/lnbitsService.ts
@@ -479,8 +479,8 @@ const updateUser = async (
       data.extra?.allowanceWalletId,
     );
 
-    console.log('privateWallet 111:', privateWallet);
-    console.log('allowanceWallet 111:', allowanceWallet);
+    console.log('privateWallet :', privateWallet);
+    console.log('allowanceWallet :', allowanceWallet);
 
     // Map the user to match the User interface
     const userData: User = {

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -60,11 +60,11 @@ export class UserService {
   public async ensureUserSetup(
     teamsChannelAccount: TeamsChannelAccount,
   ): Promise<User> {
-    console.log('ensureUserSetup starting ...');
+    const aadObjectId = teamsChannelAccount.aadObjectId ;
 
     let user: User | null = null;
     let lnbitsUsers = await getUsers(adminKey, {
-      aadObjectId: teamsChannelAccount.aadObjectId, // userProfile.aadObjectId,
+      aadObjectId: aadObjectId, // userProfile.aadObjectId,
     });
     if (lnbitsUsers.length > 1) {
       throw new Error('More than one user found with the same aadObjectId');
@@ -79,7 +79,7 @@ export class UserService {
         teamsChannelAccount.email,
         '', // The password is a legacy field and ignored anyway.
         {
-          aadObjectId: teamsChannelAccount.aadObjectId,
+          aadObjectId: aadObjectId,
           userType: 'teammate',
           profileImg: `https://hiberniaevros.sharepoint.com/_layouts/15/userphoto.aspx?AccountName='${teamsChannelAccount.userPrincipalName}`, // TODO: Get the user's profile image from Teams
           //profileImg: teamsChannelAccount.properties

--- a/src/teamsBot.ts
+++ b/src/teamsBot.ts
@@ -257,7 +257,7 @@ export class TeamsBot extends TeamsActivityHandler {
 
     //this.onMembersAdded(async (context, next) => {
     this.onCommand(async (context, next) => {
-      // Retrieve the per-user setup flag
+      /* Retrieve the per-user setup flag
       //const currentUser = await this.userProfileAccessor.get(context);
       const userService = UserService.getInstance();
       const currentUser = userService.getCurrentUser();
@@ -292,8 +292,8 @@ export class TeamsBot extends TeamsActivityHandler {
           );
         }
       }
-    });
-  }
+    }*/;
+  })}
 
   async run(context: TurnContext) {
     try {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,5 @@
     "skipLibCheck": true // Skip type checking of all declaration files (*.d.ts)
   },
   "include": ["src/**/*.ts", "src/types/**/*.d.ts"], // Ensure this covers your `global.d.ts`
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules","tabs", "functions"]
 }


### PR DESCRIPTION
### Description

When new users were installing Zapp.ie is was creating duplicate accounts.
Resovle the issue by review and updating the code to ensure users are only created once.

### Screenshot/video

![image](https://github.com/user-attachments/assets/cb9727dc-c27d-420c-abeb-5c7b191c84f7)

### Related workitems

-[Bug 91952](https://dev.azure.com/EvrosPowerPlatformTeam/Default/_workitems/edit/91952): CreateUser must be running for users who already exist

Fixes # (issue)

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Test Instructions

To test this PR:

1. First your LNBits Account on the Sandbox (Dev or Test instances)
1. Open Zapp.ie (test) within MS Teams
1. Select the Show My Balance, this will trigger the bot to create a new account
![image](https://github.com/user-attachments/assets/eeb858fd-f915-4106-b4b9-8f995d31ad3c)
is an expected error message for first time creation.
1. Send the same prompt again and your balance will display.

### Checklist:

- [x] My code follows the style guidelines of this project (see "Contribute" in the wiki)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New and existing unit tests pass locally with my changes