### PR TITLE
Convert bot registration to single-tenant

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,11 +19,18 @@ import { FetchUserMiddleware } from './services/fetchUserMiddleware';
 
 // Create adapter.
 // See https://aka.ms/about-bot-adapter to learn more about adapters.
+const tenantId = config.tenantId;
+if (!tenantId) {
+  throw new Error(
+    'AAD_APP_TENANT_ID is not set. A SingleTenant bot registration cannot authenticate without it.',
+  );
+}
+
 const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
   MicrosoftAppId: config.botId,
   MicrosoftAppPassword: config.botPassword,
   MicrosoftAppType: 'SingleTenant',
-  MicrosoftAppTenantId: config.tenantId,
+  MicrosoftAppTenantId: tenantId,
 });
 
 const botFrameworkAuthentication = new ConfigurationBotFrameworkAuthentication(

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,8 @@ import { FetchUserMiddleware } from './services/fetchUserMiddleware';
 const credentialsFactory = new ConfigurationServiceClientCredentialFactory({
   MicrosoftAppId: config.botId,
   MicrosoftAppPassword: config.botPassword,
-  MicrosoftAppType: 'MultiTenant',
+  MicrosoftAppType: 'SingleTenant',
+  MicrosoftAppTenantId: config.tenantId,
 });
 
 const botFrameworkAuthentication = new ConfigurationBotFrameworkAuthentication(


### PR DESCRIPTION
## Description

Converts the bot's registered app type from multi-tenant to single-tenant, since Microsoft deprecated creating new multi-tenant Azure Bot registrations - this was silently blocking `botFramework/create` during local provisioning and leaving the Azure Bot resource half-registered, so the bot could receive messages but had no trust to reply (401 on every turn).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change
- [ ] Documentation update

## Related Issues

Fixes #155

## Changes Made

- `src/index.ts`: `MicrosoftAppType` changed from `'MultiTenant'` to `'SingleTenant'`, added `MicrosoftAppTenantId: config.tenantId`.
- Azure-side (not in this diff, required alongside this code change): the Entra app registration needs "Supported account types" set to single-tenant, and its Service Principal created if missing (Overview → "Create Service Principal" - not automatic when converting an existing multi-tenant app).

## Screenshots (if applicable)

N/A - backend/auth fix, no UI change.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have tested my changes locally
- [x] My changes generate no new warnings
- [ ] I have added/updated documentation as needed