### PR TITLE
fix: rate limit tabs backend API routes

### DIFF
--- a/tabs/backend/configRoutes.test.js
+++ b/tabs/backend/configRoutes.test.js
@@ -85,7 +85,7 @@ const call = (method, route, auth, body) =>
       },
       res => {
         res.resume();
-        res.on('end', () => resolve({ status: res.statusCode }));
+        res.on('end', () => resolve({ status: res.statusCode, headers: res.headers }));
       },
     );
     req.on('error', reject);
@@ -99,7 +99,9 @@ const post = (route, auth, body) => call('POST', route, auth, body);
 const PROTECTED_READS = ['/api/automations', '/api/reward-amounts'];
 
 test('reward-name is readable without credentials, since the portal reads it before sign-in', async () => {
-  assert.equal((await get('/api/reward-name')).status, 200);
+  const response = await get('/api/reward-name');
+  assert.equal(response.status, 200);
+  assert.match(response.headers['ratelimit-policy'], /300;w=900/);
 });
 
 for (const route of PROTECTED_READS) {

--- a/tabs/backend/rateLimit.test.js
+++ b/tabs/backend/rateLimit.test.js
@@ -1,0 +1,50 @@
+// Proves the limiter actually enforces HTTP 429, not just that it advertises
+// a policy header. Runs in its own process so the tiny limit cannot starve
+// the other route suites.
+process.env.API_RATE_LIMIT = '3';
+process.env.TAB_BACKEND_TOKEN = 'test-internal-token';
+process.env.AAD_TENANT_ID = 'test-tenant';
+process.env.AAD_CLIENT_ID = 'test-client';
+
+const assert = require('node:assert/strict');
+const { before, after, test } = require('node:test');
+const http = require('http');
+
+const app = require('./server');
+
+let server;
+let base;
+
+before(async () => {
+  await new Promise(resolve => {
+    server = app.listen(0, () => {
+      base = `http://127.0.0.1:${server.address().port}`;
+      resolve();
+    });
+  });
+});
+
+after(async () => {
+  await new Promise(resolve => server.close(resolve));
+});
+
+const get = route =>
+  new Promise((resolve, reject) => {
+    const req = http.request(`${base}${route}`, { method: 'GET' }, res => {
+      res.resume();
+      res.on('end', () => resolve({ status: res.statusCode, headers: res.headers }));
+    });
+    req.on('error', reject);
+    req.end();
+  });
+
+test('returns 429 once the request budget is spent', async () => {
+  for (let i = 0; i < 3; i++) {
+    const response = await get('/api/reward-name');
+    assert.equal(response.status, 200);
+  }
+
+  const limited = await get('/api/reward-name');
+  assert.equal(limited.status, 429);
+  assert.match(limited.headers['ratelimit-policy'], /3;w=900/);
+});

--- a/tabs/backend/server.js
+++ b/tabs/backend/server.js
@@ -1,5 +1,6 @@
 // filepath: /c:/projects/ZapVibes/tabs/backend/server.js
 const express = require('express');
+const { rateLimit } = require('express-rate-limit');
 const cors = require('cors');
 const bodyParser = require('body-parser');
 const path = require('path');
@@ -16,7 +17,17 @@ const {
 const app = express();
 const port = process.env.PORT || 5000;
 
+const apiRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  limit: 300,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
 app.use(cors());
+// Apply abuse protection before any API route performs authentication, file
+// access, or outbound requests. Static assets remain outside this budget.
+app.use('/api', apiRateLimiter);
 app.use(bodyParser.json());
 
 // Mounted before the generic authMiddleware below: its user-facing routes

--- a/tabs/backend/server.js
+++ b/tabs/backend/server.js
@@ -17,16 +17,20 @@ const {
 const app = express();
 const port = process.env.PORT || 5000;
 
+// Azure App Service fronts the app with a single proxy; without this the
+// limiter would key every client on the proxy's IP.
+app.set('trust proxy', 1);
+
 const apiRateLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
-  limit: 300,
+  limit: Number(process.env.API_RATE_LIMIT) || 300,
   standardHeaders: true,
   legacyHeaders: false,
 });
 
 app.use(cors());
-// Apply abuse protection before any API route performs authentication, file
-// access, or outbound requests. Static assets remain outside this budget.
+// Mounted app-wide, not on /api: CodeQL also flags the sendFile catch-all
+// below (js/missing-rate-limiting), and every route does file or network work.
 app.use(apiRateLimiter);
 app.use(bodyParser.json());
 

--- a/tabs/backend/server.js
+++ b/tabs/backend/server.js
@@ -27,7 +27,7 @@ const apiRateLimiter = rateLimit({
 app.use(cors());
 // Apply abuse protection before any API route performs authentication, file
 // access, or outbound requests. Static assets remain outside this budget.
-app.use('/api', apiRateLimiter);
+app.use(apiRateLimiter);
 app.use(bodyParser.json());
 
 // Mounted before the generic authMiddleware below: its user-facing routes

--- a/tabs/package-lock.json
+++ b/tabs/package-lock.json
@@ -21,6 +21,7 @@
         "cors": "^2.8.5",
         "dotenv-flow": "^4.1.0",
         "express": "^4.21.2",
+        "express-rate-limit": "^8.6.1",
         "http-proxy-middleware": "^2.0.6",
         "jose": "^4.15.9",
         "light-bolt11-decoder": "^3.2.0",
@@ -9825,6 +9826,25 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/express/node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -11196,6 +11216,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/ipaddr.js": {

--- a/tabs/package.json
+++ b/tabs/package.json
@@ -19,6 +19,7 @@
     "cors": "^2.8.5",
     "dotenv-flow": "^4.1.0",
     "express": "^4.21.2",
+    "express-rate-limit": "^8.6.1",
     "http-proxy-middleware": "^2.0.6",
     "jose": "^4.15.9",
     "light-bolt11-decoder": "^3.2.0",


### PR DESCRIPTION
## What changed

- Add `express-rate-limit` to the tabs backend.
- Apply a 300-request/15-minute limiter before backend work.
- Verify the standardized rate-limit policy header.

## Why

CodeQL reports missing-rate-limiting alerts in backend feature PRs.

## Risk

The in-memory store is process-local and must be validated against the production proxy topology.

## Test plan

- Run `npm ci` in `tabs/`.
- Run `npm run test:backend`.
- Run `CI=true npm test -- --watchAll=false`.
- Run `npm run build`.
- Verify HTTP 429 enforcement and the intended route scope.

Fixes #265
