### PR TITLE
test: cover scheduledTopup at the LNbits HTTP boundary

### DIFF
--- a/src/services/lnbitsService.test.ts
+++ b/src/services/lnbitsService.test.ts
@@ -422,3 +422,375 @@ describe('payInvoice', () => {
     ).rejects.toThrow('fetch failed');
   });
 });
+
+describe('scheduledTopup', () => {
+  const ADMIN_KEY = 'admin-key';
+  const IN_KEY = 'in-key';
+  const HOST_USER_ID = 'host-user';
+  const HOST_WALLET_ID = 'host-wallet';
+  const ALLOWANCE = '5000';
+
+  const topupEnv: Record<string, string> = {
+    LNBITS_ADMINKEY: ADMIN_KEY,
+    LNBITS_INKEY: IN_KEY,
+    LNBITS_HOST_USER_ID: HOST_USER_ID,
+    LNBITS_HOST_WALLET_ID: HOST_WALLET_ID,
+    LNBITS_INITIAL_ALLOWANCE: ALLOWANCE,
+  };
+  const originalTopupEnv = Object.keys(topupEnv).map(
+    key => [key, process.env[key]] as const,
+  );
+
+  beforeEach(() => {
+    Object.assign(process.env, topupEnv);
+  });
+
+  afterEach(() => {
+    originalTopupEnv.forEach(([key, value]) => restoreEnv(key, value));
+  });
+
+  type AllowanceHolder = {
+    userId: string;
+    walletId: string;
+    displayName: string;
+    balanceMsat: number;
+  };
+
+  type PaymentExtra = { from: { id: string }; to: unknown; tag: string };
+  type PaymentBody = {
+    out: boolean;
+    amount?: number;
+    memo?: string;
+    bolt11?: string;
+    extra: PaymentExtra;
+  };
+  type TopupBody = { id: string; amount: number };
+
+  const alice: AllowanceHolder = {
+    userId: 'u-1',
+    walletId: 'w-1',
+    displayName: 'Alice Smith',
+    balanceMsat: 21000,
+  };
+  const bob: AllowanceHolder = {
+    userId: 'u-2',
+    walletId: 'w-2',
+    displayName: 'Bob Jones',
+    balanceMsat: 7000,
+  };
+
+  const listEntry = (holder: AllowanceHolder) => ({
+    id: holder.walletId,
+    admin: `${holder.walletId}-admin`,
+    name: 'Allowance',
+    adminkey: `${holder.walletId}-ak`,
+    user: holder.userId,
+    inkey: `${holder.walletId}-ik`,
+  });
+
+  const walletEntry = (holder: AllowanceHolder) => ({
+    ...listEntry(holder),
+    balance_msat: holder.balanceMsat,
+    deleted: false,
+  });
+
+  const hostWallet = {
+    id: HOST_WALLET_ID,
+    admin: 'host-admin',
+    name: 'Host',
+    adminkey: 'host-ak',
+    user: HOST_USER_ID,
+    inkey: 'host-ik',
+    balance_msat: 900000,
+    deleted: false,
+  };
+
+  const stubTopupRoutes = (
+    holders: AllowanceHolder[],
+    responses: {
+      wallets?: () => Response;
+      host?: () => Response;
+      invoice?: (body: PaymentBody) => Response;
+      payment?: (body: PaymentBody) => Response;
+      topup?: (body: TopupBody) => Response;
+    } = {},
+  ) => {
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url === `${BASE}/api/v1/auth`)
+        return jsonResponse({ access_token: 'tok-1' });
+      if (url === `${BASE}/api/v1/wallets`)
+        return responses.wallets
+          ? responses.wallets()
+          : jsonResponse(holders.map(listEntry));
+      if (url === `${BASE}/users/api/v1/user/${HOST_USER_ID}/wallet`)
+        return responses.host ? responses.host() : jsonResponse([hostWallet]);
+      const holder = holders.find(
+        candidate =>
+          url === `${BASE}/users/api/v1/user/${candidate.userId}` ||
+          url === `${BASE}/users/api/v1/user/${candidate.userId}/wallet`,
+      );
+      if (holder) {
+        return url.endsWith('/wallet')
+          ? jsonResponse([walletEntry(holder)])
+          : jsonResponse({
+              id: holder.userId,
+              extra: { display_name: holder.displayName },
+            });
+      }
+      if (url === `${BASE}/api/v1/payments`) {
+        const body = JSON.parse(String(init?.body)) as PaymentBody;
+        if (body.out) {
+          return responses.payment
+            ? responses.payment(body)
+            : jsonResponse({ payment_hash: 'hash-1' });
+        }
+        return responses.invoice
+          ? responses.invoice(body)
+          : jsonResponse({ payment_request: 'lnbc1invoice' });
+      }
+      if (url === `${BASE}/users/api/v1/balance`) {
+        const body = JSON.parse(String(init?.body)) as TopupBody;
+        return responses.topup
+          ? responses.topup(body)
+          : jsonResponse({ id: body.id, balance: body.amount });
+      }
+      throw new Error(`Unexpected fetch call: ${url}`);
+    });
+  };
+
+  const paymentRequests = (out: boolean) =>
+    fetchMock.mock.calls
+      .filter(call => String(call[0]) === `${BASE}/api/v1/payments`)
+      .map(call => ({
+        headers: call[1]?.headers as Record<string, string>,
+        body: JSON.parse(String(call[1]?.body)) as PaymentBody,
+      }))
+      .filter(request => request.body.out === out);
+
+  const topupRequests = () =>
+    fetchMock.mock.calls
+      .filter(call => String(call[0]) === `${BASE}/users/api/v1/balance`)
+      .map(call => ({
+        init: call[1],
+        body: JSON.parse(String(call[1]?.body)) as TopupBody,
+      }));
+
+  const settleBackgroundWork = async () => {
+    let seen = -1;
+    while (seen !== fetchMock.mock.calls.length) {
+      seen = fetchMock.mock.calls.length;
+      for (let tick = 0; tick < 5; tick++) {
+        await new Promise(resolve => setImmediate(resolve));
+      }
+    }
+  };
+
+  const collectUnawaitedRejections = async (run: () => Promise<void>) => {
+    const rejections: unknown[] = [];
+    const originalForEach = Array.prototype.forEach;
+    Array.prototype.forEach = function patchedForEach(
+      this: unknown[],
+      callback: (...args: unknown[]) => unknown,
+      thisArg?: unknown,
+    ) {
+      originalForEach.call(this, (...args: unknown[]) => {
+        const result = callback.apply(thisArg, args);
+        if (result instanceof Promise) {
+          result.catch(error => rejections.push(error));
+        }
+      });
+    } as unknown as typeof Array.prototype.forEach;
+
+    try {
+      await run();
+    } finally {
+      Array.prototype.forEach = originalForEach;
+    }
+    await settleBackgroundWork();
+    return rejections.map(String);
+  };
+
+  test('clears the allowance wallet into the host wallet and restores the allowance', async () => {
+    stubTopupRoutes([alice]);
+
+    await service.scheduledTopup();
+    await settleBackgroundWork();
+
+    const invoices = paymentRequests(false);
+    expect(invoices).toHaveLength(1);
+    expect(invoices[0].headers['X-Api-Key']).toBe(IN_KEY);
+    expect(invoices[0].body).toEqual({
+      out: false,
+      amount: 21,
+      memo: 'Alice Smith Weekly Allowance cleared',
+      extra: { from: walletEntry(alice), to: hostWallet, tag: 'zap' },
+    });
+
+    const payments = paymentRequests(true);
+    expect(payments).toHaveLength(1);
+    expect(payments[0].headers['X-Api-Key']).toBe(`${alice.walletId}-ak`);
+    expect(payments[0].body).toEqual({
+      out: true,
+      bolt11: 'lnbc1invoice',
+      extra: { from: walletEntry(alice), to: hostWallet, tag: 'zap' },
+    });
+
+    const topups = topupRequests();
+    expect(topups).toHaveLength(1);
+    expect(topups[0].init?.method).toBe('PUT');
+    expect(topups[0].init?.headers).toEqual({
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer tok-1',
+    });
+    expect(topups[0].body).toEqual({ id: alice.walletId, amount: 5000 });
+  });
+
+  test('awaits the host wallet lookup so the payment extra carries the wallet and not a pending promise', async () => {
+    stubTopupRoutes([alice]);
+
+    await service.scheduledTopup();
+    await settleBackgroundWork();
+
+    const requests = [...paymentRequests(false), ...paymentRequests(true)];
+    expect(requests).toHaveLength(2);
+    requests.forEach(request => {
+      expect(request.body.extra.to).not.toEqual({});
+      expect(request.body.extra.to).toEqual(hostWallet);
+    });
+  });
+
+  test('tops up a wallet with no balance without creating a payment', async () => {
+    stubTopupRoutes([{ ...alice, balanceMsat: 0 }]);
+
+    await service.scheduledTopup();
+    await settleBackgroundWork();
+
+    expect(paymentRequests(false)).toHaveLength(0);
+    expect(paymentRequests(true)).toHaveLength(0);
+    expect(topupRequests().map(request => request.body)).toEqual([
+      { id: alice.walletId, amount: 5000 },
+    ]);
+  });
+
+  test('touches no wallet when there is no allowance wallet to process', async () => {
+    stubTopupRoutes([]);
+
+    await service.scheduledTopup();
+    await settleBackgroundWork();
+
+    expect(paymentRequests(false)).toHaveLength(0);
+    expect(topupRequests()).toHaveLength(0);
+  });
+
+  test('returns before the per wallet payment chain has run', async () => {
+    stubTopupRoutes([alice]);
+
+    await service.scheduledTopup();
+    const callsOnReturn = fetchMock.mock.calls.length;
+    const paymentsOnReturn = paymentRequests(false).length;
+    await settleBackgroundWork();
+
+    expect(paymentsOnReturn).toBe(0);
+    expect(paymentRequests(false)).toHaveLength(1);
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(callsOnReturn);
+  });
+
+  test('rejects with a TypeError when listing the allowance wallets fails, because getWallets resolves with the error', async () => {
+    stubTopupRoutes([alice], {
+      wallets: () => jsonResponse({}, { status: 500 }),
+    });
+
+    await expect(service.scheduledTopup()).rejects.toThrow(TypeError);
+  });
+
+  test('rejects when the host wallet lookup fails at the network level', async () => {
+    stubTopupRoutes([alice], {
+      host: () => {
+        throw new TypeError('fetch failed');
+      },
+    });
+
+    await expect(service.scheduledTopup()).rejects.toThrow('fetch failed');
+  });
+
+  test('still moves the balance when the host wallet lookup returns a non-2xx and records a null recipient', async () => {
+    stubTopupRoutes([alice], { host: () => jsonResponse({}, { status: 500 }) });
+
+    await service.scheduledTopup();
+    await settleBackgroundWork();
+
+    const invoices = paymentRequests(false);
+    expect(invoices).toHaveLength(1);
+    expect(invoices[0].body.extra.to).toBeNull();
+    expect(topupRequests()).toHaveLength(1);
+  });
+
+  test('reports a failed invoice creation only as an unawaited rejection and leaves the wallet untouched', async () => {
+    stubTopupRoutes([alice], {
+      invoice: () => jsonResponse({}, { status: 500 }),
+    });
+
+    const rejections = await collectUnawaitedRejections(() =>
+      service.scheduledTopup(),
+    );
+
+    expect(rejections).toEqual([
+      'Error: Error creating an invoice (status: 500)',
+    ]);
+    expect(paymentRequests(true)).toHaveLength(0);
+    expect(topupRequests()).toHaveLength(0);
+  });
+
+  test('reports a failed payment only as an unawaited rejection and skips the top-up', async () => {
+    stubTopupRoutes([alice], {
+      payment: () => jsonResponse({}, { status: 502 }),
+    });
+
+    const rejections = await collectUnawaitedRejections(() =>
+      service.scheduledTopup(),
+    );
+
+    expect(rejections).toEqual(['Error: Error paying invoice (status: 502)']);
+    expect(topupRequests()).toHaveLength(0);
+  });
+
+  test('keeps processing the other wallets when one wallet payment fails', async () => {
+    stubTopupRoutes([alice, bob], {
+      payment: body =>
+        body.extra.from.id === alice.walletId
+          ? jsonResponse({}, { status: 502 })
+          : jsonResponse({ payment_hash: 'hash-1' }),
+    });
+
+    const rejections = await collectUnawaitedRejections(() =>
+      service.scheduledTopup(),
+    );
+
+    expect(rejections).toEqual(['Error: Error paying invoice (status: 502)']);
+    expect(topupRequests().map(request => request.body)).toEqual([
+      { id: bob.walletId, amount: 5000 },
+    ]);
+  });
+
+  test('swallows a failed top-up so the caller cannot tell the allowance was not restored', async () => {
+    stubTopupRoutes([alice, bob], {
+      topup: body =>
+        body.id === alice.walletId
+          ? jsonResponse({}, { status: 500 })
+          : jsonResponse({ id: body.id, balance: body.amount }),
+    });
+
+    const rejections = await collectUnawaitedRejections(() =>
+      service.scheduledTopup(),
+    );
+
+    expect(rejections).toEqual([]);
+    expect(paymentRequests(true)).toHaveLength(2);
+    expect(
+      topupRequests()
+        .map(request => request.body.id)
+        .sort(),
+    ).toEqual([alice.walletId, bob.walletId]);
+  });
+});


