### PR TITLE
Remove no-op onCommand handler from TeamsBot

### DIFF
--- a/src/teamsBot.ts
+++ b/src/teamsBot.ts
@@ -310,9 +310,6 @@ export class TeamsBot extends TeamsActivityHandler {
 
       await next();
     });
-
-    //this.onMembersAdded(async (context, next) => {
-    this.onCommand(async (_context, _next) => {});
   }
 
   async run(context: TurnContext) {


### PR DESCRIPTION
## What changed
Removes dead code from `src/teamsBot.ts`:

- `this.onCommand(async (_context, _next) => {});` — a handler registering an empty callback that did nothing (it never even called `next()`)
- The stale commented-out `//this.onMembersAdded(...)` fragment directly above it

## Why
Flagged during review of #144: the no-op handler was reformatted and its args renamed to satisfy the new `no-unused-vars` rule, when it should simply have been deleted. `onCommand` is referenced nowhere else in the codebase, so removing the registration has no behavior change.

## Test plan for QA
- No functional change expected — this only unregisters an empty handler.
- `npm run lint`, `npm run format:check`, `npm run typecheck`, and `npm run build` all pass locally (7 pre-existing `no-explicit-any` warnings, zero errors).
- Smoke-check the bot in Teams: send a zap and an unrecognized text command; both should behave exactly as before.

No screenshots — server-side dead-code removal with no UI surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TmoEvEjqQ9kVkiyQvVUQjc