### PR TITLE
feat: Zap a message right-click action command to recognise the author

### DIFF
--- a/.github/workflows/ci-quality-checks.yml
+++ b/.github/workflows/ci-quality-checks.yml
@@ -121,6 +121,10 @@ jobs:
           CI: true
         run: npm test -- --watchAll=false
 
+      - name: Run backend tests
+        working-directory: tabs
+        run: npm run test:backend
+
   build-check:
     name: Build Verification
     runs-on: ubuntu-latest

--- a/manifest.template.json
+++ b/manifest.template.json
@@ -63,7 +63,23 @@
             ]
         }
     ],
-    "composeExtensions": [],
+    "composeExtensions": [
+        {
+            "botId": "${{BOT_ID}}",
+            "commands": [
+                {
+                    "id": "zapMessage",
+                    "type": "action",
+                    "context": [
+                        "message"
+                    ],
+                    "title": "Zap ⚡",
+                    "description": "Send sats to the author of this message",
+                    "fetchTask": false
+                }
+            ]
+        }
+    ],
     "configurableTabs": [],
     "staticTabs": [
         { 

--- a/manifest.template.json
+++ b/manifest.template.json
@@ -75,7 +75,15 @@
                     ],
                     "title": "Zap ⚡",
                     "description": "Send sats to the author of this message",
-                    "fetchTask": false
+                    "fetchTask": false,
+                    "parameters": [
+                        {
+                            "name": "memo",
+                            "inputType": "text",
+                            "title": "Memo",
+                            "description": "Optional memo; leave empty to use the message text"
+                        }
+                    ]
                 }
             ]
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,14 +21,12 @@
         "isomorphic-fetch": "^3.0.0",
         "node-cron": "^3.0.3",
         "react-qr-reader": "^3.0.0-beta-1",
-        "sanitize-html": "2.17.0",
         "uuid": "^8.3.2"
       },
       "devDependencies": {
         "@types/express": "^5.0.6",
         "@types/jest": "^29.5.12",
         "@types/node": "^14.0.0",
-        "@types/sanitize-html": "^2.16.1",
         "@typescript-eslint/eslint-plugin": "^7.0.0",
         "@typescript-eslint/parser": "^7.0.0",
         "cross-env": "^7.0.3",
@@ -2378,49 +2376,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/sanitize-html": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/@types/sanitize-html/-/sanitize-html-2.16.1.tgz",
-      "integrity": "sha512-n9wjs8bCOTyN/ynwD8s/nTcTreIHB1vf31vhLMGqUPNHaweKC4/fAl4Dj+hUlCTKYgm4P3k83fmiFfzkZ6sgMA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "htmlparser2": "^10.1"
-      }
-    },
-    "node_modules/@types/sanitize-html/node_modules/entities": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
-      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/@types/sanitize-html/node_modules/htmlparser2": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
-      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
-      "dev": true,
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.2.2",
-        "entities": "^7.0.1"
-      }
-    },
     "node_modules/@types/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
@@ -4154,6 +4109,7 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6186,15 +6142,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-plain-object": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -7521,24 +7468,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
-    "node_modules/nanoid": {
-      "version": "3.3.18",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
-      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
     "node_modules/native-duplexpair": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/native-duplexpair/-/native-duplexpair-1.0.0.tgz",
@@ -7954,12 +7883,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/parse-srcset": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
-      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
-      "license": "MIT"
-    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -8041,6 +7964,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -8082,34 +8006,6 @@
       "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/postcss": {
-      "version": "8.5.26",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
-      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.17",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/prelude-ls": {
@@ -8633,51 +8529,6 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
-    "node_modules/sanitize-html": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.0.tgz",
-      "integrity": "sha512-dLAADUSS8rBwhaevT12yCezvioCA+bmUTPH/u57xKPT8d++voeYE6HeluA/bPbQ15TwDBG2ii+QZIEmYx8VdxA==",
-      "license": "MIT",
-      "dependencies": {
-        "deepmerge": "^4.2.2",
-        "escape-string-regexp": "^4.0.0",
-        "htmlparser2": "^8.0.0",
-        "is-plain-object": "^5.0.0",
-        "parse-srcset": "^1.0.2",
-        "postcss": "^8.3.11"
-      }
-    },
-    "node_modules/sanitize-html/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/sanitize-html/node_modules/htmlparser2": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
-      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.0.1",
-        "entities": "^4.4.0"
-      }
-    },
     "node_modules/scheduler": {
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
@@ -9113,15 +8964,6 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-js": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,12 +21,14 @@
         "isomorphic-fetch": "^3.0.0",
         "node-cron": "^3.0.3",
         "react-qr-reader": "^3.0.0-beta-1",
+        "sanitize-html": "2.17.0",
         "uuid": "^8.3.2"
       },
       "devDependencies": {
         "@types/express": "^5.0.6",
         "@types/jest": "^29.5.12",
         "@types/node": "^14.0.0",
+        "@types/sanitize-html": "^2.16.1",
         "@typescript-eslint/eslint-plugin": "^7.0.0",
         "@typescript-eslint/parser": "^7.0.0",
         "cross-env": "^7.0.3",
@@ -2376,6 +2378,49 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/sanitize-html": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@types/sanitize-html/-/sanitize-html-2.16.1.tgz",
+      "integrity": "sha512-n9wjs8bCOTyN/ynwD8s/nTcTreIHB1vf31vhLMGqUPNHaweKC4/fAl4Dj+hUlCTKYgm4P3k83fmiFfzkZ6sgMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "htmlparser2": "^10.1"
+      }
+    },
+    "node_modules/@types/sanitize-html/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@types/sanitize-html/node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
     "node_modules/@types/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
