### PR TITLE
ci: build functions/ in CI, and pin its tsconfig types

### DIFF
--- a/.github/workflows/ci-quality-checks.yml
+++ b/.github/workflows/ci-quality-checks.yml
@@ -151,3 +151,13 @@ jobs:
         env:
           CI: false
         run: npm run build
+
+      # functions/ is a third deployable package. Without this step its
+      # dependency bumps pass CI while actually breaking the build.
+      - name: Install Functions dependencies
+        working-directory: functions
+        run: npm ci
+
+      - name: Build Functions
+        working-directory: functions
+        run: npm run build

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -5,6 +5,10 @@
     "outDir": "dist",
     "rootDir": ".",
     "sourceMap": true,
-    "strict": false
+    "strict": false,
+    // Without this, TypeScript 7 treats functions/types/ as a typeRoots entry,
+    // which replaces the default node_modules/@types root and drops @types/node
+    // (Buffer, inspector, buffer all stop resolving). No-op on TS 4.x.
+    "types": ["node"]
   }
 }


### PR DESCRIPTION
## The gap
`ci-quality-checks.yml` covers the bot (root) and `tabs/` — but **never `functions/`**, the third deployable package. So dependency bumps touching it **pass every check while breaking its build**.

This isn't hypothetical. Three open Dependabot PRs are green right now and fail `npm run build` locally on Node 24:

| PR | Bump | Local build |
|---|---|---|
| #215 | typescript 4.9.5 → 7.0.2 | ❌ 4 × TS2591 (`Buffer`, `inspector`, `buffer` unresolved) |
| #219 | @types/node 20 → 26 | ❌ 25+ parse errors (TS 4.9 can't read v26 declarations) |
| #217 | @azure/functions 3 → 4 | ❌ 9 errors — v4 is a programming-model rewrite, not a bump |

## Changes
1. **Build `functions/` in CI** — adds Install + Build steps to Build Verification.
2. **`functions/tsconfig.json`: `"types": ["node"]`** — TypeScript 7 treats the existing `functions/types/` directory as a `typeRoots` entry, which *replaces* the default `node_modules/@types` root and silently drops `@types/node`. Setting `types` explicitly prevents that.

## Verification
On Node 24 (`nvm use 24.15.0`), in `functions/`:
- **Before** the tsconfig change: `npm ci && npm run build` → exit 0
- **After**: `npm run build` → exit 0

So the tsconfig change is a **verified no-op under the current TypeScript 4.9.5**, safe to land on its own, and it unblocks #215.

## Knock-on effects
- **#216** (rimraf) is the only one of the four `functions/` bumps that actually builds — safe to merge.
- **#215** becomes mergeable once this lands; **#219** must follow #215 (TS 4.9 can't parse `@types/node@26`).
- **#217** should be closed — v4 needs `app.http()` registration, a `main` entry point and `HttpResponseInit` returns; that's a migration, not a bump.

## Test plan for QA
- Build Verification on this PR should now show Install/Build Functions steps passing.
- Re-running CI on #215/#219/#217 after merge should turn them red, correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TmoEvEjqQ9kVkiyQvVUQjc