### PR TITLE
test: cover pendingRewardsService and correct the identity docs

### DIFF
--- a/docs/identity-connections.md
+++ b/docs/identity-connections.md
@@ -1,0 +1,105 @@
+# Identity connections
+
+Zaplie routes automated rewards by stable identities rather than display names.
+For GitHub, the canonical chain is:
+
+```text
+GitHub numeric user id -> linked identity -> Entra oid -> LNbits external_id
+```
+
+The GitHub login is stored only as a label. Renaming a GitHub account does not
+change reward routing.
+
+## Trust boundaries
+
+- The browser calls `POST /api/identities/github/authorize-url` and
+  `GET /api/identities/mine` with its MSAL ID token. The backend validates its
+  signature, tenant, audience, and `oid` claim.
+- GitHub's client secret, OAuth access token, and `IDENTITY_STATE_SECRET` remain
+  in the tab backend. The signed, expiring OAuth state binds the callback to the
+  verified Entra `oid` that started the flow.
+- The bot calls `GET /api/identities/resolve` with `TAB_BACKEND_TOKEN`. This is a
+  server-to-server secret and must never be exposed through a `REACT_APP_*`
+  variable or otherwise sent to browser code.
+- A linked GitHub numeric id can belong to only one Entra person. Conflicting
+  links fail instead of silently reassigning the account.
+
+## Required configuration
+
+Configure these values in the tab backend's approved server-side secret store.
+[`tabs/backend/.env.example`](../tabs/backend/.env.example) lists names only.
+
+| Variable | Purpose |
+| --- | --- |
+| `AAD_TENANT_ID` | Entra tenant accepted by the backend JWT verifier. |
+| `AAD_CLIENT_ID` | Audience expected on the portal's MSAL ID token. |
+| `GITHUB_OAUTH_CLIENT_ID` | GitHub OAuth App client id. |
+| `GITHUB_OAUTH_CLIENT_SECRET` | GitHub OAuth App client secret; server only. |
+| `GITHUB_OAUTH_REDIRECT_URI` | Exact callback URL registered in GitHub: `https://<backend>/api/identities/github/callback`. |
+| `IDENTITY_STATE_SECRET` | Random secret used to sign the expiring OAuth state. |
+| `PORTAL_URL` | Portal URL that receives the `?github=connected`, `conflict`, or `error` result. |
+| `TAB_BACKEND_TOKEN` | Shared server-to-server token expected from the bot. Generate independently with `openssl rand -hex 32`. |
+
+Configure these values on the bot process:
+
+| Variable | Purpose |
+| --- | --- |
+| `WEBSITE_API_URL` | Tab backend API base URL, including `/api`. Required in production. |
+| `TAB_BACKEND_TOKEN` | The same server-to-server value configured on the tab backend. |
+| `LNBITS_NODE_URL` | LNbits base URL. |
+| `LNBITS_USERNAME` / `LNBITS_PASSWORD` | LNbits service credentials used to obtain the admin bearer token. |
+| `LNBITS_ADMINKEY` | Required guard for the linked-user lookup and wallet access. |
+
+Do not reuse `REWARDS_API_KEY` as `TAB_BACKEND_TOKEN`; the external automation
+boundary and the internal bot-to-backend boundary have different exposure and
+rotation needs. Missing values and the old `your-secret-token` placeholder are
+configuration errors, not development fallbacks.
+
+## GitHub OAuth setup
+
+1. Create a GitHub OAuth App for the deployed environment.
+2. Set its callback URL to the exact `GITHUB_OAUTH_REDIRECT_URI` above.
+3. Set `PORTAL_URL` to the portal Settings route for that environment.
+4. Provision the Entra and GitHub values in the backend secret store.
+5. Provision the same newly generated `TAB_BACKEND_TOKEN` on the bot and tab
+   backend, then restart both processes.
+
+Identity and pending-reward JSON stores are runtime data and are gitignored.
+Do not copy production identity data into the repository or screenshots.
+
+## Known readiness dependency
+
+`TAB_BACKEND_TOKEN` protects the server-to-server routes
+(`GET /api/identities/resolve`, `POST /api/pending-rewards`) and is also
+accepted, as an alternative to a verified MSAL token, on the config reads
+guarded by `requireSignedInOrBot` (`GET /api/automations`,
+`GET /api/reward-amounts`).
+
+Nothing binds the token to server-side callers: `authMiddleware` and
+`requireSignedInOrBot` authorize any HTTP client that presents the value in the
+`Authorization` header, including a browser. The token is a full bearer
+credential for those routes, not a server-only secret by construction; keeping
+it out of browsers is an operational obligation. Never expose it through a
+`REACT_APP_*` variable, client code, logs, or screenshots, and rotate it
+immediately if it reaches any of those.
+
+Administrative writes (`POST /api/automations`, `POST /api/reward-amounts`,
+`POST /api/reward-name`) do not accept the shared token: they require a
+verified MSAL ID token whose account carries the `Zaplie.Admin` app role.
+
+## Verification
+
+From a Node.js 24 checkout:
+
+```bash
+npx jest --ci --runInBand src/services/internalAuth.test.ts src/services/identityService.test.ts src/services/pendingRewardsService.test.ts
+
+cd tabs
+npm run test:backend
+```
+
+Then exercise the real Settings flow: verify loading and error states, connect a
+GitHub account, refresh to confirm the linked handle, and confirm a conflicting
+link cannot be reassigned. Finally, call the internal resolve route with a wrong
+token (expect `401`) and with the configured server token (expect the linked
+`personAad`; never log either token).

