### PR TITLE
Add zapHistoryService for reliable zap/reward history

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -102,7 +102,7 @@ const config: Config = {
   // notifyMode: "failure-change",
 
   // A preset that is used as a base for Jest's configuration
-  // preset: undefined,
+  preset: 'ts-jest',
 
   // Run tests from one or more projects
   // projects: undefined,
@@ -126,9 +126,10 @@ const config: Config = {
   // rootDir: undefined,
 
   // A list of paths to directories that Jest should use to search for files in
-  // roots: [
-  //   "<rootDir>"
-  // ],
+  // tabs/ and functions/ are separate sub-projects (own package.json, own
+  // tsconfig, own test runner) and are excluded from the root tsconfig.json —
+  // keep this in sync so ts-jest doesn't try to compile them.
+  roots: ['<rootDir>/src'],
 
   // Allows you to use a custom runner instead of Jest's default test runner
   // runner: "jest-runner",

--- a/src/services/lnbitsService.test.ts
+++ b/src/services/lnbitsService.test.ts
@@ -17,54 +17,60 @@ import {
   
   // Mock the necessary dependencies (like fetch)
   jest.mock('./lnbitsService');
-  
+
+  const mockGetAccessToken = getAccessToken as jest.MockedFunction<typeof getAccessToken>;
+  const mockCreateInvoice = createInvoice as jest.MockedFunction<typeof createInvoice>;
+  const mockGetWallets = getWallets as jest.MockedFunction<typeof getWallets>;
+  const mockGetUserWallets = getUserWallets as jest.MockedFunction<typeof getUserWallets>;
+  const mockPayInvoice = payInvoice as jest.MockedFunction<typeof payInvoice>;
+
   describe('LNbitsService tests', () => {
     const mockAccessToken = 'testAccessToken';
     const mockAdminKey = 'adminKey';
     const mockInKey = 'inKey';
-  
+
     beforeEach(() => {
       jest.clearAllMocks();
     });
-  
+
     test('getAccessToken should return cached token', async () => {
-      (getAccessToken as jest.Mock).mockResolvedValue(mockAccessToken);
-  
+      mockGetAccessToken.mockResolvedValue(mockAccessToken);
+
       const token = await getAccessToken('user', 'pass');
       expect(token).toBe(mockAccessToken);
     });
-  
+
     test('createInvoice should return payment request', async () => {
       const mockPaymentRequest = 'lnbc1...';
-      (createInvoice as jest.Mock).mockResolvedValue(mockPaymentRequest);
-  
+      mockCreateInvoice.mockResolvedValue(mockPaymentRequest);
+
       const result = await createInvoice(mockInKey, 'walletId', 1000, 'test', {});
       expect(result).toBe(mockPaymentRequest);
       expect(createInvoice).toHaveBeenCalledWith(mockInKey, 'walletId', 1000, 'test', {});
     });
-  
+
     test('getWallets should return filtered wallet data', async () => {
-      const mockWallets = [{ id: '1', name: 'testWallet' }];
-      (getWallets as jest.Mock).mockResolvedValue(mockWallets);
-  
+      const mockWallets = [{ id: '1', name: 'testWallet' }] as unknown as Wallet[];
+      mockGetWallets.mockResolvedValue(mockWallets);
+
       const wallets = await getWallets(mockAdminKey);
       expect(wallets).toEqual(mockWallets);
-      expect(getWallets).toHaveBeenCalledWith(mockAdminKey, undefined, undefined);
+      expect(getWallets).toHaveBeenCalledWith(mockAdminKey);
     });
-  
+
     test('getUserWallets should return user wallets', async () => {
-      const mockUserWallets = [{ id: 'wallet1', name: 'userWallet' }];
-      (getUserWallets as jest.Mock).mockResolvedValue(mockUserWallets);
-  
+      const mockUserWallets = [{ id: 'wallet1', name: 'userWallet' }] as unknown as Wallet[];
+      mockGetUserWallets.mockResolvedValue(mockUserWallets);
+
       const result = await getUserWallets(mockAdminKey, 'userId');
       expect(result).toEqual(mockUserWallets);
       expect(getUserWallets).toHaveBeenCalledWith(mockAdminKey, 'userId');
     });
-  
+
     test('payInvoice should resolve payment', async () => {
       const mockPaymentResult = { payment_hash: '123abc' };
-      (payInvoice as jest.Mock).mockResolvedValue(mockPaymentResult);
-  
+      mockPayInvoice.mockResolvedValue(mockPaymentResult);
+
       const result = await payInvoice(mockAdminKey, 'paymentRequest', {});
       expect(result).toEqual(mockPaymentResult);
       expect(payInvoice).toHaveBeenCalledWith(mockAdminKey, 'paymentRequest', {});

--- a/src/services/zapHistoryService.test.ts
+++ b/src/services/zapHistoryService.test.ts
@@ -1,0 +1,324 @@
+// zapHistoryService.test.ts
+//
+// Mocks lnbitsService (an external dependency of the module under test), not
+// zapHistoryService itself — the matching/filtering logic being tested here
+// lives entirely in zapHistoryService.
+
+import { getRecentZaps } from './zapHistoryService';
+import { getUsers, getUserWallets, getPayments } from './lnbitsService';
+import { expect, describe, test, beforeEach, jest } from '@jest/globals';
+
+jest.mock('./lnbitsService');
+
+const mockGetUsers = getUsers as jest.MockedFunction<typeof getUsers>;
+const mockGetUserWallets = getUserWallets as jest.MockedFunction<typeof getUserWallets>;
+const mockGetPayments = getPayments as jest.MockedFunction<typeof getPayments>;
+
+const alice: User = {
+  id: 'user-alice',
+  displayName: 'Alice',
+  profileImg: '',
+  aadObjectId: 'aad-alice',
+  email: 'alice@example.com',
+  privateWallet: null,
+  allowanceWallet: null,
+};
+
+const bob: User = {
+  id: 'user-bob',
+  displayName: 'Bob',
+  profileImg: '',
+  aadObjectId: 'aad-bob',
+  email: 'bob@example.com',
+  privateWallet: null,
+  allowanceWallet: null,
+};
+
+const aliceAllowance: Wallet = {
+  id: 'w-alice-allow',
+  admin: '',
+  name: 'Allowance',
+  user: alice.id,
+  adminkey: 'adm-alice-allow',
+  inkey: 'ink-alice-allow',
+  balance_msat: 900000,
+  deleted: false,
+};
+
+const alicePrivate: Wallet = {
+  id: 'w-alice-priv',
+  admin: '',
+  name: 'Private',
+  user: alice.id,
+  adminkey: 'adm-alice-priv',
+  inkey: 'ink-alice-priv',
+  balance_msat: 0,
+  deleted: false,
+};
+
+const bobAllowance: Wallet = {
+  id: 'w-bob-allow',
+  admin: '',
+  name: 'Allowance',
+  user: bob.id,
+  adminkey: 'adm-bob-allow',
+  inkey: 'ink-bob-allow',
+  balance_msat: 1000000,
+  deleted: false,
+};
+
+const bobPrivate: Wallet = {
+  id: 'w-bob-priv',
+  admin: '',
+  name: 'Private',
+  user: bob.id,
+  adminkey: 'adm-bob-priv',
+  inkey: 'ink-bob-priv',
+  balance_msat: 100000,
+  deleted: false,
+};
+
+const walletsByInkey: Record<string, Transaction[]> = {};
+
+const setupUsersAndWallets = () => {
+  mockGetUsers.mockResolvedValue([alice, bob]);
+  mockGetUserWallets.mockImplementation(async (_adminKey, userId) => {
+    if (userId === alice.id) return [aliceAllowance, alicePrivate];
+    if (userId === bob.id) return [bobAllowance, bobPrivate];
+    return [];
+  });
+  mockGetPayments.mockImplementation(async (inKey: string) =>
+    (walletsByInkey[inKey] || []) as any,
+  );
+};
+
+const tx = (overrides: Partial<Transaction>): Transaction => ({
+  checking_id: 'default',
+  pending: false,
+  amount: 0,
+  fee: 0,
+  memo: '',
+  time: 0,
+  extra: {},
+  wallet_id: '',
+  ...overrides,
+});
+
+describe('zapHistoryService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    for (const key of Object.keys(walletsByInkey)) {
+      delete walletsByInkey[key];
+    }
+    setupUsersAndWallets();
+  });
+
+  test('matches a zap across the Allowance (debit) and Private (credit) sides by checking_id', async () => {
+    walletsByInkey[aliceAllowance.inkey] = [
+      tx({
+        checking_id: 'zap1',
+        amount: -100000,
+        memo: 'Great work!',
+        time: 1750000000,
+        wallet_id: aliceAllowance.id,
+      }),
+    ];
+    walletsByInkey[bobPrivate.inkey] = [
+      tx({
+        checking_id: 'internal_zap1',
+        amount: 100000,
+        memo: 'Great work!',
+        time: 1750000000,
+        wallet_id: bobPrivate.id,
+      }),
+    ];
+
+    const result = await getRecentZaps();
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      amountSats: 100,
+      memo: 'Great work!',
+    });
+    expect(result[0].from?.displayName).toBe('Alice');
+    expect(result[0].to?.displayName).toBe('Bob');
+  });
+
+  test('excludes scheduled "Weekly Allowance cleared" sweeps', async () => {
+    walletsByInkey[aliceAllowance.inkey] = [
+      tx({
+        checking_id: 'sweep1',
+        amount: -50000,
+        memo: 'Weekly Allowance cleared',
+        time: 1750000000,
+        wallet_id: aliceAllowance.id,
+      }),
+    ];
+    walletsByInkey[bobPrivate.inkey] = [
+      tx({
+        checking_id: 'internal_sweep1',
+        amount: 50000,
+        memo: 'Weekly Allowance cleared',
+        time: 1750000000,
+        wallet_id: bobPrivate.id,
+      }),
+    ];
+
+    const result = await getRecentZaps();
+
+    expect(result).toHaveLength(0);
+  });
+
+  test('excludes outgoing Allowance payments with no matching Private-wallet receipt', async () => {
+    walletsByInkey[aliceAllowance.inkey] = [
+      tx({
+        checking_id: 'external1',
+        amount: -30000,
+        memo: 'External lightning payment',
+        time: 1750000000,
+        wallet_id: aliceAllowance.id,
+      }),
+    ];
+
+    const result = await getRecentZaps();
+
+    expect(result).toHaveLength(0);
+  });
+
+  test('deduplicates a single zap seen from both the debit and credit wallet fetch', async () => {
+    walletsByInkey[aliceAllowance.inkey] = [
+      tx({
+        checking_id: 'zap1',
+        amount: -100000,
+        memo: 'Thanks!',
+        time: 1750000000,
+        wallet_id: aliceAllowance.id,
+      }),
+    ];
+    walletsByInkey[bobPrivate.inkey] = [
+      tx({
+        checking_id: 'internal_zap1',
+        amount: 100000,
+        memo: 'Thanks!',
+        time: 1750000000,
+        wallet_id: bobPrivate.id,
+      }),
+    ];
+    walletsByInkey[alicePrivate.inkey] = [];
+    walletsByInkey[bobAllowance.inkey] = [];
+
+    const result = await getRecentZaps();
+
+    expect(result).toHaveLength(1);
+  });
+
+  test('filters out zaps before sinceTimestamp', async () => {
+    walletsByInkey[aliceAllowance.inkey] = [
+      tx({
+        checking_id: 'old-zap',
+        amount: -10000,
+        memo: 'old',
+        time: 1000000000,
+        wallet_id: aliceAllowance.id,
+      }),
+      tx({
+        checking_id: 'new-zap',
+        amount: -20000,
+        memo: 'new',
+        time: 1750000000,
+        wallet_id: aliceAllowance.id,
+      }),
+    ];
+    walletsByInkey[bobPrivate.inkey] = [
+      tx({
+        checking_id: 'internal_old-zap',
+        amount: 10000,
+        memo: 'old',
+        time: 1000000000,
+        wallet_id: bobPrivate.id,
+      }),
+      tx({
+        checking_id: 'internal_new-zap',
+        amount: 20000,
+        memo: 'new',
+        time: 1750000000,
+        wallet_id: bobPrivate.id,
+      }),
+    ];
+
+    const result = await getRecentZaps({ sinceTimestamp: 1700000000 });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].memo).toBe('new');
+  });
+
+  test('filters to zaps involving a specific user as either sender or receiver', async () => {
+    walletsByInkey[aliceAllowance.inkey] = [
+      tx({
+        checking_id: 'a-to-b',
+        amount: -10000,
+        memo: 'alice to bob',
+        time: 1750000000,
+        wallet_id: aliceAllowance.id,
+      }),
+    ];
+    walletsByInkey[bobAllowance.inkey] = [
+      tx({
+        checking_id: 'b-to-a',
+        amount: -20000,
+        memo: 'bob to alice',
+        time: 1750000001,
+        wallet_id: bobAllowance.id,
+      }),
+    ];
+    walletsByInkey[bobPrivate.inkey] = [
+      tx({
+        checking_id: 'internal_a-to-b',
+        amount: 10000,
+        memo: 'alice to bob',
+        time: 1750000000,
+        wallet_id: bobPrivate.id,
+      }),
+    ];
+    walletsByInkey[alicePrivate.inkey] = [
+      tx({
+        checking_id: 'internal_b-to-a',
+        amount: 20000,
+        memo: 'bob to alice',
+        time: 1750000001,
+        wallet_id: alicePrivate.id,
+      }),
+    ];
+
+    const result = await getRecentZaps({ userAadObjectId: bob.aadObjectId });
+
+    expect(result).toHaveLength(2);
+  });
+
+  test('sorts newest first and respects limit', async () => {
+    walletsByInkey[aliceAllowance.inkey] = [
+      tx({ checking_id: 'z1', amount: -1000, memo: 'first', time: 100, wallet_id: aliceAllowance.id }),
+      tx({ checking_id: 'z2', amount: -1000, memo: 'second', time: 200, wallet_id: aliceAllowance.id }),
+      tx({ checking_id: 'z3', amount: -1000, memo: 'third', time: 300, wallet_id: aliceAllowance.id }),
+    ];
+    walletsByInkey[bobPrivate.inkey] = [
+      tx({ checking_id: 'internal_z1', amount: 1000, memo: 'first', time: 100, wallet_id: bobPrivate.id }),
+      tx({ checking_id: 'internal_z2', amount: 1000, memo: 'second', time: 200, wallet_id: bobPrivate.id }),
+      tx({ checking_id: 'internal_z3', amount: 1000, memo: 'third', time: 300, wallet_id: bobPrivate.id }),
+    ];
+
+    const result = await getRecentZaps({ limit: 2 });
+
+    expect(result).toHaveLength(2);
+    expect(result[0].memo).toBe('third');
+    expect(result[1].memo).toBe('second');
+  });
+
+  test('returns an empty array when there are no users', async () => {
+    mockGetUsers.mockResolvedValue([]);
+
+    const result = await getRecentZaps();
+
+    expect(result).toEqual([]);
+  });
+});