@@ -4109,7 +4154,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4300,9 +4344,10 @@
       }
     },
     "node_modules/domutils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
-      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
       "dependencies": {
         "dom-serializer": "^2.0.0",
         "domelementtype": "^2.3.0",
@@ -6141,6 +6186,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -7467,6 +7521,24 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/native-duplexpair": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/native-duplexpair/-/native-duplexpair-1.0.0.tgz",
@@ -7882,6 +7954,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse-srcset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
+      "license": "MIT"
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -7960,10 +8038,10 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
-      "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==",
-      "dev": true
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -8004,6 +8082,34 @@
       "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/prelude-ls": {
@@ -8527,6 +8633,51 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "node_modules/sanitize-html": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.0.tgz",
+      "integrity": "sha512-dLAADUSS8rBwhaevT12yCezvioCA+bmUTPH/u57xKPT8d++voeYE6HeluA/bPbQ15TwDBG2ii+QZIEmYx8VdxA==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.2.2",
+        "escape-string-regexp": "^4.0.0",
+        "htmlparser2": "^8.0.0",
+        "is-plain-object": "^5.0.0",
+        "parse-srcset": "^1.0.2",
+        "postcss": "^8.3.11"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
@@ -8962,6 +9113,15 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }

--- a/package.json
+++ b/package.json
@@ -42,12 +42,14 @@
     "isomorphic-fetch": "^3.0.0",
     "node-cron": "^3.0.3",
     "react-qr-reader": "^3.0.0-beta-1",
+    "sanitize-html": "2.17.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@types/express": "^5.0.6",
     "@types/jest": "^29.5.12",
     "@types/node": "^14.0.0",
+    "@types/sanitize-html": "^2.16.1",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",
     "cross-env": "^7.0.3",

--- a/package.json
+++ b/package.json
@@ -42,14 +42,12 @@
     "isomorphic-fetch": "^3.0.0",
     "node-cron": "^3.0.3",
     "react-qr-reader": "^3.0.0-beta-1",
-    "sanitize-html": "2.17.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@types/express": "^5.0.6",
     "@types/jest": "^29.5.12",
     "@types/node": "^14.0.0",
-    "@types/sanitize-html": "^2.16.1",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",
     "cross-env": "^7.0.3",

--- a/src/teamsBot.test.ts
+++ b/src/teamsBot.test.ts
@@ -97,6 +97,25 @@ describe('TeamsBot handleTeamsMessagingExtensionSubmitAction', () => {
     expect(response).toEqual({});
   });
 
+  test('reduces malformed message HTML to a safe plaintext memo', async () => {
+    mockGetUsers.mockResolvedValue([authorUser]);
+    mockCreateZapCard.mockResolvedValue({ type: 'AdaptiveCard' } as never);
+
+    const context = buildContext(currentUser);
+    await bot.handleTeamsMessagingExtensionSubmitAction(
+      context,
+      buildAction(
+        authorUser.aadObjectId,
+        'Great <<script>script>alert(1)</script> & <b>safe</b>',
+      ),
+    );
+
+    const memo = mockCreateZapCard.mock.calls[0][2]?.message;
+    expect(memo).not.toMatch(/[<>&]/);
+    expect(memo).toContain('Great');
+    expect(memo).toContain('safe');
+  });
+
   test('guards against zapping yourself', async () => {
     mockGetUsers.mockResolvedValue([currentUser]);
 

--- a/src/teamsBot.test.ts
+++ b/src/teamsBot.test.ts
@@ -1,0 +1,152 @@
+// teamsBot.test.ts
+import { expect, describe, test, beforeEach, jest } from '@jest/globals';
+
+jest.mock('./services/lnbitsService');
+jest.mock('./services/fetchRewardsName');
+jest.mock('./commands/sendZapCommand', () => {
+  const actual = jest.requireActual('./commands/sendZapCommand') as object;
+  return {
+    ...actual,
+    createZapCard: jest.fn(),
+  };
+});
+
+import { TeamsBot } from './teamsBot';
+import { getUsers } from './services/lnbitsService';
+import { getRewardName } from './services/fetchRewardsName';
+import { createZapCard } from './commands/sendZapCommand';
+
+const mockGetUsers = getUsers as jest.MockedFunction<typeof getUsers>;
+const mockGetRewardName = getRewardName as jest.MockedFunction<typeof getRewardName>;
+const mockCreateZapCard = createZapCard as jest.MockedFunction<typeof createZapCard>;
+
+const currentUser = {
+  id: 'currentUserId',
+  displayName: 'Current User',
+  profileImg: '',
+  aadObjectId: 'aad-current',
+  email: 'current@test.com',
+  privateWallet: null,
+  allowanceWallet: null,
+} as User;
+
+const authorUser = {
+  id: 'authorUserId',
+  displayName: 'Author User',
+  profileImg: '',
+  aadObjectId: 'aad-author',
+  email: 'author@test.com',
+  privateWallet: null,
+  allowanceWallet: null,
+} as User;
+
+function buildContext(user: User | undefined) {
+  const turnState = new Map<string, unknown>();
+  if (user) {
+    turnState.set('user', user);
+  }
+  return {
+    turnState,
+    sendActivity: jest.fn(),
+  } as unknown as import('botbuilder').TurnContext;
+}
+
+function buildAction(authorAadId: string | undefined, content = '<p>Great work!</p>') {
+  return {
+    messagePayload: {
+      from: {
+        user: {
+          id: authorAadId,
+          displayName: 'Author User',
+        },
+      },
+      body: {
+        content,
+      },
+    },
+  } as unknown as import('botbuilder').MessagingExtensionAction;
+}
+
+describe('TeamsBot handleTeamsMessagingExtensionSubmitAction', () => {
+  let bot: TeamsBot;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    bot = new TeamsBot();
+    mockGetRewardName.mockResolvedValue('Sats');
+  });
+
+  test('sends the zap card prefilled for the message author and returns {}', async () => {
+    mockGetUsers.mockResolvedValue([currentUser, authorUser]);
+    mockCreateZapCard.mockResolvedValue({ type: 'AdaptiveCard' } as never);
+
+    const context = buildContext(currentUser);
+    const action = buildAction(authorUser.aadObjectId);
+
+    const response = await bot.handleTeamsMessagingExtensionSubmitAction(
+      context,
+      action,
+    );
+
+    expect(mockCreateZapCard).toHaveBeenCalledWith(
+      currentUser,
+      'Sats',
+      expect.objectContaining({ receiverId: authorUser.id, message: 'Great work!' }),
+    );
+    expect(context.sendActivity).toHaveBeenCalledTimes(1);
+    expect(response).toEqual({});
+  });
+
+  test('guards against zapping yourself', async () => {
+    mockGetUsers.mockResolvedValue([currentUser]);
+
+    const context = buildContext(currentUser);
+    const action = buildAction(currentUser.aadObjectId);
+
+    const response = await bot.handleTeamsMessagingExtensionSubmitAction(
+      context,
+      action,
+    );
+
+    expect(mockCreateZapCard).not.toHaveBeenCalled();
+    expect(context.sendActivity).toHaveBeenCalledWith(
+      expect.stringContaining("can't zap yourself"),
+    );
+    expect(response).toEqual({});
+  });
+
+  test('guards when the message author has no Zaplie account', async () => {
+    mockGetUsers.mockResolvedValue([currentUser]);
+
+    const context = buildContext(currentUser);
+    const action = buildAction('aad-unknown-author');
+
+    const response = await bot.handleTeamsMessagingExtensionSubmitAction(
+      context,
+      action,
+    );
+
+    expect(mockCreateZapCard).not.toHaveBeenCalled();
+    expect(context.sendActivity).toHaveBeenCalledWith(
+      expect.stringContaining("doesn't have a Zaplie account"),
+    );
+    expect(response).toEqual({});
+  });
+
+  test('guards when the invoking user is not provisioned', async () => {
+    const context = buildContext(undefined);
+    const action = buildAction(authorUser.aadObjectId);
+
+    const response = await bot.handleTeamsMessagingExtensionSubmitAction(
+      context,
+      action,
+    );
+
+    expect(mockGetUsers).not.toHaveBeenCalled();
+    expect(mockCreateZapCard).not.toHaveBeenCalled();
+    expect(context.sendActivity).toHaveBeenCalledWith(
+      expect.stringContaining("couldn't find your Zaplie account"),
+    );
+    expect(response).toEqual({});
+  });
+});

--- a/src/teamsBot.test.ts
+++ b/src/teamsBot.test.ts
@@ -1,8 +1,20 @@
 // teamsBot.test.ts
-import { expect, describe, test, beforeEach, jest } from '@jest/globals';
+import {
+  expect,
+  describe,
+  test,
+  beforeEach,
+  afterAll,
+  jest,
+} from '@jest/globals';
+
+const originalPointsLabel = process.env.LNBITS_POINTS_LABEL;
+const originalAdminKey = process.env.LNBITS_ADMINKEY;
+
+process.env.LNBITS_POINTS_LABEL = 'Sats';
+process.env.LNBITS_ADMINKEY = 'admin-key';
 
 jest.mock('./services/lnbitsService');
-jest.mock('./services/fetchRewardsName');
 jest.mock('./commands/sendZapCommand', () => {
   const actual = jest.requireActual('./commands/sendZapCommand') as object;
   return {
@@ -11,14 +23,17 @@ jest.mock('./commands/sendZapCommand', () => {
   };
 });
 
-import { TeamsBot } from './teamsBot';
 import { getUsers } from './services/lnbitsService';
-import { getRewardName } from './services/fetchRewardsName';
 import { createZapCard } from './commands/sendZapCommand';
 
+// require, not import: imports hoist above the jest.mock calls above.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { TeamsBot } = require('./teamsBot') as typeof import('./teamsBot');
+
 const mockGetUsers = getUsers as jest.MockedFunction<typeof getUsers>;
-const mockGetRewardName = getRewardName as jest.MockedFunction<typeof getRewardName>;
-const mockCreateZapCard = createZapCard as jest.MockedFunction<typeof createZapCard>;
+const mockCreateZapCard = createZapCard as jest.MockedFunction<
+  typeof createZapCard
+>;
 
 const currentUser = {
   id: 'currentUserId',
@@ -40,19 +55,22 @@ const authorUser = {
   allowanceWallet: null,
 } as User;
 
-function buildContext(user: User | undefined) {
+function buildContext(user: User) {
   const turnState = new Map<string, unknown>();
-  if (user) {
-    turnState.set('user', user);
-  }
+  turnState.set('user', user);
   return {
     turnState,
     sendActivity: jest.fn(),
   } as unknown as import('botbuilder').TurnContext;
 }
 
-function buildAction(authorAadId: string | undefined, content = '<p>Great work!</p>') {
+function buildAction(
+  authorAadId: string | undefined,
+  content = '<p>Great work!</p>',
+  data?: Record<string, unknown>,
+) {
   return {
+    data,
     messagePayload: {
       from: {
         user: {
@@ -68,16 +86,20 @@ function buildAction(authorAadId: string | undefined, content = '<p>Great work!<
 }
 
 describe('TeamsBot handleTeamsMessagingExtensionSubmitAction', () => {
-  let bot: TeamsBot;
+  let bot: InstanceType<typeof TeamsBot>;
 
   beforeEach(() => {
     jest.clearAllMocks();
     bot = new TeamsBot();
-    mockGetRewardName.mockResolvedValue('Sats');
+  });
+
+  afterAll(() => {
+    restoreEnv('LNBITS_POINTS_LABEL', originalPointsLabel);
+    restoreEnv('LNBITS_ADMINKEY', originalAdminKey);
   });
 
   test('sends the zap card prefilled for the message author and returns {}', async () => {
-    mockGetUsers.mockResolvedValue([currentUser, authorUser]);
+    mockGetUsers.mockResolvedValue([authorUser]);
     mockCreateZapCard.mockResolvedValue({ type: 'AdaptiveCard' } as never);
 
     const context = buildContext(currentUser);
@@ -88,16 +110,19 @@ describe('TeamsBot handleTeamsMessagingExtensionSubmitAction', () => {
       action,
     );
 
-    expect(mockCreateZapCard).toHaveBeenCalledWith(
-      currentUser,
-      'Sats',
-      expect.objectContaining({ receiverId: authorUser.id, message: 'Great work!' }),
-    );
+    expect(mockCreateZapCard).toHaveBeenCalledWith(currentUser, 'Sats', {
+      receiverId: authorUser.id,
+      amountSats: 1000,
+      message: 'Great work!',
+    });
+    expect(mockGetUsers).toHaveBeenCalledWith('admin-key', {
+      aadObjectId: authorUser.aadObjectId,
+    });
     expect(context.sendActivity).toHaveBeenCalledTimes(1);
     expect(response).toEqual({});
   });
 
-  test('reduces malformed message HTML to a safe plaintext memo', async () => {
+  test('extracts a plain-text memo, decoding HTML entities', async () => {
     mockGetUsers.mockResolvedValue([authorUser]);
     mockCreateZapCard.mockResolvedValue({ type: 'AdaptiveCard' } as never);
 
@@ -106,14 +131,58 @@ describe('TeamsBot handleTeamsMessagingExtensionSubmitAction', () => {
       context,
       buildAction(
         authorUser.aadObjectId,
-        'Great <<script>script>alert(1)</script> & <b>safe</b>',
+        '<p>that&#39;s great &amp;&nbsp;fast &#x2764; &lt;b&gt; &copy;</p>',
       ),
     );
 
-    const memo = mockCreateZapCard.mock.calls[0][2]?.message;
-    expect(memo).not.toMatch(/[<>&]/);
-    expect(memo).toContain('Great');
-    expect(memo).toContain('safe');
+    // Unsupported entities (&copy;) stay literal rather than decoding wrongly.
+    expect(mockCreateZapCard.mock.calls[0][2]?.message).toBe(
+      "that's great & fast ❤ <b> &copy;",
+    );
+  });
+
+  test('sends an empty memo when the message has no body content', async () => {
+    mockGetUsers.mockResolvedValue([authorUser]);
+    mockCreateZapCard.mockResolvedValue({ type: 'AdaptiveCard' } as never);
+
+    const context = buildContext(currentUser);
+    const action = buildAction(authorUser.aadObjectId);
+    delete (action as { messagePayload?: { body?: unknown } }).messagePayload!
+      .body;
+
+    await bot.handleTeamsMessagingExtensionSubmitAction(context, action);
+
+    expect(mockCreateZapCard.mock.calls[0][2]?.message).toBe('');
+  });
+
+  test('caps the memo preview at 80 characters', async () => {
+    mockGetUsers.mockResolvedValue([authorUser]);
+    mockCreateZapCard.mockResolvedValue({ type: 'AdaptiveCard' } as never);
+
+    const context = buildContext(currentUser);
+    await bot.handleTeamsMessagingExtensionSubmitAction(
+      context,
+      buildAction(authorUser.aadObjectId, `<p>${'x'.repeat(100)}</p>`),
+    );
+
+    expect(mockCreateZapCard.mock.calls[0][2]?.message).toBe('x'.repeat(80));
+  });
+
+  test('prefers a memo typed in the action dialog over the message text', async () => {
+    mockGetUsers.mockResolvedValue([authorUser]);
+    mockCreateZapCard.mockResolvedValue({ type: 'AdaptiveCard' } as never);
+
+    const context = buildContext(currentUser);
+    await bot.handleTeamsMessagingExtensionSubmitAction(
+      context,
+      buildAction(authorUser.aadObjectId, '<p>Great work!</p>', {
+        memo: '  Deploy fix appreciated  ',
+      }),
+    );
+
+    expect(mockCreateZapCard.mock.calls[0][2]?.message).toBe(
+      'Deploy fix appreciated',
+    );
   });
 
   test('guards against zapping yourself', async () => {
@@ -135,7 +204,7 @@ describe('TeamsBot handleTeamsMessagingExtensionSubmitAction', () => {
   });
 
   test('guards when the message author has no Zaplie account', async () => {
-    mockGetUsers.mockResolvedValue([currentUser]);
+    mockGetUsers.mockResolvedValue([]);
 
     const context = buildContext(currentUser);
     const action = buildAction('aad-unknown-author');
@@ -152,20 +221,31 @@ describe('TeamsBot handleTeamsMessagingExtensionSubmitAction', () => {
     expect(response).toEqual({});
   });
 
-  test('guards when the invoking user is not provisioned', async () => {
-    const context = buildContext(undefined);
-    const action = buildAction(authorUser.aadObjectId);
+  test('returns a friendly guard when the author lookup fails', async () => {
+    mockGetUsers.mockRejectedValue(new Error('LNbits unavailable'));
+    const errorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
 
+    const context = buildContext(currentUser);
     const response = await bot.handleTeamsMessagingExtensionSubmitAction(
       context,
-      action,
+      buildAction(authorUser.aadObjectId),
     );
 
-    expect(mockGetUsers).not.toHaveBeenCalled();
     expect(mockCreateZapCard).not.toHaveBeenCalled();
     expect(context.sendActivity).toHaveBeenCalledWith(
-      expect.stringContaining("couldn't find your Zaplie account"),
+      expect.stringContaining("couldn't check that teammate's Zaplie account"),
     );
     expect(response).toEqual({});
+    errorSpy.mockRestore();
   });
 });
+
+function restoreEnv(key: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+}

--- a/src/teamsBot.ts
+++ b/src/teamsBot.ts
@@ -11,7 +11,6 @@ import {
   MessagingExtensionAction,
   MessagingExtensionActionResponse,
 } from 'botbuilder';
-import sanitizeHtml from 'sanitize-html';
 import { SSOCommandMap } from './commands/SSOCommandMap';
 import {
   SendZapCommand,
@@ -420,13 +419,8 @@ export class TeamsBot extends TeamsActivityHandler {
     context: TurnContext,
     action: MessagingExtensionAction,
   ): Promise<MessagingExtensionActionResponse> {
+    // FetchUserMiddleware guarantees 'user' is set (or the turn already threw).
     const currentUser = context.turnState.get('user');
-    if (!currentUser) {
-      await context.sendActivity(
-        "D'oh! I couldn't find your Zaplie account. Message me directly first to get set up.",
-      );
-      return {};
-    }
 
     const authorUser = action.messagePayload?.from?.user;
     if (!authorUser?.id) {
@@ -436,8 +430,20 @@ export class TeamsBot extends TeamsActivityHandler {
       return {};
     }
 
-    const users = await getUsers(adminKey, null);
-    const author = users?.find(user => user.aadObjectId === authorUser.id);
+    let author: User | undefined;
+    try {
+      const users = await getUsers(adminKey, { aadObjectId: authorUser.id });
+      author = users[0];
+    } catch (error) {
+      console.error(
+        'Unable to resolve the message author in Zaplie:',
+        error instanceof Error ? error.message : error,
+      );
+      await context.sendActivity(
+        "D'oh! I couldn't check that teammate's Zaplie account right now. Please try again later.",
+      );
+      return {};
+    }
     if (!author) {
       await context.sendActivity(
         `D'oh! ${authorUser.displayName || 'That person'} doesn't have a Zaplie account yet.`,
@@ -452,10 +458,15 @@ export class TeamsBot extends TeamsActivityHandler {
       return {};
     }
 
+    // 'memo' comes from the static-parameter dialog Teams shows before this
+    // invoke (manifest zapMessage command); empty means "use the message text".
+    const dialogMemo =
+      typeof action.data?.memo === 'string' ? action.data.memo.trim() : '';
     const card = await createZapCard(currentUser, globalRewardName, {
       receiverId: author.id,
-      amountSats: getZapMessageDefaultSats(),
-      message: stripHtmlSnippet(action.messagePayload?.body?.content),
+      amountSats: ZAP_MESSAGE_DEFAULT_SATS,
+      message:
+        dialogMemo || htmlToMemoPreview(action.messagePayload?.body?.content),
     });
 
     await context.sendActivity(
@@ -466,21 +477,40 @@ export class TeamsBot extends TeamsActivityHandler {
   }
 }
 
-// HTML -> plaintext, capped to a short preview for the zap memo field.
-function stripHtmlSnippet(html: string | undefined): string {
+// Prefill only: the user can still edit the amount on the card, whose input
+// regex enforces 1..10,000.
+const ZAP_MESSAGE_DEFAULT_SATS = 1000;
+
+const HTML_ENTITIES: Record<string, string> = {
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  apos: "'",
+  nbsp: ' ',
+};
+
+// The memo is a plain-text Adaptive Card value, never rendered as HTML, so we
+// extract text (strip tags, decode entities) instead of sanitizing. Entities
+// are decoded after tag removal so "&lt;b&gt;" stays the literal text "<b>".
+function htmlToMemoPreview(html: string | undefined): string {
   if (!html) return '';
-  return sanitizeHtml(html, { allowedTags: [], allowedAttributes: {} })
-    .replace(/[<>&]/g, ' ')
+  return html
+    .replace(/<[^>]*>/g, ' ')
+    .replace(
+      /&(#\d+|#[xX][0-9a-fA-F]+|[a-zA-Z]+);/g,
+      (entity, body: string) => {
+        if (body[0] === '#') {
+          const code =
+            body[1] === 'x' || body[1] === 'X'
+              ? parseInt(body.slice(2), 16)
+              : parseInt(body.slice(1), 10);
+          return code <= 0x10ffff ? String.fromCodePoint(code) : entity;
+        }
+        return HTML_ENTITIES[body.toLowerCase()] ?? entity;
+      },
+    )
     .replace(/\s+/g, ' ')
     .trim()
     .slice(0, 80);
-}
-
-function getZapMessageDefaultSats(): number {
-  const raw = process.env.ZAP_MESSAGE_DEFAULT_SATS ?? '1000';
-  const amount = Number(raw);
-  if (!Number.isInteger(amount) || amount <= 0) {
-    throw new Error(`ZAP_MESSAGE_DEFAULT_SATS must be a positive integer, got "${raw}".`);
-  }
-  return amount;
 }

--- a/src/teamsBot.ts
+++ b/src/teamsBot.ts
@@ -8,9 +8,15 @@ import {
   StatePropertyAccessor,
   CardFactory,
   MessageFactory,
+  MessagingExtensionAction,
+  MessagingExtensionActionResponse,
 } from 'botbuilder';
 import { SSOCommandMap } from './commands/SSOCommandMap';
-import { SendZapCommand, SendZap } from './commands/sendZapCommand';
+import {
+  SendZapCommand,
+  SendZap,
+  createZapCard,
+} from './commands/sendZapCommand';
 import { ZapLedger, zapKey } from './services/zapLedger';
 import {
   getPendingRecipientIds,
@@ -30,7 +36,7 @@ import {
 } from './commands/connectCalendarCommand';
 import { runConversationalTurn } from './services/foundryAgentService';
 import { createAgentTools } from './commands/agentTools';
-import { getUser, getWalletBalance } from './services/lnbitsService';
+import { getUser, getUsers, getWalletBalance } from './services/lnbitsService';
 
 const UNRECOGNIZED_COMMAND_MESSAGE =
   "D'oh! I'm sorry, but I didn't recognize that command. But don't worry, I'm always getting better!";
@@ -407,4 +413,69 @@ export class TeamsBot extends TeamsActivityHandler {
       console.error('Error in handleTeamsSigninTokenExchange:', error);
     }
   }
+
+  // "Zap a message" action command: right-click a message -> pre-fill a zap card for its author.
+  async handleTeamsMessagingExtensionSubmitAction(
+    context: TurnContext,
+    action: MessagingExtensionAction,
+  ): Promise<MessagingExtensionActionResponse> {
+    const currentUser = context.turnState.get('user');
+    if (!currentUser) {
+      await context.sendActivity(
+        "D'oh! I couldn't find your Zaplie account. Message me directly first to get set up.",
+      );
+      return {};
+    }
+
+    const authorUser = action.messagePayload?.from?.user;
+    if (!authorUser?.id) {
+      await context.sendActivity(
+        "D'oh! I couldn't tell who sent that message, so I can't zap them.",
+      );
+      return {};
+    }
+
+    const users = await getUsers(adminKey, null);
+    const author = users?.find(user => user.aadObjectId === authorUser.id);
+    if (!author) {
+      await context.sendActivity(
+        `D'oh! ${authorUser.displayName || 'That person'} doesn't have a Zaplie account yet.`,
+      );
+      return {};
+    }
+
+    if (author.aadObjectId === currentUser.aadObjectId) {
+      await context.sendActivity(
+        "D'oh! You can't zap yourself - the allowance is for recognising others.",
+      );
+      return {};
+    }
+
+    const card = await createZapCard(currentUser, globalRewardName, {
+      receiverId: author.id,
+      amountSats: getZapMessageDefaultSats(),
+      message: stripHtmlSnippet(action.messagePayload?.body?.content),
+    });
+
+    await context.sendActivity(
+      MessageFactory.attachment(CardFactory.adaptiveCard(card)),
+    );
+
+    return {};
+  }
+}
+
+// HTML -> plaintext, capped to a short preview for the zap memo field.
+function stripHtmlSnippet(html: string | undefined): string {
+  if (!html) return '';
+  return html.replace(/<[^>]+>/g, '').trim().slice(0, 80);
+}
+
+function getZapMessageDefaultSats(): number {
+  const raw = process.env.ZAP_MESSAGE_DEFAULT_SATS ?? '1000';
+  const amount = Number(raw);
+  if (!Number.isInteger(amount) || amount <= 0) {
+    throw new Error(`ZAP_MESSAGE_DEFAULT_SATS must be a positive integer, got "${raw}".`);
+  }
+  return amount;
 }

--- a/src/teamsBot.ts
+++ b/src/teamsBot.ts
@@ -11,6 +11,7 @@ import {
   MessagingExtensionAction,
   MessagingExtensionActionResponse,
 } from 'botbuilder';
+import sanitizeHtml from 'sanitize-html';
 import { SSOCommandMap } from './commands/SSOCommandMap';
 import {
   SendZapCommand,
@@ -468,7 +469,11 @@ export class TeamsBot extends TeamsActivityHandler {
 // HTML -> plaintext, capped to a short preview for the zap memo field.
 function stripHtmlSnippet(html: string | undefined): string {
   if (!html) return '';
-  return html.replace(/<[^>]+>/g, '').trim().slice(0, 80);
+  return sanitizeHtml(html, { allowedTags: [], allowedAttributes: {} })
+    .replace(/[<>&]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 80);
 }
 
 function getZapMessageDefaultSats(): number {

--- a/tabs/backend/server.js
+++ b/tabs/backend/server.js
@@ -2,7 +2,6 @@
 const express = require('express');
 const { rateLimit } = require('express-rate-limit');
 const cors = require('cors');
-const bodyParser = require('body-parser');
 const path = require('path');
 const fs = require('fs');
 const authMiddleware = require('./authMiddleware'); // Import the authentication middleware
@@ -35,7 +34,7 @@ app.use(cors());
 // Mounted app-wide, not on /api: CodeQL also flags the sendFile catch-all
 // below (js/missing-rate-limiting), and every route does file or network work.
 app.use(apiRateLimiter);
-app.use(bodyParser.json());
+app.use(express.json());
 
 // Deployment smoke tests need a dependency-free liveness signal. Readiness of
 // authenticated LNbits operations is exercised separately by the API tests.
@@ -242,7 +241,9 @@ app.post('/api/pending-rewards', (req, res) => {
 // Serve the React app
 app.use(express.static(path.join(__dirname, '../build')));
 
-app.get('*', (req, res) => {
+// A regular expression works with both Express 4 and path-to-regexp v8 in
+// Express 5. Bare wildcard strings such as '*' throw during Express 5 startup.
+app.get(/.*/, (req, res) => {
   res.sendFile(path.join(__dirname, '../build', 'index.html'));
 });
 

--- a/tabs/package-lock.json
+++ b/tabs/package-lock.json
@@ -17,7 +17,6 @@
         "@testing-library/user-event": "^14.6.3",
         "@yudiel/react-qr-scanner": "^2.0.8",
         "axios": "^1.8.1",
-        "body-parser": "^1.20.3",
         "cors": "^2.8.5",
         "dotenv-flow": "^4.1.0",
         "express": "^4.21.2",

--- a/tabs/package.json
+++ b/tabs/package.json
@@ -15,7 +15,6 @@
     "@testing-library/user-event": "^14.6.3",
     "@yudiel/react-qr-scanner": "^2.0.8",
     "axios": "^1.8.1",
-    "body-parser": "^1.20.3",
     "cors": "^2.8.5",
     "dotenv-flow": "^4.1.0",
     "express": "^4.21.2",


### PR DESCRIPTION
Recreated from #179. GitHub closed that pull request automatically when the source fork was detached from the upstream network. The code is identical and the branch now lives in this repository. Review history stays readable on #179.

---

Fixes #178

## Description

Adds the Zap action to the Teams message "More actions" menu and connects it to the existing zap confirmation and payment flow, so recognising a specific message no longer means retyping who and what in the bot chat.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Breaking change
- [ ] Documentation update

## Related Issues

N/A

## Changes Made

- Registered the Teams message action in the manifest and implemented `handleTeamsMessagingExtensionSubmitAction` in `TeamsBot`.
- Resolves the message author through their AAD object ID and prefills the zap card with the recipient and the message text.
- Reuses the existing budget, recipient, self-zap, confirmation and duplicate-submit protections rather than adding a second payment path.
- Guards every failure mode with a plain message instead of a silent no-op: invoker not provisioned, author has no Zaplie account, author lookup failed, and self-zap.
- `ZAP_MESSAGE_DEFAULT_SATS` falls back to 1000 with a warning when it is not a positive integer.
- Merged `origin/main` (4a339c1b); the only conflict was the import block in `teamsBot.ts`.

## Verification

From clean installs on Node 24:

- `npx tsc --noEmit`, `npm run lint` and `npm run format:check` clean.
- `npx jest --ci --runInBand`: the six new `teamsBot` cases pass, covering the happy path and all five guards. The one remaining failure, `createInvoice > rejects on a non-2xx response`, is pre-existing on `main`: a `test.failing` marker left behind after #188 fixed the bug it described. Untouched here; removed in #192.

## Test plan for QA

1. In a Teams channel, open "More actions" on a colleague's message and pick Zap. The zap card opens prefilled with that person and the message text.
2. Confirm the zap and check the payment lands once. Submit the same card twice and confirm the duplicate is rejected.
3. Try it on your own message: it must refuse with the self-zap message.
4. Try it on a message from someone with no Zaplie account: it must say so rather than fail silently.
5. Set `ZAP_MESSAGE_DEFAULT_SATS` to a non-numeric value and confirm the card opens at 1000 with a warning logged.

## Screenshots

The visual surface here is the Teams client context menu and the resulting card, so the capture has to come from the Teams desktop or web client rather than the portal. Pending.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have tested my changes locally
- [x] My changes generate no new warnings
- [x] I have added/updated documentation as needed

