### PR TITLE
ci: skip Claude Code Review on fork PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,10 @@ on:
 
 jobs:
   claude-review:
+    # Fork PRs get neither secrets nor OIDC tokens on pull_request runs, so the
+    # action cannot authenticate — skip them instead of failing the check.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||


### PR DESCRIPTION
## Description

The **Claude Code Review** workflow fails on every PR opened from a fork (e.g. #154, #177) with:

> Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?

The permission is already there — the real cause is that GitHub withholds both **secrets** and **OIDC tokens** from `pull_request` runs on fork PRs, so `anthropics/claude-code-action` can never authenticate in that context. This adds a job-level guard so fork PRs skip the review instead of red-Xing the check. Branches pushed to this repo still get reviewed.

`pull_request_target` was deliberately **not** used: it would expose `CLAUDE_CODE_OAUTH_TOKEN` to untrusted PR content (prompt-injection / secret-exfiltration risk).

`claude.yml` needs no change — its triggers (`issue_comment`, `issues`, `pull_request_review`) always run in the base-repo context with secrets available.

## Type of Change

- [x] Bug fix

## Test plan for QA

- Fork PRs: the `claude-review` check shows **skipped** instead of **failed**.
- Same-repo PRs: the review runs as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JURpCGXTdaKLHzwh238WF8