### PR DESCRIPTION
Fixes #206

## Summary

- Adds 12 tests for `scheduledTopup` in `src/services/lnbitsService.test.ts`, a function that moves real sats and had **zero** coverage. No production code is touched.
- Tests go through `global.fetch` with a URL router, following the boundary-mocking pattern main adopted in #202. The module under test is never mocked, so the tests exercise the real call chain rather than asserting on a mock.
- Covers the happy path (invoice, payment, balance top-up), the zero-balance and no-wallet branches, the #144 regression where the host wallet lookup must be awaited, and seven failure paths including a partial failure across two wallets.
- **Every test was verified against a broken implementation, not just a working one.** Removing the `await` from the host lookup turns 4 tests red; making `createInvoice` return `null` instead of rethrowing turns another red; dropping the `await` on `payInvoice` turns two more red. The source was restored afterwards and `git status` confirmed only the test file changed.

**Four defects found while writing these, pinned as current behaviour rather than fixed** (this PR is scoped to coverage):

- `allowancewallets.forEach(async wallet => ...)` is fire and forget. `scheduledTopup` resolves **before any payment runs**, and every failure inside the callback becomes an unobserved rejection with no caller, no scheduler and no log to catch it. The function reports success either way. This is the same class of bug #144 fixed one line above, and it contradicts the "payments fail loudly" invariant in `AGENTS.md`.
- `topUpWallet` catches and logs without rethrowing, so a failed allowance restore is indistinguishable from a successful one.
- `getWalletById` returns `null` on a non-2xx, so a failed host lookup does not stop the money moving: the zap still goes out with `extra.to: null`.
- `createInvoice` never uses its `recipientWalletId` parameter, so the invoice is raised against whatever wallet the `INKEY` belongs to.

If someone converts that loop to `for...of` with `await`, four of these tests go red immediately. That is the intended safety net.

## Test plan

- [ ] `npx jest --ci --runInBand` passes, 61 tests across 4 suites
- [ ] Remove the `await` from the host wallet lookup in `scheduledTopup`, confirm 4 tests fail, then restore it
- [ ] `node scripts/check-coverage-ratchet.js` passes (statements 34.27 to 40.39, `lnbitsService.ts` reaches 60.25%)
- [ ] `npx tsc --noEmit` and `npm run lint` both clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
