### PR TITLE
docs: correct AGENTS.md runtime to Node 24

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,8 +49,8 @@ Full details: `docs/SOLUTION_DESIGN.adoc`. Requirements catalogue:
 
 ## Build, Run, Test
 
-Use **npm** (not pnpm/yarn). Node 18 is the supported runtime (CI builds on 20;
-if you hit MSAL issues on Node 20 see the override note in README.md).
+Use **npm** (not pnpm/yarn). Node 24 is the supported runtime (declared in
+`package.json` `engines`; CI builds on Node 24).
 
 ### Bot (repo root)
 


### PR DESCRIPTION
## What
Fixes the stale runtime line in `AGENTS.md`.

It claimed *"Node 18 is the supported runtime (CI builds on 20; if you hit MSAL issues on Node 20 see the override note in README.md)"* — but:
- The repo actually requires **Node 24** (`package.json` `engines.node: "24"`, CI `node-version: 24.x`, since #201).
- The referenced MSAL/Node-20 override note **no longer exists** in `README.md`.

## Why it matters
This stale line misled the automated reviewer into flagging Node-compatibility concerns on **#183** (`node --watch`) and **#210** (react-router 7 needs Node ≥20) — both non-issues on Node 24. Keeping the doc accurate stops those false flags recurring.

## Test plan for QA
- Docs-only change; no code affected.
- Verify the line now reads "Node 24 is the supported runtime".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TmoEvEjqQ9kVkiyQvVUQjc