--- a/src/services/zapHistoryService.ts
+++ b/src/services/zapHistoryService.ts
@@ -1,0 +1,178 @@
+// zapHistoryService.ts
+//
+// Reconstructs "who zapped whom, when, why, how much" from raw LNbits payments.
+//
+// LNbits payments don't reliably carry `extra.tag === 'zap'` in practice (see
+// tabs/src/utils/walletUtilities.ts, which documents and abandons that filter).
+// The pattern that does work in production, ported from
+// tabs/src/components/FeedList.tsx: identify wallets by name convention
+// (Allowance = sender, Private = receiver), keep outgoing Allowance payments,
+// and cross-reference by checking_id against the receiving side to confirm it
+// landed in a Private wallet.
+
+import { getUsers, getUserWallets, getPayments } from './lnbitsService';
+
+const adminKey = process.env.LNBITS_ADMINKEY as string;
+
+const WALLET_NAME_ALLOWANCE = 'Allowance';
+const WALLET_NAME_PRIVATE = 'Private';
+
+const isAllowanceWallet = (walletName: string): boolean =>
+  walletName?.toLowerCase() === WALLET_NAME_ALLOWANCE.toLowerCase();
+
+const isPrivateWallet = (walletName: string): boolean =>
+  walletName?.toLowerCase() === WALLET_NAME_PRIVATE.toLowerCase();
+
+const parseTransactionTime = (timestamp: number | string): Date | null => {
+  if (typeof timestamp === 'number') {
+    return new Date(timestamp * 1000);
+  }
+  if (typeof timestamp === 'string') {
+    const date = new Date(timestamp);
+    return isNaN(date.getTime()) ? null : date;
+  }
+  return null;
+};
+
+const cleanCheckingId = (checkingId: string | undefined): string =>
+  checkingId?.replace('internal_', '') || '';
+
+export interface ZapActivity {
+  from: User | null;
+  to: User | null;
+  amountSats: number;
+  memo: string;
+  time: Date;
+}
+
+export interface GetRecentZapsOptions {
+  limit?: number;
+  sinceTimestamp?: number; // Unix seconds
+  userAadObjectId?: string; // matches zaps where the user is either sender or receiver
+}
+
+const DEFAULT_LIMIT = 50;
+
+export async function getRecentZaps(
+  options: GetRecentZapsOptions = {},
+): Promise<ZapActivity[]> {
+  const { limit = DEFAULT_LIMIT, sinceTimestamp, userAadObjectId } = options;
+
+  const users = await getUsers(adminKey, null);
+  if (!users || users.length === 0) {
+    return [];
+  }
+
+  const walletsByUser = await Promise.all(
+    users.map(async user => ({
+      user,
+      wallets: (await getUserWallets(adminKey, user.id)) || [],
+    })),
+  );
+
+  const walletToUser = new Map<string, User>();
+  const allowanceWallets: Wallet[] = [];
+  const privateWalletIds = new Set<string>();
+  const relevantWallets: Wallet[] = [];
+
+  for (const { user, wallets } of walletsByUser) {
+    for (const wallet of wallets) {
+      walletToUser.set(wallet.id, user);
+      if (isAllowanceWallet(wallet.name)) {
+        allowanceWallets.push(wallet);
+        relevantWallets.push(wallet);
+      } else if (isPrivateWallet(wallet.name)) {
+        privateWalletIds.add(wallet.id);
+        relevantWallets.push(wallet);
+      }
+    }
+  }
+
+  const allowanceWalletIds = new Set(allowanceWallets.map(w => w.id));
+
+  const paymentsPerWallet = await Promise.all(
+    relevantWallets.map(async wallet => {
+      try {
+        const payments = await getPayments(wallet.inkey);
+        return (payments || []) as Transaction[];
+      } catch (error) {
+        console.error(
+          `getRecentZaps: failed to fetch payments for wallet ${wallet.id}:`,
+          error,
+        );
+        return [] as Transaction[];
+      }
+    }),
+  );
+
+  // tsconfig targets es2017, so flatten without Array.prototype.flat (es2019).
+  const allPayments: Transaction[] = ([] as Transaction[]).concat(...paymentsPerWallet);
+
+  // Internal transfers write both the debit and credit side under the same
+  // checking_id (one side prefixed with "internal_") — index both so either
+  // side can find its counterpart.
+  const paymentsByCheckingId = new Map<string, Transaction[]>();
+  for (const payment of allPayments) {
+    const cleanId = cleanCheckingId(payment.checking_id);
+    if (!cleanId) continue;
+    const existing = paymentsByCheckingId.get(cleanId) || [];
+    existing.push(payment);
+    paymentsByCheckingId.set(cleanId, existing);
+  }
+
+  const findReceivingPayment = (payment: Transaction): Transaction | undefined => {
+    const cleanId = cleanCheckingId(payment.checking_id);
+    const matches = paymentsByCheckingId.get(cleanId) || [];
+    return matches.find(p => p.wallet_id !== payment.wallet_id && p.amount > 0);
+  };
+
+  const zapPayments = allPayments.filter(payment => {
+    if (!allowanceWalletIds.has(payment.wallet_id)) return false; // must originate from an Allowance wallet
+    if (payment.amount >= 0) return false; // must be outgoing
+    if (payment.memo?.includes('Weekly Allowance cleared')) return false; // exclude scheduled top-up sweeps
+
+    const receivingPayment = findReceivingPayment(payment);
+    return !!receivingPayment && privateWalletIds.has(receivingPayment.wallet_id);
+  });
+
+  // Both sides of an internal transfer can surface once per wallet fetched,
+  // so dedupe by checking_id before mapping to ZapActivity.
+  const seenCheckingIds = new Set<string>();
+  const dedupedPayments = zapPayments.filter(payment => {
+    const cleanId = cleanCheckingId(payment.checking_id);
+    if (!cleanId) return true;
+    if (seenCheckingIds.has(cleanId)) return false;
+    seenCheckingIds.add(cleanId);
+    return true;
+  });
+
+  let activity: ZapActivity[] = dedupedPayments.map(payment => {
+    const receivingPayment = findReceivingPayment(payment);
+    const time = parseTransactionTime(payment.time) ?? new Date(0);
+    return {
+      from: walletToUser.get(payment.wallet_id) ?? null,
+      to: receivingPayment ? walletToUser.get(receivingPayment.wallet_id) ?? null : null,
+      amountSats: Math.abs(Math.floor(payment.amount / 1000)),
+      memo: payment.memo ?? '',
+      time,
+    };
+  });
+
+  if (sinceTimestamp) {
+    activity = activity.filter(
+      entry => Math.floor(entry.time.getTime() / 1000) >= sinceTimestamp,
+    );
+  }
+
+  if (userAadObjectId) {
+    activity = activity.filter(
+      entry =>
+        entry.from?.aadObjectId === userAadObjectId ||
+        entry.to?.aadObjectId === userAadObjectId,
+    );
+  }
+
+  activity.sort((a, b) => b.time.getTime() - a.time.getTime());
+
+  return activity.slice(0, limit);
+}

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -22,3 +22,15 @@ interface User {
 }
 
 type WalletType = 'Allowance' | 'Private';
