### PR TITLE
ci: group peer-linked packages so Dependabot majors can install

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,8 +24,9 @@ updates:
         patterns:
           - 'eslint'
           - '@typescript-eslint/*'
-      # One PR for all remaining minor/patch bumps to keep the noise down;
-      # majors still get individual PRs.
+      # One PR for all remaining minor/patch bumps to keep the noise down.
+      # Majors get individual PRs, except for the peer-linked groups above,
+      # which are deliberately grouped across every update type.
       minor-and-patch:
         update-types:
           - 'minor'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,11 @@
 # Dependabot — automated dependency update PRs.
 # PR titles use the `deps:` / `ci:` prefixes so they pass PR Lint
 # (which also skips its Fixes/test-plan checks for dependabot[bot]).
+#
+# Packages with peer-dependency relationships are grouped across ALL
+# update types. A major bump to one half of such a pair on its own cannot
+# install (`npm ci` fails with ERESOLVE), so the PR can never go green —
+# they have to move together.
 version: 2
 updates:
   # Bot / backend (repo root)
@@ -12,7 +17,14 @@ updates:
     commit-message:
       prefix: 'deps'
     groups:
-      # One PR for all minor/patch bumps to keep the noise down;
+      # eslint and the typescript-eslint plugins are peer-linked:
+      # @typescript-eslint/* v7 requires eslint ^8.56, so bumping eslint
+      # alone to v9/v10 breaks installation.
+      eslint:
+        patterns:
+          - 'eslint'
+          - '@typescript-eslint/*'
+      # One PR for all remaining minor/patch bumps to keep the noise down;
       # majors still get individual PRs.
       minor-and-patch:
         update-types:
@@ -28,6 +40,17 @@ updates:
     commit-message:
       prefix: 'deps'
     groups:
+      # msal-react declares a peer range on msal-browser.
+      msal:
+        patterns:
+          - '@azure/msal-*'
+      # react, react-dom and their @types must stay on the same major.
+      react:
+        patterns:
+          - 'react'
+          - 'react-dom'
+          - '@types/react'
+          - '@types/react-dom'
       minor-and-patch:
         update-types:
           - 'minor'


### PR DESCRIPTION
Fixes #234

## The problem
Of the 19 open Dependabot PRs, **14 pass and 5 fail**. Four of the five fail for the same structural reason: **`npm ci` cannot resolve the dependency tree**, so the PR can never go green no matter how often it re-runs.

| PR | Bump | Failure |
|---|---|---|
| #226 | eslint 8 → 10 | `ERESOLVE` — `@typescript-eslint/*` v7 requires eslint `^8.56.0` |
| #233 | `@azure/msal-browser` 3 → 5 | `ERESOLVE` — `@azure/msal-react` 2.2 requires msal-browser `^3.27.0` |
| #225 | react-dom (+ @types) | react/react-dom split across majors |
| #229 | react (+ @types) | same |

These packages are **peer-linked** — they must move together or not at all.

## Cause
The `dependabot.yml` I added in #212 groups only `minor` and `patch` updates, so **every major arrives as its own PR**, splitting these pairs by design.

## Fix
Group peer-linked packages across **all** update types:

- **root:** `eslint` + `@typescript-eslint/*`
- **tabs:** `@azure/msal-*`; and `react` + `react-dom` + `@types/react` + `@types/react-dom`

Dependabot will supersede the four failing PRs with combined ones that install cleanly. (The existing `minor-and-patch` grouping is unchanged.)

## Not covered here
**#231 (`web-vitals` 2 → 6)** is a real breaking API change, not a config problem — `ReportHandler` and `getCLS`/`getFID`/… no longer exist, so `tabs/src/reportWebVitals.tsx` needs migrating to `onCLS`/`onINP`/…. That needs the code change and the bump in the same commit, so it's tracked in #234 rather than bundled here.

## Test plan for QA
- Config-only change; no runtime code touched. CI on this PR should be green.
- After merge, Dependabot re-runs (or `@dependabot recreate` on #226/#233/#225/#229) should produce combined PRs whose `npm ci` succeeds.
- Verify the four superseded PRs close automatically or can be closed manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TmoEvEjqQ9kVkiyQvVUQjc