### PR TITLE
Fetched the remaining balance and updated the adaptive card

### DIFF
--- a/src/commands/sendZapCommand.ts
+++ b/src/commands/sendZapCommand.ts
@@ -13,7 +13,7 @@ import {
   TeamsActivityHandler,
 } from 'botbuilder';
 import { ConnectorClient } from 'botframework-connector';
-import { getUsers, payInvoice, createInvoice } from '../services/lnbitsService';
+import { getUsers, payInvoice, createInvoice, getWalletBalance } from '../services/lnbitsService';
 import { error } from 'console';
 import { UserService } from '../services/userService';
 
@@ -90,6 +90,10 @@ export async function SendZap(
 
     if (result && result.payment_hash && updateCard) {
       // Updated adaptive card (read-only)
+      //fetch remainingBalance
+      const remainingBalance = await getWalletBalance(sender.allowanceWallet.inkey);
+      console.log('Remaining Balance:', remainingBalance);
+
       const updatedCard = {
         type: 'AdaptiveCard',
         body: [
@@ -178,6 +182,32 @@ export async function SendZap(
               },
             ],
           },
+          {
+            type: 'ColumnSet',
+            columns: [
+              {
+                type: 'Column',
+                width: 'auto',
+                items: [
+                  {
+                    type: 'TextBlock',
+                    text: `Remaining Amount (Sats):`,
+                    weight: 'Bolder',
+                  },
+                ],
+              },
+              {
+                type: 'Column',
+                width: 'stretch',
+                items: [
+                  {
+                    type: 'TextBlock',
+                    text: `${remainingBalance}`,
+                  },
+                ],
+              },
+            ],
+          }
         ],
         $schema: 'http://adaptivecards.io/schemas/adaptive-card.json',
         version: '1.2',

--- a/src/commands/sendZapCommand.ts
+++ b/src/commands/sendZapCommand.ts
@@ -1,20 +1,14 @@
-import { SSOCommand, SSOCommandMap } from './SSOCommandMap';
+import { SSOCommand } from './SSOCommandMap';
 import {
   TurnContext,
   ActivityTypes,
   Activity,
-  TeamsInfo,
   CardFactory,
   MessageFactory,
-  CloudAdapter,
-  ConversationReference,
   ConversationParameters,
-  ChannelAccount,
-  TeamsActivityHandler,
 } from 'botbuilder';
 import { ConnectorClient } from 'botframework-connector';
 import { getUsers, payInvoice, createInvoice, getWalletBalance } from '../services/lnbitsService';
-import { error } from 'console';
 import { UserService } from '../services/userService';
 
 const adminKey = process.env.LNBITS_ADMINKEY as string;

--- a/src/teamsBot.ts
+++ b/src/teamsBot.ts
@@ -28,6 +28,7 @@ import {
   createUser,
   createWallet,
   updateUser,
+  getWalletBalance,
 } from './services/lnbitsService';
 import { UserService } from './services/userService';
 import { access } from 'fs';
@@ -133,6 +134,10 @@ export class TeamsBot extends TeamsActivityHandler {
             .map((name) => `- ${name}`)
             .join('\n');
 
+          //fetch remainingBalance
+          const remainingBalance = await getWalletBalance(currentUser.allowanceWallet.inkey);
+          console.log('Remaining Balance:', remainingBalance);
+
           // Update adaptive card to read-only with list of recipients
           const updatedCard = {
             type: 'AdaptiveCard',
@@ -158,6 +163,12 @@ export class TeamsBot extends TeamsActivityHandler {
                 type: 'TextBlock',
                 text: `**Amount (Sats):** ${zapAmount}`,
                 wrap: true
+              },
+              {
+                type: 'TextBlock',
+                text: `**Remaining Amount (Sats):** ${remainingBalance}`,
+                wrap: true,
+                color: 'Good',
               },
             ],
             $schema: 'http://adaptivecards.io/schemas/adaptive-card.json',

--- a/src/teamsBot.ts
+++ b/src/teamsBot.ts
@@ -6,15 +6,10 @@ import {
   MemoryStorage,
   ConversationState,
   UserState,
-  TeamInfo,
   CardFactory,
-  Middleware,
   MessageFactory,
-  TeamsInfo,
-  StatePropertyAccessor,
-  Mention
 } from 'botbuilder';
-import { SSOCommand, SSOCommandMap } from './commands/SSOCommandMap';
+import {  SSOCommandMap } from './commands/SSOCommandMap';
 import { Client } from '@microsoft/microsoft-graph-client';
 import { OnBehalfOfUserCredential } from '@microsoft/teamsfx';
 import { SendZapCommand, SendZap } from './commands/sendZapCommand';
@@ -23,15 +18,8 @@ import { WithdrawFundsCommand } from './commands/withdrawFundsCommand';
 import { ShowLeaderboardCommand } from './commands/showLeaderboardCommand';
 import {
   getUser,
-  getUsers,
-  getWalletById,
-  createUser,
-  createWallet,
-  updateUser,
   getWalletBalance,
 } from './services/lnbitsService';
-import { UserService } from './services/userService';
-import { access } from 'fs';
 
 const adminKey = process.env.LNBITS_ADMINKEY as string;
 interface CancellationToken {


### PR DESCRIPTION
### Description
Add the Remaining Amount (Sats) to the adaptive card
Updated the command files to fetch the latest balance after sending the Zaps to a colleague.
 
### Screenshot/video
 
1. ![image](https://github.com/user-attachments/assets/fd3fc089-f780-4f05-af32-db1c18994623)

### Related work items
 
- [Enhancement 101278](https://dev.azure.com/EvrosPowerPlatformTeam/Default/_workitems/edit/101278): Add Remaining Amount (Sats) to adaptive card
 
Fixes # (issue)
 
### Type of Change
 
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
 
### Test Instructions
 
To test this PR:
 
1. Open the Zappie Branch to your local VScode
2. Run npm install
3. Click on the play button to run the Team bot
4. Login with your developer/Test credentials
5. Once the Teams bot for Zappie is opened, click on the command named 'Zend Zaps'
6. Enter the form and send some test zaps to any colleague
7. Wait for the confirmation message, this will display the remaining balance
 
### Checklist:
 
- [x] My code follows the style guidelines of this project (see "Contribute" in the wiki)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New and existing unit tests pass locally with my changes