--- a/src/services/pendingRewardsService.test.ts
+++ b/src/services/pendingRewardsService.test.ts
@@ -1,0 +1,64 @@
+import { afterAll, beforeEach, expect, jest, test } from '@jest/globals';
+import { createPendingReward, PendingReward } from './pendingRewardsService';
+
+const originalFetch = global.fetch;
+const originalToken = process.env.TAB_BACKEND_TOKEN;
+const originalApiUrl = process.env.WEBSITE_API_URL;
+const fetchMock = jest.fn<typeof fetch>();
+
+const pendingReward: PendingReward = {
+  provider: 'github',
+  providerId: '583231',
+  recipientLabel: 'octocat',
+  amountSats: 210,
+  reason: 'GitHub: PR #7 merged',
+  source: 'github',
+};
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  global.fetch = fetchMock;
+  process.env.TAB_BACKEND_TOKEN = 'test-internal-token';
+  process.env.WEBSITE_API_URL = 'https://portal.example.test/api/';
+});
+
+afterAll(() => {
+  global.fetch = originalFetch;
+  if (originalToken === undefined) {
+    delete process.env.TAB_BACKEND_TOKEN;
+  } else {
+    process.env.TAB_BACKEND_TOKEN = originalToken;
+  }
+  if (originalApiUrl === undefined) {
+    delete process.env.WEBSITE_API_URL;
+  } else {
+    process.env.WEBSITE_API_URL = originalApiUrl;
+  }
+});
+
+test('posts pending rewards with the server-only shared token', async () => {
+  fetchMock.mockResolvedValue({ ok: true, status: 201 } as Response);
+
+  await createPendingReward(pendingReward);
+
+  expect(fetchMock).toHaveBeenCalledWith(
+    'https://portal.example.test/api/pending-rewards',
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'test-internal-token',
+      },
+      body: JSON.stringify(pendingReward),
+    },
+  );
+});
+
+test('fails before the request when TAB_BACKEND_TOKEN is missing', async () => {
+  delete process.env.TAB_BACKEND_TOKEN;
+
+  await expect(createPendingReward(pendingReward)).rejects.toThrow(
+    'TAB_BACKEND_TOKEN',
+  );
+  expect(fetchMock).not.toHaveBeenCalled();
+});

--- a/tabs/backend/identityRoutes.js
+++ b/tabs/backend/identityRoutes.js
@@ -1,7 +1,7 @@
 // filepath: tabs/backend/identityRoutes.js
 // "Connect GitHub" self-linking flow. Person canonical = LNbits user, anchored
 // to aadObjectId; GitHub is an optional linked identity, matched by numeric id
-// only (never the renamable login). See docs/wilmer/implementacion/identidad/.
+// only (never the renamable login). See docs/identity-connections.md.
 const express = require('express');
 const authMiddleware = require('./authMiddleware');
 const { verifyMsalToken, extractBearerToken } = require('./msalValidator');


### PR DESCRIPTION
Two small pieces salvaged from the closed #257, both standalone on main.

1. `pendingRewardsService.test.ts`: covers the service at its HTTP boundary. It pins the exact Authorization header and path (so renaming either fails the test) and asserts that no fetch happens at all when the internal token is missing.
2. `docs/identity-connections.md`: documents the identity and connections flow that landed with #192, and corrects a false claim from the draft version: the internal `TAB_BACKEND_TOKEN` IS accepted by `authMiddleware` from any HTTP client, browsers included. Keeping it out of the browser is an operational rule, not something enforced by construction. The doc now says so and lists which routes accept which credentials.
3. Fixes the dead doc link in the `identityRoutes.js` header comment.

## Test plan
- Root `npm test`: 13 suites, 138 tests pass, including the 3 new suites for the service.
- `npm run lint && npm run typecheck`: clean.
- Doc reviewed against the actual middleware behaviour in `tabs/backend/authMiddleware.js`.
