### PR TITLE
docs(bot): OAuth connections require migrating the legacy bot registration

### DIFF
--- a/docs/bot-oauth-setup.md
+++ b/docs/bot-oauth-setup.md
@@ -1,0 +1,87 @@
+# Bot OAuth connections and the legacy Bot Framework registration
+
+Features that make the bot call Microsoft Graph on behalf of the chatting user
+(calendar-based recognition suggestions, and later e-mail) rely on the **Bot
+Framework token service**: the user signs in once, the token service stores and
+refreshes their token, and the bot retrieves it through an **OAuth connection**
+configured on the bot.
+
+This document explains a gotcha every developer hits when enabling these
+features against a locally debugged bot, and how to fix it.
+
+## The problem: local-debug bots are legacy registrations
+
+Teams Toolkit's local-debug provisioning registers the bot with the
+`botFramework/create` action in `teamsapp.local.yml`. That action creates a
+**legacy registration** in the Bot Framework portal (`dev.botframework.com`) —
+it is not an Azure resource.
+
+The legacy portal **no longer offers OAuth Connection Settings**. Its settings
+page ends at Save/Delete, with a *Migrate* button at the top. OAuth connections
+can only be configured on an **Azure Bot resource**, so a bot registered this
+way cannot use the token service at all.
+
+## The fix: migrate the registration to an Azure Bot
+
+Migration is one-way but safe: it keeps the Microsoft App ID, password,
+messaging endpoint and configured channels (including Teams), so the running
+bot is unaffected. The Azure Bot's F0 tier is free.
+
+1. Open `https://dev.botframework.com/bots/settings?id=<BOT_ID>` and press
+   **Migrate**. This opens an Azure *Custom deployment* pre-filled with the bot.
+2. Pick a subscription and resource group, and change the **Sku to F0**.
+3. Deploy. Verify with:
+
+   ```bash
+   az bot show -g <resource-group> -n <BOT_ID> \
+     --query "{appId:properties.msaAppId, endpoint:properties.endpoint}"
+   ```
+
+### Keep local debug working after migration
+
+`botFramework/create` manages the legacy registration, which no longer exists
+after migration — the next debug session would fail on that step. Replace it in
+`teamsapp.local.yml` with an endpoint update against the Azure Bot (dev tunnel
+URLs are persistent per machine, so this is usually a no-op):
+
+```yaml
+  - uses: script
+    with:
+      run: az bot update -g <resource-group> -n <BOT_ID> --endpoint ${{BOT_ENDPOINT}}/api/messages
+```
+
+This requires the Azure CLI to be signed in to the subscription that owns the
+bot resource.
+
+## Creating the OAuth connection
+
+With the Azure Bot in place, create the connection the code refers to via
+`GRAPH_CONNECTION_NAME`:
+
+```bash
+az bot authsetting create -g <resource-group> -n <BOT_ID> \
+  --setting-name GraphCalendars \
+  --client-id <SSO_APP_CLIENT_ID> \
+  --client-secret <SSO_APP_CLIENT_SECRET> \
+  --service Aadv2 \
+  --provider-scope-string "Calendars.Read" \
+  --parameters clientId=<SSO_APP_CLIENT_ID> clientSecret=<SSO_APP_CLIENT_SECRET> \
+      tenantId=<TENANT_ID> tokenExchangeUrl=api://botid-<BOT_ID>
+```
+
+Where:
+
+- `<SSO_APP_CLIENT_ID>` is the AAD app used for SSO (`AAD_APP_CLIENT_ID`) — the
+  app that exposes `api://botid-<BOT_ID>` and holds the delegated Graph
+  permissions. It needs delegated `Calendars.Read` plus admin consent.
+- `tokenExchangeUrl` must match the SSO app's Application ID URI, or silent
+  token exchange in Teams fails and users fall back to the sign-in card.
+
+Then set `GRAPH_CONNECTION_NAME=GraphCalendars` in the bot's environment.
+
+## Verifying
+
+1. Start the bot and type `connect calendar` in a 1:1 chat — silent SSO should
+   connect without showing a sign-in card (the card appearing means the token
+   exchange URL or connection settings are wrong).
+2. Ask the agent about recent meetings.


### PR DESCRIPTION
## Description

A setup guide (`docs/bot-oauth-setup.md`) for enabling Bot Framework **OAuth connections** on a locally debugged bot - required by any feature where the bot calls Microsoft Graph on behalf of the chatting user.

Teams Toolkit's local-debug provisioning (`botFramework/create` in `teamsapp.local.yml`) creates a **legacy registration** in the old Bot Framework portal (`dev.botframework.com`). That portal **removed its OAuth Connection Settings section** - connections can only be configured on an **Azure Bot resource** - so a locally debugged bot cannot use the token service until its registration is migrated.

Hit this while wiring up the calendar suggestions (#170); documenting it saves the next person the discovery time.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change
- [x] Documentation update

## Related Issues

Related to #168 / #170 (calendar suggestions need this setup; the future e-mail phase will too). No issue is closed by this PR.

## Changes Made

The guide covers:

- Why the legacy registration cannot hold OAuth connections.
- Migrating to an Azure Bot (one-way but safe: keeps App ID, endpoint and the Teams channel; F0 tier is free).
- Keeping local debug working afterwards: `botFramework/create` targets the now-gone legacy registration, so it must be replaced with an `az bot update --endpoint` script step.
- Creating the connection with `az bot authsetting create`, including the `tokenExchangeUrl` gotcha that silently breaks Teams SSO when it does not match the SSO app's Application ID URI.
- How to verify (silent SSO on `connect calendar` - a sign-in card appearing means the connection settings are wrong).

Docs only - no code changes. `teamsapp.local.yml` is intentionally untouched: the replacement step hardcodes each developer's own resource group, so it stays a documented local edit.

## Screenshots (if applicable)

Not applicable - documentation only.

## Test plan for QA

Follow the guide top to bottom on a fresh local-debug bot: migrate, patch the yml, create the connection, then `connect calendar` connects silently and the agent answers questions about recent meetings.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have tested my changes locally
- [x] My changes generate no new warnings
- [x] I have added/updated documentation as needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