+
+interface Transaction {
+  checking_id: string;
+  pending: boolean;
+  amount: number; // in millisatoshis (msats)
+  fee: number;
+  memo: string;
+  time: number | string; // Unix timestamp (number) or ISO date string
+  extra: { [key: string]: any }; // JSON object
+  wallet_id: string;
+  bolt11?: string; // Lightning invoice (optional)
+}


### PR DESCRIPTION
## Description

Adds `src/services/zapHistoryService.ts`, a backend service that reliably reconstructs "who zapped whom, when, why, how much" from raw LNbits payments. This is a standalone, read-only foundation piece for the upcoming conversational assistant work (Trial objective #1) — no AI or payment-moving surface in this PR.

Also fixes `jest.config.ts`: it never had a `preset`/`transform` configured, so **every TypeScript test file in this repo currently fails to parse and silently reports 0 suites run** (`npm test` is also an unimplemented stub — `"echo \"Error: no test specified\" && exit 1"`). This PR wires up the `ts-jest` preset (already an installed but unused devDependency) and scopes `roots` to `src/`, since `tabs/` and `functions/` are separate sub-projects already excluded from the root `tsconfig.json` and don't type-check under it.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Enhancement (fixes a pre-existing broken test harness)
- [ ] Breaking change
- [ ] Documentation update

## Related Issues

Fixes #159

## Changes Made

- `src/services/zapHistoryService.ts`: new `getRecentZaps({ limit, sinceTimestamp?, userAadObjectId? })`. Ports the reliable wallet-name + `checking_id` cross-referencing pattern already proven in `tabs/src/components/FeedList.tsx`, instead of filtering by `extra.tag === 'zap'` — which `tabs/src/utils/walletUtilities.ts` already documented and abandoned as unreliable on this LNbits instance's payment data.
- `src/types/global.d.ts`: add the `Transaction` interface (mirrors the one already declared in `tabs/src/types/global.d.ts` for the same LNbits payment shape).
- `jest.config.ts`: set `preset: 'ts-jest'` and `roots: ['<rootDir>/src']`.
- `src/services/lnbitsService.test.ts`: fix mock typings and one assertion that only "passed" because the suite never actually ran under a working TS transform.

## Screenshots (if applicable)

Not applicable — backend service, no UI surface.

## Test plan for QA

1. `npx jest` — all suites green (`zapHistoryService.test.ts`: 8 tests covering checking_id matching, dedup, "Weekly Allowance cleared" exclusion, no-matching-receipt exclusion, `sinceTimestamp` filtering, `userAadObjectId` filtering, sort+limit, and empty-users; `lnbitsService.test.ts`: 5 pre-existing tests, now actually running).
2. `npx tsc --noEmit` — clean, no type errors.
3. Against the local LNbits instance: call `getRecentZaps()` for a user/team with known zap history and confirm sender/receiver/amount/memo match what the `tabs/` Feed page shows for the same data.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have tested my changes locally
- [x] My changes generate no new warnings
- [x] I have added/updated documentation as needed