### PR TITLE
Redact secrets from the startup config log

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,6 @@ const config = {
   timeout: process.env.TIMEOUT || 30000,
 };
 
-console.log('Configuration:', config);
+console.log('Configuration:', { ...config, botPassword: '[REDACTED]', clientSecret: '[REDACTED]' });
 
 export default config;

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,12 @@ const config = {
   timeout: process.env.TIMEOUT || 30000,
 };
 
-console.log('Configuration:', { ...config, botPassword: '[REDACTED]', clientSecret: '[REDACTED]' });
+const redact = (value?: string) => (value ? '[REDACTED]' : value);
+
+console.log('Configuration:', {
+  ...config,
+  botPassword: redact(config.botPassword),
+  clientSecret: redact(config.clientSecret),
+});
 
 export default config;


### PR DESCRIPTION
## Description

Redacts secrets that were being printed to the console in plaintext on every bot process start.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change
- [ ] Documentation update

## Related Issues

Fixes #157

## Changes Made

- `src/config.ts`: `console.log('Configuration:', config)` now redacts `botPassword` and `clientSecret`; the rest of the config (tenant/client IDs, domain, timeout) stays visible for debugging.

## Screenshots (if applicable)

N/A - console output, no UI change.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have tested my changes locally
- [x] My changes generate no new warnings
- [ ] I have added/updated documentation as needed