### PR TITLE
Bug 99139: Error message in adaptive card

### DIFF
--- a/src/commands/sendZapCommand.ts
+++ b/src/commands/sendZapCommand.ts
@@ -434,20 +434,23 @@ async function messageRecipient(
     };
 
     // Create the conversation ... or Adapter.CreateConversationAsync????
+    /*
     const response = await connectorClient.conversations.createConversation(
       conversationParameters,
     );
-
+    */
     // Create the message
     const message = MessageFactory.text(
       `You have received ${zapAmount} Sats from ${sender.displayName} with a message: "${zapMessage}"`,
     );
 
     // Send the message to the new conversation
+    /* 
     await connectorClient.conversations.sendToConversation(
       response.id,
       message,
     );
+    */
   } catch (error) {
     if (
       error.statusCode === 403 ||


### PR DESCRIPTION
### Description

The error occurs because the bot is attempting to send a message to the recipient of the Zap, but it fails since this logic is not yet complete.

To prevent this issue, I have commented out the part of the logic responsible for sending the message on behalf of the bot for now.

### Screenshot/video

![image](https://github.com/user-attachments/assets/44c1f32e-9cf1-4da1-96c0-ba5938774a96)

### Related work items

- [Bug 99139](https://dev.azure.com/EvrosPowerPlatformTeam/Default/_workitems/edit/99139): Error message in adaptive card

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Test Instructions

To test this PR:

1. Go the the tabs folder with cd tabs
2. Run Zapp.ie bot locally
3. Select the prompt – Send Zap and send a Zap to someone.
4. Check if the error message is no longer visible.

### Checklist:

- [x] My code follows the style guidelines of this project (see "Contribute" in the wiki)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New and existing unit tests pass locally with my changes

fyi @EdiWeeks 