### PR TITLE
Enhancement 100638: Add "Sorting" ability to Feed by clicking on column title

### DIFF
--- a/tabs/src/components/FeedList.module.css
+++ b/tabs/src/components/FeedList.module.css
@@ -226,3 +226,12 @@
     color: #555;
     transform: none;
   }
+
+  .hoverable {
+    cursor: pointer;
+    transition: color 0.2s ease;
+  }
+  
+  .hoverable:hover {
+    color: #5b5fc7;
+  }


### PR DESCRIPTION
## This is a new PR created from an existing branch
### Description

Sorting has been added to the React Zapp.ie app. By clicking on a column title, you can sort all columns (except Memo) in both ascending and descending order.

- An arrow has been added next to the sorted column, indicating the active sorting field and whether it is sorted ascending (up) or descending (down).

- A hover effect has also been implemented to signal that the column names are clickable for sorting.

Two tickets in one PR

1. [Enhancement 100638](https://dev.azure.com/EvrosPowerPlatformTeam/Default/_workitems/edit/100638): Add "Sorting" ability to Feed by clicking on column title
2. [Bug 100637](https://dev.azure.com/EvrosPowerPlatformTeam/Default/_workitems/edit/100637): Sats sorting is incorrect in 30 and 60 days tabs

### Screenshot/video

1. ![image](https://github.com/user-attachments/assets/a4482f7f-b203-42f7-8074-ed61aa01231b)
2. ![image](https://github.com/user-attachments/assets/e7df1a05-70cb-4963-8819-1b143cb6209b)

### Related workitems

- [Enhancement 100638](https://dev.azure.com/EvrosPowerPlatformTeam/Default/_workitems/edit/100638): Add "Sorting" ability to Feed by clicking on column title
- [Bug 100637](https://dev.azure.com/EvrosPowerPlatformTeam/Default/_workitems/edit/100637): Sats sorting is incorrect in 30 and 60 days tabs

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Test Instructions

To test this PR:

1. Go the the tabs folder with cd tabs
2. Run npm install
3. Run npm start
6. Go to the Feed tab and check if sorting works when we click on the corresponding column titles

### Checklist:

- [x] My code follows the style guidelines of this project (see "Contribute" in the wiki)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New and existing unit tests pass locally with my changes

fyi @EdiWeeks 