### PR TITLE
Fix local tab debugging: trusted HTTPS dev cert and SPA redirect URIs that survive provisioning

### DIFF
--- a/aad.manifest.json
+++ b/aad.manifest.json
@@ -99,11 +99,11 @@
         },
         {
             "url": "https://localhost:3000",
-            "type": "spa"
+            "type": "Spa"
         },
         {
             "url": "https://localhost:3000/auth-end",
-            "type": "spa"
+            "type": "Spa"
         }
     ]
 }

--- a/aad.manifest.json
+++ b/aad.manifest.json
@@ -98,7 +98,7 @@
           "type": "Web"
         },
         {
-            "url": "http://localhost:3000",
+            "url": "https://localhost:3000",
             "type": "spa"
         }
     ]

--- a/aad.manifest.json
+++ b/aad.manifest.json
@@ -100,6 +100,10 @@
         {
             "url": "https://localhost:3000",
             "type": "spa"
+        },
+        {
+            "url": "https://localhost:3000/auth-end",
+            "type": "spa"
         }
     ]
 }

--- a/teamsapp.local.yml
+++ b/teamsapp.local.yml
@@ -69,6 +69,19 @@ provision:
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
 
 deploy:
+  # The manifest embeds the tabs at https://localhost:3000, but the CRA dev
+  # server speaks plain HTTP and the Teams webview rejects both HTTP and
+  # untrusted certificates ("localhost sent an invalid response"). Install
+  # the toolkit's trusted localhost dev certificate and hand its paths to
+  # CRA via tabs/.env.development.local (gitignored, loaded automatically).
+  - uses: devTool/install
+    with:
+      devCert:
+        trust: true
+    writeToEnvironmentFile:
+      sslCertFile: SSL_CRT_FILE
+      sslKeyFile: SSL_KEY_FILE
+
   - uses: cli/runNpmCommand
     with:
       args: install --no-audit
@@ -83,3 +96,10 @@ deploy:
         AAD_APP_CLIENT_SECRET: ${{SECRET_AAD_APP_CLIENT_SECRET}}
         AAD_APP_TENANT_ID: ${{AAD_APP_TENANT_ID}}
         AAD_APP_OAUTH_AUTHORITY_HOST: ${{AAD_APP_OAUTH_AUTHORITY_HOST}}
+  - uses: file/createOrUpdateEnvironmentFile
+    with:
+      target: ./tabs/.env.development.local
+      envs:
+        HTTPS: 'true'
+        SSL_CRT_FILE: ${{SSL_CRT_FILE}}
+        SSL_KEY_FILE: ${{SSL_KEY_FILE}}

--- a/teamsapp.local.yml
+++ b/teamsapp.local.yml
@@ -69,11 +69,8 @@ provision:
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
 
 deploy:
-  # The manifest embeds the tabs at https://localhost:3000, but the CRA dev
-  # server speaks plain HTTP and the Teams webview rejects both HTTP and
-  # untrusted certificates ("localhost sent an invalid response"). Install
-  # the toolkit's trusted localhost dev certificate and hand its paths to
-  # CRA via tabs/.env.development.local (gitignored, loaded automatically).
+  # The Teams webview rejects HTTP and untrusted certs, so the tab at
+  # https://localhost:3000 needs the toolkit's OS-trusted dev certificate.
   - uses: devTool/install
     with:
       devCert:


### PR DESCRIPTION
## Description

Debugging the tabs locally inside Teams failed end-to-end ("localhost sent an invalid response", then AADSTS50011 loops). Three chained causes, all fixed here - full analysis in the linked issue.

## Type of Change

- [x] Bug fix

## Related Issues

Fixes #165

## Changes Made

- `teamsapp.local.yml`: add the toolkit's `devTool/install` action (generates and OS-trusts the localhost dev certificate) and write `HTTPS=true` + cert paths into `tabs/.env.development.local` (already gitignored, loaded by CRA automatically) - `npm start` in `tabs/` now serves trusted HTTPS with no manual steps, matching the `https://localhost:3000` contentUrl the Teams manifest promises.
- `aad.manifest.json`: register the SPA redirect as `https` (the previous `http` entry only ever matched the misconfigured HTTP dev server) and add the `https://localhost:3000/auth-end` redirect that the tab auth flow (`tabs/src/AuthStart.tsx`) actually uses.
- `aad.manifest.json`: capitalize `"type": "Spa"` - valid `replyUrlsWithType` types are `Web`, `Spa`, `InstalledClient` (case-sensitive, [app manifest reference](https://learn.microsoft.com/en-us/entra/identity-platform/reference-app-manifest)). With the lowercase value, `aadApp/update` dropped the entries and **cleared the app's SPA redirect list on every provision**, which is why fixing the URIs in the portal never stuck.

## Screenshots (if applicable)

Verified locally end-to-end: after these changes the tab loads inside Teams over HTTPS and MSAL sign-in completes (previously: ERR_SSL_PROTOCOL_ERROR, then AADSTS50011 for both redirect URIs, recurring after each F5).

## Test plan for QA

1. F5 the project (accept the one-time certificate trust prompt on first run) and confirm `tabs/.env.development.local` is generated with `HTTPS=true` and the cert paths.
2. `cd tabs && npm start` → the dev server reports `https://localhost:3000`; the browser shows a padlock with no warning.
3. Open the Zaplie tab inside Teams → it renders (no "localhost sent an invalid response").
4. Sign in from the tab → MSAL completes without AADSTS50011.
5. F5 again, then re-check the app registration's SPA redirect URIs in Entra → they are still present (previously they were wiped by every provision).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have tested my changes locally
- [x] My changes generate no new warnings
- [x] I have added/updated documentation as needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)



