### PR TITLE
ci: deploy Test from a CI-validated revision over OIDC

### DIFF
--- a/.github/workflows/Azure_App_Service_zaplie-test.yml
+++ b/.github/workflows/Azure_App_Service_zaplie-test.yml
@@ -1,135 +1,332 @@
-# Docs for the Azure Web Apps Deploy action: https://github.com/Azure/webapps-deploy
-# More GitHub Actions for Azure: https://github.com/Azure/actions
-
 name: Deploy to Azure App Service Test
 
+# Main is deployed only after the repository quality workflow succeeds. A
+# manual run is also available for an explicitly selected ref once this
+# workflow exists on the default branch.
 on:
-  push:
+  workflow_run:
+    workflows:
+      - Code Quality Checks
+    types:
+      - completed
     branches:
       - main
   workflow_dispatch:
 
+# Never interrupt an App Service deployment halfway through. This also keeps a
+# newer run from racing an older package into the shared Test environment.
+concurrency:
+  group: zaplie-test-deployment
+  cancel-in-progress: false
+
+permissions:
+  actions: read
+  contents: read
+
+env:
+  NODE_VERSION: '24.x'
+  PORTAL_APP_NAME: zaplie-test-webapp
+  BOT_APP_NAME: zaplie-test-bot-uk
+  AZURE_CORE_OUTPUT: none
+
 jobs:
