### PR TITLE
fix: read team wallets via the LNbits users API and rank by zaps sent

### DIFF
--- a/src/commands/agentTools.test.ts
+++ b/src/commands/agentTools.test.ts
@@ -4,11 +4,7 @@
 // agentTools itself.
 
 import { createReadOnlyTools } from './agentTools';
-import {
-  getUserWallets,
-  getWallets,
-  getUsers,
-} from '../services/lnbitsService';
+import { getUserWallets, getUsers } from '../services/lnbitsService';
 import { getRecentZaps } from '../services/zapHistoryService';
 import { getRecentMeetings, getRelevantPeople } from '../services/graphService';
 import {
@@ -28,7 +24,6 @@ jest.mock('../services/graphService');
 const mockGetUserWallets = getUserWallets as jest.MockedFunction<
   typeof getUserWallets
 >;
-const mockGetWallets = getWallets as jest.MockedFunction<typeof getWallets>;
 const mockGetUsers = getUsers as jest.MockedFunction<typeof getUsers>;
 const mockGetRecentZaps = getRecentZaps as jest.MockedFunction<
   typeof getRecentZaps
@@ -74,9 +69,10 @@ describe('agentTools', () => {
   });
 
   describe('get_my_balance', () => {
-    test('returns wallet balances in sats for the current user', async () => {
+    test('returns only Allowance and Private balances in sats', async () => {
       mockGetUserWallets.mockResolvedValue([
         wallet({ name: 'Allowance', balance_msat: 900000 }),
+        wallet({ name: 'LNbits wallet', balance_msat: 3000000 }),
         wallet({ name: 'Private', balance_msat: 50000 }),
       ]);
 
@@ -93,25 +89,36 @@ describe('agentTools', () => {
   });
 
   describe('get_leaderboard', () => {
-    test('ranks teammates by Private wallet balance, descending', async () => {
-      mockGetWallets.mockResolvedValue([
-        wallet({
-          id: 'w-bob',
-          name: 'Private',
-          user: 'user-bob',
-          balance_msat: 500000,
-        }),
-        wallet({
-          id: 'w-alice',
-          name: 'Private',
-          user: 'user-alice',
-          balance_msat: 1500000,
-        }),
-      ]);
+    test('enumerates every user and ranks their Private wallets', async () => {
       mockGetUsers.mockResolvedValue([
         { ...currentUser, id: 'user-bob', displayName: 'Bob' },
         { ...currentUser, id: 'user-alice', displayName: 'Alice' },
+        { ...currentUser, id: 'user-charlie', displayName: 'Charlie' },
       ]);
+      mockGetUserWallets.mockImplementation(async (_adminKey, userId) => {
+        if (userId === 'user-bob') {
+          return [
+            wallet({
+              id: 'w-bob',
+              name: 'Private',
+              user: userId,
+              balance_msat: 500000,
+            }),
+          ];
+        }
+        if (userId === 'user-alice') {
+          return [
+            wallet({ name: 'Allowance', user: userId }),
+            wallet({
+              id: 'w-alice',
+              name: 'Private',
+              user: userId,
+              balance_msat: 1500000,
+            }),
+          ];
+        }
+        return [wallet({ name: 'LNbits wallet', user: userId })];
+      });
 
       const tool = createReadOnlyTools().find(
         t => t.name === 'get_leaderboard',
@@ -122,6 +129,9 @@ describe('agentTools', () => {
         { displayName: 'Alice', balanceSats: 1500 },
         { displayName: 'Bob', balanceSats: 500 },
       ]);
+      expect(mockGetUserWallets.mock.calls.map(([, userId]) => userId)).toEqual(
+        ['user-bob', 'user-alice', 'user-charlie'],
+      );
     });
   });
 

--- a/src/commands/agentTools.test.ts
+++ b/src/commands/agentTools.test.ts
@@ -4,8 +4,11 @@
 // agentTools itself.
 
 import { createReadOnlyTools } from './agentTools';
-import { getUserWallets, getUsers } from '../services/lnbitsService';
-import { getRecentZaps } from '../services/zapHistoryService';
+import { getUserWallets } from '../services/lnbitsService';
+import {
+  getRecentZaps,
+  getZapLeaderboard,
+} from '../services/zapHistoryService';
 import { getRecentMeetings, getRelevantPeople } from '../services/graphService';
 import {
   afterEach,
@@ -24,9 +27,11 @@ jest.mock('../services/graphService');
 const mockGetUserWallets = getUserWallets as jest.MockedFunction<
   typeof getUserWallets
 >;
-const mockGetUsers = getUsers as jest.MockedFunction<typeof getUsers>;
 const mockGetRecentZaps = getRecentZaps as jest.MockedFunction<
   typeof getRecentZaps
+>;
+const mockGetZapLeaderboard = getZapLeaderboard as jest.MockedFunction<
+  typeof getZapLeaderboard
 >;
 const mockGetRecentMeetings = getRecentMeetings as jest.MockedFunction<
   typeof getRecentMeetings
@@ -89,36 +94,17 @@ describe('agentTools', () => {
   });
 
   describe('get_leaderboard', () => {
-    test('enumerates every user and ranks their Private wallets', async () => {
-      mockGetUsers.mockResolvedValue([
-        { ...currentUser, id: 'user-bob', displayName: 'Bob' },
-        { ...currentUser, id: 'user-alice', displayName: 'Alice' },
-        { ...currentUser, id: 'user-charlie', displayName: 'Charlie' },
+    test('reports sats zapped out of Allowance wallets, never wallet balances', async () => {
+      mockGetZapLeaderboard.mockResolvedValue([
+        {
+          user: { ...currentUser, id: 'user-alice', displayName: 'Alice' },
+          zappedSats: 1500,
+        },
+        {
+          user: { ...currentUser, id: 'user-bob', displayName: 'Bob' },
+          zappedSats: 500,
+        },
       ]);
-      mockGetUserWallets.mockImplementation(async (_adminKey, userId) => {
-        if (userId === 'user-bob') {
-          return [
-            wallet({
-              id: 'w-bob',
-              name: 'Private',
-              user: userId,
-              balance_msat: 500000,
-            }),
-          ];
-        }
-        if (userId === 'user-alice') {
-          return [
-            wallet({ name: 'Allowance', user: userId }),
-            wallet({
-              id: 'w-alice',
-              name: 'Private',
-              user: userId,
-              balance_msat: 1500000,
-            }),
-          ];
-        }
-        return [wallet({ name: 'LNbits wallet', user: userId })];
-      });
 
       const tool = createReadOnlyTools().find(
         t => t.name === 'get_leaderboard',
@@ -126,12 +112,10 @@ describe('agentTools', () => {
       const result: any = await tool.handler({}, makeTurnContext(currentUser));
 
       expect(result.leaderboard).toEqual([
-        { displayName: 'Alice', balanceSats: 1500 },
-        { displayName: 'Bob', balanceSats: 500 },
+        { displayName: 'Alice', zappedSats: 1500 },
+        { displayName: 'Bob', zappedSats: 500 },
       ]);
-      expect(mockGetUserWallets.mock.calls.map(([, userId]) => userId)).toEqual(
-        ['user-bob', 'user-alice', 'user-charlie'],
-      );
+      expect(mockGetUserWallets).not.toHaveBeenCalled();
     });
   });
 

--- a/src/commands/agentTools.ts
+++ b/src/commands/agentTools.ts
@@ -5,11 +5,7 @@
 
 import { TurnContext } from 'botbuilder';
 import { ToolDefinition } from '../services/foundryAgentService';
-import {
-  getUserWallets,
-  getWallets,
-  getUsers,
-} from '../services/lnbitsService';
+import { getUserWallets, getUsers } from '../services/lnbitsService';
 import { getRecentZaps } from '../services/zapHistoryService';
 import { getRecentMeetings, getRelevantPeople } from '../services/graphService';
 import {
@@ -19,8 +15,13 @@ import {
 
 const adminKey = process.env.LNBITS_ADMINKEY as string;
 const rewardLabel = process.env.LNBITS_POINTS_LABEL as string;
+const ALLOWANCE_WALLET_NAME = 'Allowance';
+const PRIVATE_WALLET_NAME = 'Private';
 
 const toSats = (balanceMsat: number): number => Math.floor(balanceMsat / 1000);
+
+const isBalanceWallet = (wallet: Wallet): boolean =>
+  wallet.name === ALLOWANCE_WALLET_NAME || wallet.name === PRIVATE_WALLET_NAME;
 
 const DAYS_PARAMETER = {
   type: 'number',
@@ -41,7 +42,7 @@ const getMyBalanceTool: ToolDefinition = {
     const wallets = await getUserWallets(adminKey, user.id);
     return {
       rewardLabel,
-      wallets: wallets.map(wallet => ({
+      wallets: wallets.filter(isBalanceWallet).map(wallet => ({
         name: wallet.name,
         balanceSats: toSats(wallet.balance_msat),
       })),
@@ -55,19 +56,28 @@ const getLeaderboardTool: ToolDefinition = {
     "Get the team leaderboard, ranked by each teammate's Private wallet balance.",
   parameters: { type: 'object', properties: {}, required: [] },
   handler: async () => {
-    const [privateWallets, users] = await Promise.all([
-      getWallets(adminKey, 'Private'),
-      getUsers(adminKey, null),
-    ]);
-    const displayNameByUserId = new Map(
-      users.map(user => [user.id, user.displayName]),
+    const users = await getUsers(adminKey, null);
+    const walletsByUser = await Promise.all(
+      users.map(async user => ({
+        user,
+        wallets: await getUserWallets(adminKey, user.id),
+      })),
     );
-    const leaderboard = privateWallets
-      .map(wallet => ({
-        displayName: displayNameByUserId.get(wallet.user) ?? 'Unknown',
-        balanceSats: toSats(wallet.balance_msat),
-      }))
-      .sort((a, b) => b.balanceSats - a.balanceSats);
+
+    const leaderboard: { displayName: string; balanceSats: number }[] = [];
+    for (const { user, wallets } of walletsByUser) {
+      const privateWallet = wallets.find(
+        wallet => wallet.name === PRIVATE_WALLET_NAME,
+      );
+      if (privateWallet) {
+        leaderboard.push({
+          displayName: user.displayName,
+          balanceSats: toSats(privateWallet.balance_msat),
+        });
+      }
+    }
+
+    leaderboard.sort((a, b) => b.balanceSats - a.balanceSats);
     return { rewardLabel, leaderboard };
   },
 };

--- a/src/commands/agentTools.ts
+++ b/src/commands/agentTools.ts
@@ -5,8 +5,11 @@
 
 import { TurnContext } from 'botbuilder';
 import { ToolDefinition } from '../services/foundryAgentService';
-import { getUserWallets, getUsers } from '../services/lnbitsService';
-import { getRecentZaps } from '../services/zapHistoryService';
+import { getUserWallets } from '../services/lnbitsService';
+import {
+  getRecentZaps,
+  getZapLeaderboard,
+} from '../services/zapHistoryService';
 import { getRecentMeetings, getRelevantPeople } from '../services/graphService';
 import {
   CONNECT_CALENDAR_COMMAND,
@@ -53,32 +56,18 @@ const getMyBalanceTool: ToolDefinition = {
 const getLeaderboardTool: ToolDefinition = {
   name: 'get_leaderboard',
   description:
-    "Get the team leaderboard, ranked by each teammate's Private wallet balance.",
+    'Get the team leaderboard, ranked by the sats each teammate has zapped to others ' +
+    'out of their Allowance wallet. Private wallet balances are never ranked.',
   parameters: { type: 'object', properties: {}, required: [] },
   handler: async () => {
-    const users = await getUsers(adminKey, null);
-    const walletsByUser = await Promise.all(
-      users.map(async user => ({
-        user,
-        wallets: await getUserWallets(adminKey, user.id),
+    const entries = await getZapLeaderboard();
+    return {
+      rewardLabel,
+      leaderboard: entries.map(entry => ({
+        displayName: entry.user.displayName,
+        zappedSats: entry.zappedSats,
       })),
-    );
-
-    const leaderboard: { displayName: string; balanceSats: number }[] = [];
-    for (const { user, wallets } of walletsByUser) {
-      const privateWallet = wallets.find(
-        wallet => wallet.name === PRIVATE_WALLET_NAME,
-      );
-      if (privateWallet) {
-        leaderboard.push({
-          displayName: user.displayName,
-          balanceSats: toSats(privateWallet.balance_msat),
-        });
-      }
-    }
-
-    leaderboard.sort((a, b) => b.balanceSats - a.balanceSats);
-    return { rewardLabel, leaderboard };
+    };
   },
 };
 

--- a/src/services/zapHistoryService.test.ts
+++ b/src/services/zapHistoryService.test.ts
@@ -4,7 +4,7 @@
 // zapHistoryService itself — the matching/filtering logic being tested here
 // lives entirely in zapHistoryService.
 
-import { getRecentZaps } from './zapHistoryService';
+import { getRecentZaps, getZapLeaderboard } from './zapHistoryService';
 import { getUsers, getUserWallets, getPayments } from './lnbitsService';
 import { expect, describe, test, beforeEach, jest } from '@jest/globals';
 
@@ -358,5 +358,141 @@ describe('zapHistoryService', () => {
     const result = await getRecentZaps();
 
     expect(result).toEqual([]);
+  });
+});
+
+describe('getZapLeaderboard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    for (const key of Object.keys(walletsByInkey)) {
+      delete walletsByInkey[key];
+    }
+    setupUsersAndWallets();
+  });
+
+  test('sums every zap a teammate sent out of their Allowance wallet, highest first', async () => {
+    walletsByInkey[aliceAllowance.inkey] = [
+      tx({
+        checking_id: 'a1',
+        amount: -100000,
+        time: 1750000000,
+        wallet_id: aliceAllowance.id,
+      }),
+      tx({
+        checking_id: 'a2',
+        amount: -20000,
+        time: 1750000001,
+        wallet_id: aliceAllowance.id,
+      }),
+    ];
+    walletsByInkey[bobAllowance.inkey] = [
+      tx({
+        checking_id: 'b1',
+        amount: -50000,
+        time: 1750000002,
+        wallet_id: bobAllowance.id,
+      }),
+    ];
+    walletsByInkey[bobPrivate.inkey] = [
+      tx({
+        checking_id: 'internal_a1',
+        amount: 100000,
+        time: 1750000000,
+        wallet_id: bobPrivate.id,
+      }),
+      tx({
+        checking_id: 'internal_a2',
+        amount: 20000,
+        time: 1750000001,
+        wallet_id: bobPrivate.id,
+      }),
+    ];
+    walletsByInkey[alicePrivate.inkey] = [
+      tx({
+        checking_id: 'internal_b1',
+        amount: 50000,
+        time: 1750000002,
+        wallet_id: alicePrivate.id,
+      }),
+    ];
+
+    const result = await getZapLeaderboard();
+
+    expect(
+      result.map(entry => [entry.user.displayName, entry.zappedSats]),
+    ).toEqual([
+      ['Alice', 120],
+      ['Bob', 50],
+    ]);
+  });
+
+  test('ignores sats received into a Private wallet', async () => {
+    // Bob's Private wallet is his own money: a payment in from anywhere other
+    // than a teammate's Allowance wallet must not put him on the leaderboard.
+    walletsByInkey[bobPrivate.inkey] = [
+      tx({
+        checking_id: 'coffee-money',
+        amount: 900000,
+        memo: 'Sold a coffee',
+        time: 1750000000,
+        wallet_id: bobPrivate.id,
+      }),
+    ];
+    walletsByInkey[aliceAllowance.inkey] = [
+      tx({
+        checking_id: 'a1',
+        amount: -10000,
+        time: 1750000001,
+        wallet_id: aliceAllowance.id,
+      }),
+    ];
+    walletsByInkey[alicePrivate.inkey] = [];
+    walletsByInkey[bobAllowance.inkey] = [];
+
+    const result = await getZapLeaderboard();
+
+    expect(result).toEqual([]);
+  });
+
+  test('breaks ties on display name so equal totals keep a stable order', async () => {
+    walletsByInkey[bobAllowance.inkey] = [
+      tx({
+        checking_id: 'b1',
+        amount: -10000,
+        time: 1750000002,
+        wallet_id: bobAllowance.id,
+      }),
+    ];
+    walletsByInkey[aliceAllowance.inkey] = [
+      tx({
+        checking_id: 'a1',
+        amount: -10000,
+        time: 1750000001,
+        wallet_id: aliceAllowance.id,
+      }),
+    ];
+    walletsByInkey[alicePrivate.inkey] = [
+      tx({
+        checking_id: 'internal_b1',
+        amount: 10000,
+        time: 1750000002,
+        wallet_id: alicePrivate.id,
+      }),
+    ];
+    walletsByInkey[bobPrivate.inkey] = [
+      tx({
+        checking_id: 'internal_a1',
+        amount: 10000,
+        time: 1750000001,
+        wallet_id: bobPrivate.id,
+      }),
+    ];
+
+    const result = await getZapLeaderboard();
+
+    expect(result.map(entry => entry.user.displayName)).toEqual([
+      'Alice',
+      'Bob',
+    ]);
   });
 });

--- a/src/services/zapHistoryService.ts
+++ b/src/services/zapHistoryService.ts
@@ -184,3 +184,36 @@ export async function getRecentZaps(
 
   return activity.slice(0, limit);
 }
+
+export interface ZapLeaderboardEntry {
+  user: User;
+  zappedSats: number;
+}
+
+// Ranks recognition given, not money held: a Private wallet is the owner's own
+// balance (and may one day be an external wallet we cannot read), so only zaps
+// sent out of Allowance wallets count. Matches tabs/src/components/Leaderboard.tsx.
+export async function getZapLeaderboard(): Promise<ZapLeaderboardEntry[]> {
+  const zaps = await getRecentZaps({ limit: Number.MAX_SAFE_INTEGER });
+
+  const totalsByUserId = new Map<string, ZapLeaderboardEntry>();
+  for (const zap of zaps) {
+    // A sending wallet that resolves to no user cannot be ranked.
+    if (!zap.from) continue;
+    const entry = totalsByUserId.get(zap.from.id);
+    if (entry) {
+      entry.zappedSats += zap.amountSats;
+    } else {
+      totalsByUserId.set(zap.from.id, {
+        user: zap.from,
+        zappedSats: zap.amountSats,
+      });
+    }
+  }
+
+  return Array.from(totalsByUserId.values()).sort(
+    (a, b) =>
+      b.zappedSats - a.zappedSats ||
+      a.user.displayName.localeCompare(b.user.displayName),
+  );
+}


### PR DESCRIPTION
Fixes #275

## Why

On LNbits 1.0+ `GET /api/v1/wallets` returns only the wallets belonging to the
authenticated account, not every wallet on the instance. `get_leaderboard`
called that endpoint and so silently dropped teammates whose Private wallet it
could not see, and `get_my_balance` returned legacy wallets that are not part of
the Zaplie model.

Ranking by Private wallet balance was also the wrong measure. A Private wallet
is the member's own money: they can spend from it or receive unrelated payments
into it, and in future a member may route incoming zaps to a wallet of their own
choosing (WoS, or a self-custodial wallet) that Zaplie cannot read at all. A
leaderboard built on it measures money held, not recognition given.

## What changed

- `get_my_balance` returns only the Allowance and Private wallets.
- `get_leaderboard` ranks by sats sent out of each member's Allowance wallet,
  the same measure the portal's `tabs/src/components/Leaderboard.tsx` uses. Its
  result field is `zappedSats`, no longer `balanceSats`.
- That measure now lives in one place: `getZapLeaderboard()` in
  `zapHistoryService`, reusing the existing zap-matching rule (outgoing
  Allowance payment, cross-referenced by `checking_id` to a credit in a Private
  wallet, "Weekly Allowance cleared" sweeps excluded).
- Team-wide reads go through the user-management API: `GET /users/api/v1/user`
  to enumerate accounts, then `GET /users/api/v1/user/{id}/wallet` per account,
  which the superuser token can read for everyone.

## Not in this PR

`src/commands/showLeaderboardCommand.ts` (the `show leaderboard` chat command)
still ranks by Private wallet balance and still calls `GET /api/v1/wallets`. It
is rewritten by #320 and also touched by #316, so changing it here would
conflict with two approved PRs. It should be moved onto `getZapLeaderboard()` in
a follow-up once #320 lands.

The leaderboard acceptance criterion in #275 ("selects one Private wallet per
user, and ranks the complete result") is superseded by the review on this PR.

## Risk

Low. All reads, no writes. Leaderboard numbers will differ from the previous
card because they now measure zaps given rather than sats held.

## Test plan for QA

- run `npx jest src/commands/agentTools.test.ts src/services/zapHistoryService.test.ts --runInBand`
- ask Zaplie for a balance and confirm only Allowance and Private appear
- ask Zaplie for the leaderboard and confirm the order and totals match the
  portal leaderboard for the same period
- send a zap, ask again, and confirm the sender moves up while the receiver does
  not
- confirm no sats move as a result of either question


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR restricts balance reads to Allowance and Private wallets. It enumerates team users through the user-management API and ranks members by `zappedSats` from internal Allowance-to-Private zap history. It centralises this logic in `getZapLeaderboard()` and adds focused tests.

## Worth a look

- **Design decision:** `getZapLeaderboard()` ranks outgoing Allowance zaps, not Private-wallet balances. Confirm this matches the portal measure.
- **Payment-path risk:** `zapHistoryService.ts` attributes internal transfers through `checking_id` and excludes `"Weekly Allowance cleared"` sweeps. External destinations remain uncounted.
- **Scalability:** Parallel wallet and payment reads have no concurrency limit or cache. This may affect larger teams.
- **Scope:** `show leaderboard` remains unchanged. A follow-up must reconcile it with the new ranking logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->