### PR TITLE
ci: make tabs backend CI catch Express 5 regressions

### DIFF
--- a/.github/workflows/ci-quality-checks.yml
+++ b/.github/workflows/ci-quality-checks.yml
@@ -121,6 +121,10 @@ jobs:
           CI: true
         run: npm test -- --watchAll=false
 
+      - name: Run backend tests
+        working-directory: tabs
+        run: npm run test:backend
+
   build-check:
     name: Build Verification
     runs-on: ubuntu-latest

--- a/tabs/backend/server.js
+++ b/tabs/backend/server.js
@@ -2,7 +2,6 @@
 const express = require('express');
 const { rateLimit } = require('express-rate-limit');
 const cors = require('cors');
-const bodyParser = require('body-parser');
 const path = require('path');
 const fs = require('fs');
 const authMiddleware = require('./authMiddleware'); // Import the authentication middleware
@@ -35,7 +34,7 @@ app.use(cors());
 // Mounted app-wide, not on /api: CodeQL also flags the sendFile catch-all
 // below (js/missing-rate-limiting), and every route does file or network work.
 app.use(apiRateLimiter);
-app.use(bodyParser.json());
+app.use(express.json());
 
 // Deployment smoke tests need a dependency-free liveness signal. Readiness of
 // authenticated LNbits operations is exercised separately by the API tests.
@@ -242,7 +241,9 @@ app.post('/api/pending-rewards', (req, res) => {
 // Serve the React app
 app.use(express.static(path.join(__dirname, '../build')));
 
-app.get('*', (req, res) => {
+// A regular expression works with both Express 4 and path-to-regexp v8 in
+// Express 5. Bare wildcard strings such as '*' throw during Express 5 startup.
+app.get(/.*/, (req, res) => {
   res.sendFile(path.join(__dirname, '../build', 'index.html'));
 });
 

--- a/tabs/package-lock.json
+++ b/tabs/package-lock.json
@@ -17,7 +17,6 @@
         "@testing-library/user-event": "^14.6.3",
         "@yudiel/react-qr-scanner": "^2.0.8",
         "axios": "^1.8.1",
-        "body-parser": "^1.20.3",
         "cors": "^2.8.5",
         "dotenv-flow": "^4.1.0",
         "express": "^4.21.2",

--- a/tabs/package.json
+++ b/tabs/package.json
@@ -15,7 +15,6 @@
     "@testing-library/user-event": "^14.6.3",
     "@yudiel/react-qr-scanner": "^2.0.8",
     "axios": "^1.8.1",
-    "body-parser": "^1.20.3",
     "cors": "^2.8.5",
     "dotenv-flow": "^4.1.0",
     "express": "^4.21.2",


### PR DESCRIPTION
Adds a backend test step to CI so Express 5 regressions in the tabs backend are caught before merge. Also makes the backend Express 5 compatible: switches body-parser to the built-in express.json() and removes the now-unused dependency. Pairs with #241, which bumps Express itself.

## Test plan
- npm run test:backend in tabs passes 37/37 locally with this branch rebased on main.
- npm ci in tabs succeeds, so the lockfile is consistent after removing body-parser.
- The new CI step runs the same npm run test:backend command on every PR.