-  build:
-    runs-on: windows-latest
-    environment: Test
-    permissions:
-      contents: read #This is required for actions/checkout
-
-    steps:
-      - uses: actions/checkout@v7
-
-      # Scanning the sources instead of the bundle keeps this guard effective
-      # regardless of whether the build ships sourcemaps.
-      - name: Fail if the portal sources read LNbits admin credentials
-        shell: bash
-        run: |
-          test -d tabs/src || { echo '::error::tabs/src not found, cannot verify the portal sources'; exit 1; }
-          if grep -REl 'process\.env\.REACT_APP_LNBITS_(ADMINKEY|PASSWORD)' tabs/src; then
-            echo '::error::Portal sources read LNbits admin credentials in browser code. Move privileged LNbits calls behind the backend.'
-            exit 1
-          fi
-
-      - name: Set up Node.js version
-        uses: actions/setup-node@v7
-        with:
-          node-version: '24.x'
-
-      - name: npm install, build, and test
-        env:
-          CI: false
-        run: |
-          cd tabs
-          npm install
-          npm run build --if-present
-      
-      # CRA inlines REACT_APP_* values into public JavaScript, so any LNbits
-      # admin credential reference in the built bundle is a secret leak. The
-      # variable names survive in CRA output even without sourcemaps, so scan
-      # for the names as well as the bare credential identifiers. A missing
-      # build directory is a failure, not a pass: grep would exit 2 there.
-      - name: Fail if the built bundle references LNbits admin credentials
-        shell: bash
-        run: |
-          test -d tabs/build || { echo '::error::No built bundle found to scan'; exit 1; }
-          if grep -RlE 'REACT_APP_LNBITS_(ADMINKEY|PASSWORD)|LNBITS_ADMINKEY|LNBITS_PASSWORD' tabs/build; then
-            echo '::error::LNbits admin credential references found in the built portal bundle. Move privileged LNbits calls behind the backend before deploying.'
-            exit 1
-          fi
-
-      # Mutable backend state lives next to the code today; never ship local
-      # JSON stores in the artifact or a deploy would overwrite live app data.
-      - name: Exclude mutable backend state from the artifact
-        shell: bash
-        run: |
-          rm -f \
-            tabs/backend/data.json \
-            tabs/backend/identities.json \
-            tabs/backend/connections.json \
-            tabs/backend/pending-rewards.json \
-            tabs/backend/secrets.json \
-            tabs/backend/webhook-keys.json \
-            tabs/backend/github-app-credentials.json \
-            tabs/backend/lnbits-zap-idempotency.json
-
-      - name: Upload artifact for deployment job
-        uses: actions/upload-artifact@v7
-        with:
-          name: node-app
-          path: tabs
-
-  deploy:
+  validated-ref:
+    name: Resolve a revision that passed CI
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
-    needs: build
+    timeout-minutes: 5
+    outputs:
+      sha: ${{ steps.revision.outputs.sha }}
+    steps:
+      - name: Require successful quality checks for the exact revision
+        id: revision
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WORKFLOW_RUN_SHA: ${{ github.event.workflow_run.head_sha }}
+          DISPATCH_SHA: ${{ github.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          sha="${WORKFLOW_RUN_SHA:-$DISPATCH_SHA}"
+          successful_runs=$(gh api --method GET \
+            "repos/${GITHUB_REPOSITORY}/actions/workflows/ci-quality-checks.yml/runs" \
+            -f head_sha="$sha" \
+            -f status=completed \
+            -f per_page=100 \
+            --jq '[.workflow_runs[] | select(.conclusion == "success")] | length')
+          if [[ "$successful_runs" -lt 1 ]]; then
+            echo "::error::Revision ${sha} has no successful Code Quality Checks run."
+            exit 1
+          fi
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "Deploying the exact CI-validated revision ${sha}." >> "$GITHUB_STEP_SUMMARY"
+
+  portal-policy:
+    name: Check portal deployment prerequisites
+    needs: validated-ref
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      allowed: ${{ steps.policy.outputs.allowed }}
+    steps:
+      - name: Check out the validated revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ needs.validated-ref.outputs.sha }}
+          persist-credentials: false
+
+      # CRA substitutes every REACT_APP_* value into public JavaScript. The
+      # portal must not be deployed until privileged LNbits calls have moved to
+      # the Express backend. Mutable JSON must also move outside wwwroot before
+      # automated code deployments can safely preserve it.
+      - name: Enforce browser-secret and mutable-state boundary
+        id: policy
+        shell: bash
+        run: |
+          set -euo pipefail
+          privileged_refs=$(grep -RIlE \
+            'REACT_APP_LNBITS_(ADMINKEY|PASSWORD|USERNAME|INKEY)' \
+            tabs/src || true)
+          mutable_refs=$(grep -RIlE \
+            --exclude='*.test.js' \
+            "path\.join\(__dirname, '(data|identities|connections|pending-rewards|webhook-keys|github-app-credentials|secrets)\.json'\)" \
+            tabs/backend || true)
+
+          if [[ -n "$privileged_refs" || -n "$mutable_refs" ]]; then
+            echo 'allowed=false' >> "$GITHUB_OUTPUT"
+            {
+              echo '## Portal deployment blocked'
+              echo
+              if [[ -n "$privileged_refs" ]]; then
+                echo 'Privileged LNbits configuration is still referenced by browser code:'
+                echo '```text'
+                echo "$privileged_refs"
+                echo '```'
+                echo 'Move these operations behind the Express backend first.'
+                echo
+              fi
+              if [[ -n "$mutable_refs" ]]; then
+                echo 'Mutable backend JSON is still stored inside the deployment tree:'
+                echo '```text'
+                echo "$mutable_refs"
+                echo '```'
+                echo 'Move it to durable storage outside `/home/site/wwwroot` first.'
+              fi
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo '::warning::Portal deploy skipped: security prerequisites are not complete.'
+          else
+            echo 'allowed=true' >> "$GITHUB_OUTPUT"
+            echo 'Portal security prerequisites passed.' >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+  portal:
+    name: Deploy portal
+    needs:
+      - validated-ref
+      - portal-policy
+    if: needs.portal-policy.outputs.allowed == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
     environment:
       name: Test
-      url: ${{ steps.deploy-to-webapp.outputs.webapp-url }}
+      url: https://zaplie-test-webapp.azurewebsites.net
     permissions:
-      id-token: write #This is required for requesting the JWT
-      contents: read #This is required for actions/checkout
-
+      contents: read
+      id-token: write
     steps:
-      - name: Download artifact from build job
-        uses: actions/download-artifact@v8
+      - name: Check out the validated revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          name: node-app
-      
-      - name: Login to Azure
-        uses: azure/login@v2
+          ref: ${{ needs.validated-ref.outputs.sha }}
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: tabs/package-lock.json
+
+      - name: Validate public build configuration
+        working-directory: tabs
+        env:
+          REACT_APP_LNBITS_NODE_URL: ${{ vars.REACT_APP_LNBITS_NODE_URL }}
+          REACT_APP_LNBITS_STORE_ID: ${{ vars.REACT_APP_LNBITS_STORE_ID }}
+          REACT_APP_LNBITS_STORE_OWNER_EMAIL: ${{ vars.REACT_APP_LNBITS_STORE_OWNER_EMAIL }}
+          REACT_APP_LNBITS_POINTS_LABEL: ${{ vars.REACT_APP_LNBITS_POINTS_LABEL }}
+          REACT_APP_TENANT_ID: ${{ vars.REACT_APP_TENANT_ID }}
+          REACT_APP_AAD_CLIENT_ID: ${{ vars.REACT_APP_AAD_CLIENT_ID }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=0
+          for name in \
+            REACT_APP_LNBITS_NODE_URL \
+            REACT_APP_LNBITS_STORE_ID \
+            REACT_APP_LNBITS_STORE_OWNER_EMAIL \
+            REACT_APP_LNBITS_POINTS_LABEL \
+            REACT_APP_TENANT_ID \
+            REACT_APP_AAD_CLIENT_ID; do
+            if [[ -z "${!name:-}" ]]; then
+              echo "::error::Missing Test environment variable: ${name}"
+              missing=1
+            fi
+          done
+          exit "$missing"
+
+      - name: Build the portal
+        working-directory: tabs
+        env:
+          CI: true
+          GENERATE_SOURCEMAP: false
+          REACT_APP_LNBITS_NODE_URL: ${{ vars.REACT_APP_LNBITS_NODE_URL }}
+          REACT_APP_LNBITS_STORE_ID: ${{ vars.REACT_APP_LNBITS_STORE_ID }}
+          REACT_APP_LNBITS_STORE_OWNER_EMAIL: ${{ vars.REACT_APP_LNBITS_STORE_OWNER_EMAIL }}
+          REACT_APP_LNBITS_POINTS_LABEL: ${{ vars.REACT_APP_LNBITS_POINTS_LABEL }}
+          REACT_APP_TENANT_ID: ${{ vars.REACT_APP_TENANT_ID }}
+          REACT_APP_AAD_CLIENT_ID: ${{ vars.REACT_APP_AAD_CLIENT_ID }}
+        run: |
+          npm ci
+          npm run build
+          npm ci --omit=dev
+
+      - name: Stage a self-contained Linux artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir portal-artifact
+          cp -R tabs/build tabs/backend tabs/node_modules \
+            tabs/package.json tabs/package-lock.json portal-artifact/
+          rm -f portal-artifact/backend/.env*
+          rm -f portal-artifact/backend/*.test.js
+          rm -f \
+            portal-artifact/backend/data.json \
+            portal-artifact/backend/identities.json \
+            portal-artifact/backend/connections.json \
+            portal-artifact/backend/pending-rewards.json \
+            portal-artifact/backend/webhook-keys.json \
+            portal-artifact/backend/github-app-credentials.json \
+            portal-artifact/backend/secrets.json \
+            portal-artifact/backend/lnbits-zap-idempotency.json
+
+          test -f portal-artifact/build/index.html
+          test -f portal-artifact/backend/server.js
+          test -f portal-artifact/node_modules/express/package.json
+          if ! grep -REq "(app|server)\.get\(['\"]/healthz['\"]" portal-artifact/backend; then
+            echo '::error::Portal artifact does not implement GET /healthz.'
+            exit 1
+          fi
+          if find portal-artifact -name '.env*' -print -quit | grep -q .; then
+            echo '::error::An environment file entered the portal artifact.'
+            exit 1
+          fi
+          if find portal-artifact/build -type f -name '*.map' -print -quit | grep -q .; then
+            echo '::error::Source maps entered the portal artifact.'
+            exit 1
+          fi
+          if find portal-artifact/backend -type f \( \
+            -name 'data.json' -o \
+            -name 'identities.json' -o \
+            -name 'connections.json' -o \
+            -name 'pending-rewards.json' -o \
+            -name 'webhook-keys.json' -o \
+            -name 'github-app-credentials.json' -o \
+            -name 'secrets.json' -o \
+            -name 'lnbits-zap-idempotency.json' \
+          \) -print -quit | grep -q .; then
+            echo '::error::Mutable backend state entered the portal artifact.'
+            exit 1
+          fi
+          node -e "for (const dep of ['body-parser','cors','express','express-rate-limit','jose']) require('./portal-artifact/node_modules/' + dep)"
+
+      - name: Log in to Azure with OIDC
+        uses: azure/login@d54469830ea7d513b7371e02a077c3ee5cb7b112 # v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-      - name: 'Ensure Slot Exists'
-        run: |
-          if [[ -n "${{ github.event.pull_request.number }}" ]]; then
-                SLOT_NAME="pr-${{ github.event.pull_request.number }}"
-              else
-                SLOT_NAME="testing"
-              fi
-          RESOURCE_GROUP="rg-zaplie-dev"
-          APP_NAME="zaplie-dev"
-          echo "Using slot: $SLOT_NAME"
-    
-          # Check if the slot exists
-          SLOT_EXISTS=$(az webapp deployment slot list --resource-group $RESOURCE_GROUP --name $APP_NAME --query "[?name=='$SLOT_NAME']" -o tsv)
-    
-          # If the slot doesn't exist, create it
-          if [[ -z "$SLOT_EXISTS" ]]; then
-            echo "Slot $SLOT_NAME does not exist. Creating..."
-            az webapp deployment slot create --resource-group $RESOURCE_GROUP --name $APP_NAME --slot $SLOT_NAME
-          else
-            echo "Slot $SLOT_NAME already exists."
-          fi
-        shell: bash
 
-      - name: 'Deploy to Azure Web App'
-        uses: azure/webapps-deploy@v3
-        id: deploy-to-webapp
+      # Mutable backend state lives under ZAPLIE_DATA_DIR outside wwwroot, so
+      # a clean deployment can remove stale code without deleting app data.
+      - name: Deploy the prebuilt portal
+        uses: azure/webapps-deploy@b686016b4de8820a23519503685d8d03fbfa03a6 # v3
         with:
-          app-name: 'zaplie-dev'
-          slot-name: ${{ github.event.pull_request.number && format('pr-{0}', github.event.pull_request.number) || 'testing' }}
-          package: .
+          app-name: ${{ env.PORTAL_APP_NAME }}
+          package: portal-artifact
+          clean: true
+          restart: true
 
-          
-          
+      - name: Smoke test portal health
+        shell: bash
+        run: bash scripts/smoke-health.sh "${PORTAL_APP_NAME}" Portal
+
+  bot:
+    name: Deploy bot
+    needs: validated-ref
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    environment:
+      name: Test
+      url: https://zaplie-test-bot-uk.azurewebsites.net/healthz
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Check out the validated revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ needs.validated-ref.outputs.sha }}
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Build the bot
+        run: |
+          npm ci
+          npm run build
+          npm ci --omit=dev
+
+      - name: Stage and validate a self-contained Linux artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir bot-artifact
+          cp -R lib node_modules package.json package-lock.json bot-artifact/
+          rm -rf bot-artifact/lib/public
+          cp -R public bot-artifact/lib/public
+          test -f bot-artifact/lib/src/index.js
+          test -f bot-artifact/lib/public/auth-end.html
+          if ! grep -Eq "(app|server)\.get\(['\"]/healthz['\"]" bot-artifact/lib/src/index.js; then
+            echo '::error::Bot artifact does not implement GET /healthz.'
+            exit 1
+          fi
+
+          # Importing the HTTP framework on the runner catches a package that
+          # cannot start on Node 24 before it replaces the running bot.
+          node -e "require('./bot-artifact/node_modules/express')"
+
+      - name: Log in to Azure with OIDC
+        uses: azure/login@d54469830ea7d513b7371e02a077c3ee5cb7b112 # v3
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Deploy the prebuilt bot
+        uses: azure/webapps-deploy@b686016b4de8820a23519503685d8d03fbfa03a6 # v3
+        with:
+          app-name: ${{ env.BOT_APP_NAME }}
+          package: bot-artifact
+          clean: true
+          restart: true
+
+      - name: Smoke test bot health
+        shell: bash
+        run: bash scripts/smoke-health.sh "${BOT_APP_NAME}" Bot

--- a/docs/DEPLOYMENT.adoc
+++ b/docs/DEPLOYMENT.adoc
@@ -16,15 +16,15 @@
 | `env/.env.dev` (tracked, non-secret values) + `teamsapp.yml`
 | Shared development deployment in Azure
 
-| test / prod (CI)
-| GitHub environments `Test` and `Prod`
-| GitHub Actions deploys the tabs app to App Service `zappie-dev` (resource group `rg-Zappie-dev`) slots
+| test / production (CI)
+| Protected GitHub environments `Test` and `Production`
+| GitHub Actions deploys prebuilt Linux artifacts to dedicated App Services; deployment slots are not used on the B1 Test plan
 |===
 
 == Prerequisites
 
-- Node.js 18 (App Service is pinned to `~18`; CI builds with Node 20 — see the
-  MSAL override note in README.md)
+- Node.js 24 (the version declared in both `package.json` files and used by CI
+  and the Linux App Services)
 - Teams Toolkit VS Code extension ≥ 5.0.0 or the TeamsFx CLI (`teamsapp`)
 - An M365 tenant with permission to upload custom Teams apps
 - An LNbits 0.12+ instance with the User Manager extension
@@ -77,34 +77,119 @@ Or press F5 in VS Code ("Debug in Teams (Edge/Chrome)"). The bot itself runs
 with `npm run dev` (nodemon + ts-node, inspector on 9239), reading
 `.localConfigs` via `npm run dev:teamsfx`.
 
-=== Web tabs (GitHub Actions)
+=== Test deployment (GitHub Actions)
 
-`.github/workflows/Azure_App_Service_zaplie-test.yml` and
-`Azure_App_Service_zaplie-prod.yml` trigger on push to `main` (and manually):
+`.github/workflows/Azure_App_Service_zaplie-test.yml` deploys both components:
 
-. Build job (windows-latest, Node 24): `cd tabs && npm install && npm run build`
-  (`CI: false`), scan the sources and the built bundle for LNbits admin
-  credentials, drop the mutable backend JSON stores, upload the `tabs` artifact
-. Deploy job (ubuntu-latest): `azure/webapps-deploy@v3`
+* portal -> `zaplie-test-webapp`
+* bot -> `zaplie-test-bot-uk`
 
-The two workflows authenticate differently today:
+The workflow runs on Ubuntu with Node 24 after `Code Quality Checks` succeeds
+on `main`, or by an explicit manual dispatch. A fixed concurrency group allows
+only one Test deployment at a time and does not cancel a deployment already in
+progress. Both artifacts are compiled on the runner, reduced to runtime
+dependencies and sent self-contained because Oryx/App Service build automation
+is disabled. Both apps must return HTTP 200 from `/healthz` after deployment.
 
-Test:: Deploys with federated OIDC — `azure/login` using the repository
-secrets `AZURE_CLIENT_ID`, `AZURE_TENANT_ID` and `AZURE_SUBSCRIPTION_ID`
-(`id-token: write`), then ensures a deployment slot exists (`pr-<number>` for
-pull requests, else `testing`) on app `zaplie-dev` before deploying to it.
-Prod:: Still deploys with a publish profile — the `AZURE_WEBAPP_PUBLISH_PROFILE`
-secret against app `zaplie-prod-webapp`, with no `azure/login` step. Migrating
-production onto the same federated OIDC credential is pending; until then the
-publish profile is a long-lived secret and must be re-downloaded whenever it is
-reset in Azure.
+The bot artifact imports Express under Node 24 before Azure login, so a package
+that cannot start on the runner never reaches the running App Service.
 
-Note: neither workflow has a bot job — CI deploys only the portal, and it
-deploys the whole portal: the React build *and* the Express backend under
-`tabs/backend`. The portal App Service must therefore use the startup command
-`node backend/server.js` (with `SCM_DO_BUILD_DURING_DEPLOYMENT=false`, since
-the artifact arrives prebuilt). The bot deploys separately via
-`teamsapp deploy`.
+Authentication uses GitHub OIDC. The protected `Test` environment must contain
+`AZURE_CLIENT_ID`, `AZURE_TENANT_ID` and `AZURE_SUBSCRIPTION_ID`; publish
+profiles are not used. Its federated credential must trust the `Test`
+environment subject. Restrict the environment's deployment branches to
+`main`; a manual dispatch still requires a successful `Code Quality Checks`
+run for the exact selected commit.
+
+The portal deploy is intentionally skipped until these prerequisites
+are satisfied:
+
+. All privileged LNbits operations have moved behind the Express backend. CRA
+  must not reference `REACT_APP_LNBITS_PASSWORD`,
+  `REACT_APP_LNBITS_ADMINKEY`, `REACT_APP_LNBITS_USERNAME` or
+  `REACT_APP_LNBITS_INKEY`; CRA embeds their values in public JavaScript.
+. Mutable JSON state has moved outside `/home/site/wwwroot` to durable storage.
+  Set `ZAPLIE_DATA_DIR=/home/data/zaplie` before the first clean deployment and
+  migrate any existing JSON there. Artifact staging excludes all eight mutable
+  JSON files, and clean deployment removes only stale code under `wwwroot`.
+  Keep `WEBSITE_RUN_FROM_PACKAGE` disabled until that operating mode has been
+  validated with the external data directory.
+. The portal and bot application changes that implement unauthenticated,
+  side-effect-free `GET /healthz` endpoints have been merged. Artifact staging
+  checks for each route before Azure login, so a missing health check cannot
+  overwrite a running app.
+
+Non-secret browser configuration is stored as GitHub `Test` environment
+variables: `REACT_APP_LNBITS_NODE_URL`, `REACT_APP_LNBITS_STORE_ID`,
+`REACT_APP_LNBITS_STORE_OWNER_EMAIL`, `REACT_APP_LNBITS_POINTS_LABEL`,
+`REACT_APP_TENANT_ID` and `REACT_APP_AAD_CLIENT_ID`. Server-side LNbits
+credentials belong only in App Service settings with the `LNBITS_` prefix.
+
+The public values currently stored as GitHub secrets cannot be read back. Set
+the corresponding environment variables interactively; `gh` reads each value
+without printing it:
+
+[source,powershell]
+----
+gh variable set REACT_APP_LNBITS_NODE_URL --env Test
+gh variable set REACT_APP_LNBITS_STORE_ID --env Test
+gh variable set REACT_APP_LNBITS_STORE_OWNER_EMAIL --env Test
+gh variable set REACT_APP_LNBITS_POINTS_LABEL --env Test
+gh variable set REACT_APP_TENANT_ID --env Test
+gh variable set REACT_APP_AAD_CLIENT_ID --env Test
+----
+
+Do not create variables for the LNbits username, password, admin key or invoice
+key. Those values remain server-side App Service settings and must be rotated
+after the browser migration.
+
+An Azure subscription Owner (or a principal with
+`Microsoft.Authorization/roleAssignments/write`) must grant the OIDC service
+principal Website Contributor on the Test resource group. The commands below
+resolve the known `0279863b...` application without echoing its identifiers:
+
+[source,powershell]
+----
+$oidcMatches = az ad sp list --all `
+  --query "[?starts_with(appId, '0279863b')].[id,appId]" `
+  --output json | ConvertFrom-Json
+if (@($oidcMatches).Count -ne 1) {
+  throw 'Expected exactly one OIDC service principal matching 0279863b...'
+}
+$subscriptionId = az account show --query id --output tsv
+$testScope = "/subscriptions/$subscriptionId/resourceGroups/ka-zaplie-test"
+az role assignment create `
+  --assignee-object-id $oidcMatches[0][0] `
+  --assignee-principal-type ServicePrincipal `
+  --role 'Website Contributor' `
+  --scope $testScope `
+  --output none
+----
+
+This workflow was manually disabled in the Actions UI on 17 August 2026 so the
+earlier version could not overwrite Test. Once the role above is granted,
+re-enable it:
+
+[source,powershell]
+----
+gh workflow enable Azure_App_Service_zaplie-test.yml
+----
+
+After the first successful OIDC deployment, remove the unused long-lived Test
+credentials (these commands remove secret records but never reveal values):
+
+[source,powershell]
+----
+gh secret delete AZURE_CLIENT_SECRET --env Test
+gh secret delete AZURE_CREDENTIALS --env Test
+gh secret delete ZAPLIE_TEST_BOT_PUBLISH_PROFILE --env Test
+gh secret delete ZAPLIE_TEST_WEBAPP_PUBLISH_PROFILE --env Test
+----
+
+`Azure_App_Service_zaplie-prod.yml` is unchanged and still deploys the portal
+to `zaplie-prod-webapp` from a publish profile on every push to `main`. It does
+not race this workflow because Test deploys the bot only, but production still
+needs its own protected OIDC promotion built on a revision that passed Test.
 
 === Azure Functions
 

--- a/scripts/smoke-health.sh
+++ b/scripts/smoke-health.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Poll an App Service /healthz endpoint until it returns 200 or attempts run out.
+# Usage: smoke-health.sh <app-name> <label>
+set -u
+app_name="$1"
+label="$2"
+for attempt in $(seq 1 12); do
+  code=$(curl -sS -o /dev/null -w '%{http_code}' \
+    --max-time 20 \
+    "https://${app_name}.azurewebsites.net/healthz" || true)
+  echo "attempt ${attempt}: HTTP ${code:-000}"
+  [[ "$code" == '200' ]] && exit 0
+  sleep 15
+done
+echo "::error::${label} /healthz never returned HTTP 200."
+exit 1


### PR DESCRIPTION
Retargeted to `main` (was `release/1.1.0`) and rebased. PRs #312 and #313 landed on `main` in the meantime and already cover a large part of what this PR originally did, so everything they cover has been dropped here. What is left is one commit.

## Why

The Test workflow on `main` deploys to App Service `zaplie-dev` in resource group `rg-zaplie-dev` and creates `pr-<number>` deployment slots. None of those exist, so the workflow cannot succeed. It also builds and deploys the portal only, so the bot has never been deployed by CI at all, and it deploys whatever is on `main` at that moment rather than a revision that passed CI.

## What changed

Single commit, three files.

`.github/workflows/Azure_App_Service_zaplie-test.yml` is replaced:

- runs on `workflow_run` after `Code Quality Checks` completes on `main`, plus manual dispatch, and resolves the exact SHA that has a successful quality run before doing anything else
- adds a bot deploy job targeting `zaplie-test-bot-uk` and points the portal job at `zaplie-test-webapp`, replacing the nonexistent `zaplie-dev` slot logic
- builds both artifacts on the runner, prunes to runtime dependencies and ships them self-contained, since Oryx build automation is off on these apps
- asserts before Azure login that each artifact has its entrypoint, a `GET /healthz` route, no `.env` file, no source map and none of the eight mutable JSON stores
- OIDC login, pinned action SHAs, a non-cancelling concurrency group and bounded timeouts on every job
- deploys with `clean: true` and `restart: true`, which is safe now that `ZAPLIE_DATA_DIR` keeps mutable state outside `wwwroot`
- polls both `/healthz` endpoints after deploy and fails the job if either never returns 200

`scripts/smoke-health.sh` is the shared health poller, used by both deploy jobs.

`docs/DEPLOYMENT.adoc` documents the workflow, the Azure role grant, and the Test environment variables. It also corrects two stale facts: the environments table still named `zappie-dev` and `rg-Zappie-dev`, and Prerequisites still said Node 18.

The portal deploy job is gated and will skip on `main` today: `tabs/src` still reads `REACT_APP_LNBITS_USERNAME` and `REACT_APP_LNBITS_INKEY`, and `tabs/backend` still resolves its JSON stores under `__dirname`. The policy job reports the exact files in the run summary instead of shipping a public bundle with privileged config in it. Only the bot deploys until that work lands.

## Dropped as already merged

- the artifact secret and mutable-state guards on both workflows, merged as #312 and #313
- the whole `Azure_App_Service_zaplie-prod.yml` rewrite. This PR no longer touches production. #312 and #313 already added the guards there, and disabling production deployment is a separate call for you to make, not part of hardening Test.
- the Node 24 Express notes, merged as #269

## Risk

Low as merged. The workflow is currently disabled in the Actions UI and cannot run until it is enabled and the Website Contributor role is granted, both documented in `docs/DEPLOYMENT.adoc`. Nothing in production changes.

## Test plan

- `docs/DEPLOYMENT.adoc` renders and the Test deployment section matches the workflow
- grant Website Contributor on `ka-zaplie-test` to the Test OIDC service principal, using the command in the deployment doc
- `gh workflow enable Azure_App_Service_zaplie-test.yml`
- dispatch the workflow for a SHA that has a successful `Code Quality Checks` run, and confirm it refuses a SHA that does not
- confirm the portal job is skipped with the blockers listed in the run summary, and that the bot job deploys
- confirm `https://zaplie-test-bot-uk.azurewebsites.net/healthz` returns 200 and that `/home/data/zaplie` is unchanged after the deploy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR replaces the Test Azure App Service workflow with OIDC-authenticated, pinned-action deployments for the bot. It builds and validates self-contained Node 24 artefacts, deploys the bot, gates the portal deployment on known blockers, and checks `/healthz`. It also adds shared health polling and updates the deployment guide.

## Worth a look

- **Blocker:** Review the portal deployment gate in `.github/workflows/Azure_App_Service_zaplie-test.yml`. It intentionally skips deployment when privileged `REACT_APP_LNBITS_*` values or mutable JSON state are present.
- **Risk:** Confirm that the exact `Code Quality Checks` revision validation and workflow-run trigger cannot deploy an unintended commit.
- **Security:** Verify the Azure role assignments and OIDC subject restrictions in `.github/workflows/Azure_App_Service_zaplie-test.yml`.
- **Cleanup:** Confirm that `scripts/smoke-health.sh` treats only HTTP 200 as healthy and that its retry window matches App Service startup time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->