### PR TITLE
Fix topUpWallet to use LNbits core balance endpoint

### DIFF
--- a/src/services/lnbitsService.ts
+++ b/src/services/lnbitsService.ts
@@ -804,8 +804,7 @@ const getWalletIdByUserId = async (adminKey: string, userId: string) => {
 async function topUpWallet(walletId: string, amount: number): Promise<void> {
   const accessToken = await getAccessToken(`${userName}`, `${password}`);
 
-  // LNbits moved wallet top-ups from the old "User Manager" extension
-  // (/users/api/v1/topup, removed in LNbits >= 1.0.0) into core (/users/api/v1/balance).
+  // /topup was removed by LNbits >= 1.0.0; balance top-ups now go through /balance.
   const url = `${lnbiturl}/users/api/v1/balance`;
   const body = {
     id: walletId,

--- a/src/services/lnbitsService.ts
+++ b/src/services/lnbitsService.ts
@@ -804,10 +804,12 @@ const getWalletIdByUserId = async (adminKey: string, userId: string) => {
 async function topUpWallet(walletId: string, amount: number): Promise<void> {
   const accessToken = await getAccessToken(`${userName}`, `${password}`);
 
-  const url = `${lnbiturl}/users/api/v1/topup`;
+  // LNbits moved wallet top-ups from the old "User Manager" extension
+  // (/users/api/v1/topup, removed in LNbits >= 1.0.0) into core (/users/api/v1/balance).
+  const url = `${lnbiturl}/users/api/v1/balance`;
   const body = {
-    amount: amount.toString(),
     id: walletId,
+    amount,
   };
 
   try {


### PR DESCRIPTION
## Description
Fixes wallet top-ups so they work against modern LNbits (>= 1.0.0), where the old User Manager extension endpoint was removed.

## Type of Change
- [x] Bug fix

## Related Issues
Fixes #148

## Changes Made
### Problem
`topUpWallet` in `src/services/lnbitsService.ts` calls `PUT /users/api/v1/topup`, an endpoint that belonged to the old LNbits "User Manager" extension.

### Root Cause
That extension is incompatible with any LNbits version >= 1.0.0 (confirmed installing it locally against LNbits 1.5.6 - the extension marketplace itself blocks installation, requiring LNbits < 1.0.0). Wallet-per-user functionality moved into LNbits core, but the top-up endpoint was renamed/moved to `PUT /users/api/v1/balance` (payload `{ id, amount }`), confirmed against the live `openapi.json` of a local LNbits 1.5.6 instance.

### Fix
`topUpWallet` now calls `PUT /users/api/v1/balance` instead of the removed `PUT /users/api/v1/topup`, with `amount` sent as an integer (matching the `UpdateBalance` schema) instead of a string.

## Screenshots (if applicable)
Not applicable - backend change (LNbits REST client), no direct visual surface.

## Test plan for QA
1. Spin up a local LNbits instance (>= 1.0.0) with the native "Users" feature enabled (FakeWallet backend works fine for testing).
2. Trigger the flow that grants `LNBITS_INITIAL_ALLOWANCE` to a new Teams user (first login).
3. Confirm the wallet receives the initial balance with no 404, against any LNbits >= 1.0.0.

## Checklist
- [x] I have performed a self-review of my code
- [x] I have tested my changes locally (reproduced against a local LNbits 1.5.6 + FakeWallet instance)