### PR TITLE
Guard reward name fetch so a failure doesn't crash the bot

### DIFF
--- a/src/teamsBot.ts
+++ b/src/teamsBot.ts
@@ -23,11 +23,15 @@ import {
 
 import { getRewardName } from './services/fetchRewardsName';
 
-let globalRewardName: string;
+let globalRewardName: string = 'Sats';
 
 (async () => {
-  globalRewardName = await getRewardName();
-  console.log(`Reward Name is `, JSON.stringify(globalRewardName));
+  try {
+    globalRewardName = await getRewardName();
+    console.log(`Reward Name is `, JSON.stringify(globalRewardName));
+  } catch (error) {
+    console.error('Failed to fetch reward name, falling back to default:', error);
+  }
 })();
 
 


### PR DESCRIPTION
## Description
Prevents the bot process from crashing when fetching the (non-critical, cosmetic) reward name label fails.

## Type of Change
- [x] Bug fix

## Related Issues
Fixes #150

## Changes Made
### Problem
`teamsBot.ts` calls `getRewardName()` at startup with no error handling. If that call fails, the rejected promise is unhandled and takes down the entire bot process.

### Root Cause
The call in `teamsBot.ts` awaited `getRewardName()` with no `try/catch`, so any network failure (connection refused, timeout, non-2xx) crashed the whole bot instead of just failing to set a cosmetic label.

### Fix
Wrapped the `getRewardName()` call in `teamsBot.ts` in a `try/catch`, falling back to a sane default (`'Sats'`) on failure, and initialized `globalRewardName` with that default so it's always defined even before the async call resolves.

### Known limitation (tracked separately, not fixed in this PR)
This PR only prevents the crash — it does not fix *why* the fetch fails in local dev (port collision between `tabs/backend/server.js` and LNbits on port 5000, plus a hardcoded placeholder auth token shared across `tabs/backend/authMiddleware.js`, `tabs/src/apiService.tsx`, and `src/services/fetchRewardsName.ts`). That's a separate, larger fix and will be tracked as its own issue rather than mixed into this one.

## Screenshots (if applicable)
Not applicable — backend change (bot startup logic), no direct visual surface. Verified live: ran the bot locally with the backend unreachable; before this fix the process crashed (`[nodemon] app crashed`), after this fix it logs the failure and keeps running with the default label.

## Test plan for QA
1. Start the bot (`npm run dev:teamsfx`) without `tabs/backend/server.js` running.
2. Confirm the bot logs "Failed to fetch reward name, falling back to default" and keeps running (does not crash).
3. Confirm bot commands that reference the reward name (e.g. balance/leaderboard commands) still respond, using the default label.

## Checklist
- [x] I have performed a self-review of my code
- [x] I have tested my changes locally (reproduced the crash against the real dev environment, confirmed the fix keeps the bot running)