### PR TITLE
ci: fail fast and retry when downloading gitleaks

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -30,8 +30,13 @@ jobs:
 
       - name: Install gitleaks
         run: |
+          set -euo pipefail
           GITLEAKS_VERSION=8.21.2
-          curl -sSL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+          # -f so an HTTP error fails here, rather than saving an error page that
+          # tar later rejects with an unhelpful "Error is not recoverable";
+          # --retry so a transient network blip doesn't fail the whole check.
+          curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
             -o /tmp/gitleaks.tar.gz
           tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
           sudo mv /tmp/gitleaks /usr/local/bin/gitleaks


### PR DESCRIPTION
## The symptom
The Secret Scan check failed on #232 with:

```
tar: Error is not recoverable: exiting now
```

## What actually happened
Not a leaked secret, and not a broken URL — I verified the pinned release asset returns **HTTP 200**, and the same check passes on #237, #224, #230 and #215. It was a **transient download blip**.

The reason the error was so unhelpful is that `curl` ran **without `-f`**: on an HTTP error curl still exits 0 and writes the error body to `gitleaks.tar.gz`, so `tar` is the thing that fails — pointing at the wrong culprit and making it look like a scanner problem.

## The fix
- **`-f`** so a bad HTTP response fails at the download step with a clear message.
- **`--retry 3 --retry-delay 2 --retry-all-errors`** so a network blip doesn't fail an otherwise-green PR.
- **`set -euo pipefail`** so nothing downstream runs on a half-installed binary.

Version stays pinned at 8.21.2; no change to what is scanned or to `.gitleaks.toml`.

## Test plan for QA
- Secret Scan should pass on this PR (it exercises the changed step).
- Re-running a previously blipped job should now either succeed or fail with a clear `curl` error instead of a `tar` one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TmoEvEjqQ9kVkiyQvVUQjc