### PR TITLE
Enhancement 99137: To be able to send Sats to Multiple users in a single Zap

### DIFF
--- a/src/commands/sendZapCommand.ts
+++ b/src/commands/sendZapCommand.ts
@@ -49,6 +49,7 @@ export async function SendZap(
   zapMessage: string,
   zapAmount: number,
   context: TurnContext,
+  updateCard: boolean = true
 ): Promise<void> {
   try {
     console.log('Sending zap ...');
@@ -87,7 +88,7 @@ export async function SendZap(
 
     console.log('Payment Result:', result);
 
-    if (result && result.payment_hash) {
+    if (result && result.payment_hash && updateCard) {
       // Updated adaptive card (read-only)
       const updatedCard = {
         type: 'AdaptiveCard',
@@ -246,10 +247,11 @@ async function createZapCard() {
       type: 'Input.ChoiceSet',
       label: 'Receiver',
       id: 'zapReceiverId',
-      placeholder: 'Select a recipient wallet',
+      placeholder: 'Select one or more recipient wallets',
       choices: walletChoices,
       isRequired: true,
-      errorMessage: 'You must select someone to zap',
+      isMultiSelect: true,
+      errorMessage: 'You must select at least one person to zap',
     },
     {
       type: 'Input.Text',
@@ -285,7 +287,7 @@ async function createZapCard() {
       }
     });
   }*/
-
+  
   return {
     type: 'AdaptiveCard',
     body: cardBody,
@@ -358,7 +360,7 @@ async function messageRecipient(
       botAppId,
       process.env.SECRET_AAD_APP_CLIENT_SECRET, // Is this password encrypted?
     );*/
-
+    
     console.log('Bot App ID:', botAppId);
     console.log('Bot Name:', botName);
 


### PR DESCRIPTION
### Description

The logic for sending Sats to users has been updated to allow multi-selection, enabling users to send the same number of Sats with the same text to multiple recipients at once.

Additionally:

- The placeholder text in the Receiver field has been updated to: **"Select one or more recipient wallets."**

![image](https://github.com/user-attachments/assets/fe337aa4-d7cc-4444-a3f0-65594ec130b8)

- The adaptive card has been modified; after sending Sats, it now displays a list of users who received them.

![image](https://github.com/user-attachments/assets/257da860-d97d-4d3d-b901-e079a5a0a69f)

### Related workitems

- [Enhancement 99137](https://dev.azure.com/EvrosPowerPlatformTeam/Default/_workitems/edit/99137): To be able to send Sats to Multiple users in a single Zap

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Test Instructions

To test this PR:

1. Run Zapp.ie bot locally (Debug in Teams).
2. Open Zapp.ie bot in Microsoft Teams.
3. Use prompt: **"Send Zap"**
4. Check if the adaptive card appears as expected and verify its full functionality.

### Checklist:

- [x] My code follows the style guidelines of this project (see "Contribute" in the wiki)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New and existing unit tests pass locally with my changes

fyi @EdiWeeks 