### PR TITLE
fix: build Teams tab manifests for tunneled debug

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -50,6 +50,17 @@
                             "endpoint": "BOT_ENDPOINT", // output tunnel endpoint as BOT_ENDPOINT
                             "domain": "BOT_DOMAIN" // output tunnel domain as BOT_DOMAIN
                         }
+                    },
+                    {
+                        // Chrome and Edge block Teams from framing localhost,
+                        // so local tabs use the same public tunnel as the bot.
+                        "portNumber": 3000,
+                        "protocol": "https",
+                        "access": "public",
+                        "writeToEnvironmentFile": {
+                            "endpoint": "TAB_ENDPOINT",
+                            "domain": "TAB_DOMAIN"
+                        }
                     }
                 ],
                 "env": "local"

--- a/aad.manifest.json
+++ b/aad.manifest.json
@@ -110,11 +110,11 @@
           "type": "Web"
         },
         {
-            "url": "https://localhost:3000",
+            "url": "${{TAB_ENDPOINT}}",
             "type": "Spa"
         },
         {
-            "url": "https://localhost:3000/auth-end",
+            "url": "${{TAB_ENDPOINT}}/auth-end",
             "type": "Spa"
         }
     ]

--- a/build.js
+++ b/build.js
@@ -2,16 +2,38 @@ const fs = require('fs');
 const path = require('path');
 const dotenv = require('dotenv');
 
-// Read environment variables from .env.dev file
+// Load optional development defaults, then overlay the active Teams
+// environment. Process variables win so CI can build without local .env files.
 const envFilePath = path.join(__dirname, '.', 'env', '.env.dev');
-const envConfig = dotenv.parse(fs.readFileSync(envFilePath));
-const contentUrl = envConfig.CONTENT_URL;
-const websiteUrl = envConfig.WEBSITE_URL;
+let envConfig = fs.existsSync(envFilePath)
+  ? dotenv.parse(fs.readFileSync(envFilePath))
+  : {};
+
+const activeEnv = process.env.TEAMSFX_ENV;
+if (activeEnv && activeEnv !== 'dev') {
+  const activeEnvPath = path.join(__dirname, '.', 'env', `.env.${activeEnv}`);
+  if (fs.existsSync(activeEnvPath)) {
+    envConfig = {
+      ...envConfig,
+      ...dotenv.parse(fs.readFileSync(activeEnvPath)),
+    };
+  }
+}
+
+envConfig = {
+  ...envConfig,
+  ...process.env,
+};
+
+const contentUrl = envConfig.TAB_ENDPOINT || envConfig.CONTENT_URL;
+const websiteUrl = envConfig.TAB_ENDPOINT || envConfig.WEBSITE_URL;
 
 
 // Check for missing environment variables
 if (!contentUrl || !websiteUrl) {
-  console.error('Error: CONTENT_URL and WEBSITE_URL environment variables added to your envirfonment file.');
+  console.error(
+    'Error: configure TAB_ENDPOINT, or both CONTENT_URL and WEBSITE_URL.',
+  );
   process.exit(1);
 }
 

--- a/docs/TROUBLESHOOTING.adoc
+++ b/docs/TROUBLESHOOTING.adoc
@@ -22,6 +22,12 @@
 | Tabs show a blank page or bounce to `/login`
 | `acquireTokenSilent` failed — verify `REACT_APP_AAD_CLIENT_ID` / `REACT_APP_TENANT_ID` and that the redirect URI `<origin>/auth-end` is registered on the AAD app
 
+| Tab fails in Teams because a public page tried to connect to the local network
+| Chrome and Edge block `teams.microsoft.com` from framing `localhost`. Start the normal F5 debug session: the tunnel task forwards port 3000 and writes `TAB_ENDPOINT` and `TAB_DOMAIN`, which the Entra and Teams manifests consume. Do not point the Teams manifest directly at `localhost`
+
+| Values containing `#` or `$` are truncated when read from a `.env` file
+| `#` starts a comment and CRA expands `$`. Quote the complete value in `env/.env.*`; in `tabs/.env.development`, escape a literal `$` as `\$`
+
 | Reward name does not load / defaults to "Sats"
 | The Express backend (`tabs/backend/server.js`, port 5000) is not running, or `WEBSITE_API_URL` (bot side) points to the wrong host
 

--- a/env/.env.dev.example
+++ b/env/.env.dev.example
@@ -53,6 +53,9 @@ FOUNDRY_MODEL=
 GRAPH_CONNECTION_NAME=GraphWorkSignals
 
 # Bot Manifest file variables
+# Public Teams tab URL. Local debug overwrites this with the port 3000 tunnel.
+TAB_ENDPOINT=https://localhost:3000
+TAB_DOMAIN=localhost
 CONTENT_URL=https://localhost:3000
 WEBSITE_URL=https://localhost:3000
 

--- a/manifest.template.json
+++ b/manifest.template.json
@@ -138,6 +138,7 @@
     ],
     "validDomains": [
         "${{BOT_DOMAIN}}",
+        "${{TAB_DOMAIN}}",
         "*.azurestaticapps.net",
         "*.microsoft.com"
     ],


### PR DESCRIPTION
Fixes #276

Related: #165

## Why

Current Chromium clients prevent Teams from framing localhost, while `build.js` also required a local `env/.env.dev` file even when CI supplied every required value.

## What changed

- tunnels port 3000 and writes `TAB_ENDPOINT` and `TAB_DOMAIN`
- uses the tunnel endpoint for Entra redirects and Teams content URLs
- adds the exact tunnel domain instead of a production wildcard
- makes local environment files optional and gives process variables final precedence
- documents tunnel and environment parsing failures in AsciiDoc

## Risk

Low. The changes affect generated manifests and local tooling; production values retain the existing `CONTENT_URL` fallback.

## Test plan for QA

- generate a manifest in a clean checkout using process variables and no `env/.env.dev`
- start the normal F5 session and confirm both bot and tab tunnels are created
- confirm generated Entra redirects use `TAB_ENDPOINT`
- confirm the Teams manifest contains the exact `TAB_DOMAIN`
- open the tab in Teams and confirm Chromium does not report a local-network iframe block

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR enables tunneled Teams tab debugging by using the tunnel endpoint in redirects and content URLs. It also supports clean checkouts without `env/.env.dev` and applies environment values in the order: development defaults, active environment, then process variables.

## Worth a look

- `build.js`: Confirm that accepting `TAB_ENDPOINT` as the shared fallback for `CONTENT_URL` and `WEBSITE_URL` matches the intended deployment model. Separate values remain an alternative.
- `manifest.template.json` and `build.js`: Verify that the exact `TAB_DOMAIN` value is always a valid Teams manifest domain and cannot include a scheme, path, or port.
- `.vscode/tasks.json`: Confirm that exposing port 3000 is safe for the local tunnel and that the task reliably writes both `TAB_ENDPOINT` and `TAB_DOMAIN` before manifest generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->