### PR TITLE
feat: zap the card recipient with a ⚡ reaction

### DIFF
--- a/docs/DEPLOYMENT.adoc
+++ b/docs/DEPLOYMENT.adoc
@@ -147,6 +147,10 @@ Deploy `dist/` with Azure Functions Core Tools or your preferred pipeline
 | Default reward-unit label (renamable in Settings)
 | Bot, Tabs
 
+| `ZAP_REACTION_SATS`
+| Sats paid when someone reacts to a zap card with ⚡. Optional, defaults to 21; must be a whole number between 1 and 10,000 or the reaction zap fails closed
+| Bot
+
 | `REACT_APP_AAD_CLIENT_ID`, `REACT_APP_TENANT_ID`
 | MSAL configuration for the tabs SPA
 | Tabs

--- a/src/commands/agentTools.ts
+++ b/src/commands/agentTools.ts
@@ -15,6 +15,7 @@ import {
 } from './connectCalendarCommand';
 import { createZapCard } from './sendZapCommand';
 import { MAX_ZAP_SATS } from './zapBudget';
+import { registerZapTarget } from '../services/reactionZapTargets';
 import { isRecord } from '../utils/typeGuards';
 
 const adminKey = process.env.LNBITS_ADMINKEY as string;
@@ -298,8 +299,13 @@ const proposeZapTool: ToolDefinition = {
       message: memo,
       amountSats,
     });
-    await turnContext.sendActivity(
+    const sent = await turnContext.sendActivity(
       MessageFactory.attachment(CardFactory.adaptiveCard(card)),
+    );
+    registerZapTarget(
+      turnContext.activity?.conversation?.id,
+      sent?.id,
+      recipient.id,
     );
 
     return {

--- a/src/services/reactionZapTargets.test.ts
+++ b/src/services/reactionZapTargets.test.ts
@@ -1,0 +1,72 @@
+// reactionZapTargets.test.ts — the configurable ⚡ reaction amount.
+import { expect, describe, test, beforeEach, afterAll } from '@jest/globals';
+
+import { MAX_ZAP_SATS } from '../commands/zapBudget';
+import {
+  zapReactionSats,
+  ZAP_REACTION_DEFAULT_SATS,
+} from './reactionZapTargets';
+
+const originalReactionSats = process.env.ZAP_REACTION_SATS;
+
+describe('zapReactionSats', () => {
+  beforeEach(() => {
+    delete process.env.ZAP_REACTION_SATS;
+  });
+
+  afterAll(() => {
+    if (originalReactionSats === undefined) {
+      delete process.env.ZAP_REACTION_SATS;
+    } else {
+      process.env.ZAP_REACTION_SATS = originalReactionSats;
+    }
+  });
+
+  test('defaults to 21 when unset', () => {
+    expect(zapReactionSats()).toBe(21);
+    expect(ZAP_REACTION_DEFAULT_SATS).toBe(21);
+  });
+
+  test('defaults when set to blank, so an empty app setting is not a zero zap', () => {
+    for (const blank of ['', '   ']) {
+      process.env.ZAP_REACTION_SATS = blank;
+      expect(zapReactionSats()).toBe(ZAP_REACTION_DEFAULT_SATS);
+    }
+  });
+
+  test('returns the configured amount', () => {
+    process.env.ZAP_REACTION_SATS = '210';
+    expect(zapReactionSats()).toBe(210);
+  });
+
+  test('accepts the boundaries', () => {
+    process.env.ZAP_REACTION_SATS = '1';
+    expect(zapReactionSats()).toBe(1);
+    process.env.ZAP_REACTION_SATS = String(MAX_ZAP_SATS);
+    expect(zapReactionSats()).toBe(MAX_ZAP_SATS);
+  });
+
+  test('rejects anything that is not a positive whole number in range', () => {
+    for (const invalid of [
+      '0',
+      '-21',
+      '21.5',
+      'twenty-one',
+      'NaN',
+      'Infinity',
+      String(MAX_ZAP_SATS + 1),
+    ]) {
+      process.env.ZAP_REACTION_SATS = invalid;
+      expect(zapReactionSats).toThrow(
+        `ZAP_REACTION_SATS must be a whole number between 1 and ${MAX_ZAP_SATS}, received: ${invalid}`,
+      );
+    }
+  });
+
+  test('re-reads the environment on every call', () => {
+    process.env.ZAP_REACTION_SATS = '50';
+    expect(zapReactionSats()).toBe(50);
+    process.env.ZAP_REACTION_SATS = '75';
+    expect(zapReactionSats()).toBe(75);
+  });
+});

--- a/src/services/reactionZapTargets.ts
+++ b/src/services/reactionZapTargets.ts
@@ -1,3 +1,5 @@
+import { MAX_ZAP_SATS } from '../commands/zapBudget';
+
 // Maps bot-sent zap cards to their pre-filled recipient so a ⚡ reaction on
 // the card can pay that recipient. Teams only forwards reactions for messages
 // the bot itself sent, so this registry is the entire phase-1 surface.
@@ -12,8 +14,25 @@ const MAX_TARGETS = 500;
 // logging shows something else arriving.
 export const ZAP_REACTION_TYPES = new Set(['26a1_highvoltagesymbol', '⚡']);
 
-// Prefill only: a reaction is a one-tap gesture, so keep the amount small.
+// A reaction is a one-tap gesture with no card to edit, so the default stays
+// small; operators raise it with ZAP_REACTION_SATS.
 export const ZAP_REACTION_DEFAULT_SATS = 21;
+
+// Read per reaction rather than at import so a misconfigured value surfaces on
+// the next zap instead of silently paying the default forever.
+export function zapReactionSats(): number {
+  const configured = process.env.ZAP_REACTION_SATS;
+  if (configured === undefined || configured.trim() === '') {
+    return ZAP_REACTION_DEFAULT_SATS;
+  }
+  const amount = Number(configured);
+  if (!Number.isInteger(amount) || amount < 1 || amount > MAX_ZAP_SATS) {
+    throw new Error(
+      `ZAP_REACTION_SATS must be a whole number between 1 and ${MAX_ZAP_SATS}, received: ${configured}`,
+    );
+  }
+  return amount;
+}
 
 interface ZapTarget {
   receiverId: string;

--- a/src/services/reactionZapTargets.ts
+++ b/src/services/reactionZapTargets.ts
@@ -1,0 +1,56 @@
+// Maps bot-sent zap cards to their pre-filled recipient so a ⚡ reaction on
+// the card can pay that recipient. Teams only forwards reactions for messages
+// the bot itself sent, so this registry is the entire phase-1 surface.
+// In-memory and bounded: after a restart old cards simply stop reacting,
+// which fails safe (no payment). Durability is not needed because the zap
+// ledger still deduplicates any card that does get zapped twice.
+const MAX_TARGETS = 500;
+
+// Teams sends the expanded emoji reaction ids to bots on newer clients
+// (⚡ is 26a1_highvoltagesymbol); older clients may still map to the six
+// legacy types, so this set is the single place to widen if the spike
+// logging shows something else arriving.
+export const ZAP_REACTION_TYPES = new Set(['26a1_highvoltagesymbol', '⚡']);
+
+// Prefill only: a reaction is a one-tap gesture, so keep the amount small.
+export const ZAP_REACTION_DEFAULT_SATS = 21;
+
+interface ZapTarget {
+  receiverId: string;
+}
+
+const targets = new Map<string, ZapTarget>();
+
+const keyFor = (conversationId: string, activityId: string): string =>
+  `${conversationId}:${activityId}`;
+
+export function registerZapTarget(
+  conversationId: string | undefined,
+  activityId: string | undefined,
+  receiverId: string,
+): void {
+  if (!conversationId || !activityId || !receiverId) {
+    return;
+  }
+  if (targets.size >= MAX_TARGETS) {
+    const oldest = targets.keys().next().value;
+    if (oldest !== undefined) {
+      targets.delete(oldest);
+    }
+  }
+  targets.set(keyFor(conversationId, activityId), { receiverId });
+}
+
+export function getZapTarget(
+  conversationId: string | undefined,
+  activityId: string | undefined,
+): ZapTarget | undefined {
+  if (!conversationId || !activityId) {
+    return undefined;
+  }
+  return targets.get(keyFor(conversationId, activityId));
+}
+
+export function resetZapTargetsForTests(): void {
+  targets.clear();
+}

--- a/src/teamsBot.ts
+++ b/src/teamsBot.ts
@@ -26,6 +26,12 @@ import {
   validateSelfZap,
 } from './commands/zapRecipient';
 import { validateZapSubmit } from './commands/zapBudget';
+import {
+  getZapTarget,
+  registerZapTarget,
+  ZAP_REACTION_DEFAULT_SATS,
+  ZAP_REACTION_TYPES,
+} from './services/reactionZapTargets';
 import { ShowMyBalanceCommand } from './commands/showMyBalanceCommand';
 import { WithdrawFundsCommand } from './commands/withdrawFundsCommand';
 import { ShowLeaderboardCommand } from './commands/showLeaderboardCommand';
@@ -83,6 +89,11 @@ export class TeamsBot extends TeamsActivityHandler {
         new ConnectCalendarCommand(),
       );
     }
+
+    this.onReactionsAdded(async (context, next) => {
+      await this.handleZapReaction(context);
+      await next();
+    });
 
     this.onMessage(async (context, next) => {
       console.log('Running onMessage ...');
@@ -469,11 +480,96 @@ export class TeamsBot extends TeamsActivityHandler {
         dialogMemo || htmlToMemoPreview(action.messagePayload?.body?.content),
     });
 
-    await context.sendActivity(
+    const sent = await context.sendActivity(
       MessageFactory.attachment(CardFactory.adaptiveCard(card)),
     );
+    registerZapTarget(context.activity?.conversation?.id, sent?.id, author.id);
 
     return {};
+  }
+
+  // A ⚡ reaction on a zap card the bot sent pays the card's pre-filled
+  // recipient a small default amount. Teams only forwards reactions for the
+  // bot's own messages, so unregistered messages are ignored quietly.
+  async handleZapReaction(context: TurnContext): Promise<void> {
+    const reactions = context.activity.reactionsAdded ?? [];
+    // Spike telemetry: classic Bot Framework docs only list the six legacy
+    // reaction types; log what actually arrives to confirm the expanded
+    // emoji ids in this tenant.
+    console.log(
+      'Reactions received:',
+      reactions.map(reaction => reaction.type).join(', ') || '(none)',
+    );
+
+    const cardId = context.activity.replyToId;
+    const target = getZapTarget(context.activity.conversation?.id, cardId);
+    if (!target) {
+      return;
+    }
+    if (!reactions.some(reaction => ZAP_REACTION_TYPES.has(reaction.type))) {
+      return;
+    }
+
+    const currentUser: User | undefined = context.turnState.get('user');
+    if (!currentUser?.allowanceWallet?.inkey) {
+      return;
+    }
+
+    try {
+      const liveBalance = await getWalletBalance(
+        currentUser.allowanceWallet.inkey,
+      );
+      const amount = validateZapSubmit(
+        ZAP_REACTION_DEFAULT_SATS,
+        1,
+        liveBalance,
+        globalRewardName,
+      );
+      const outcome = await processZapRecipient({
+        ledger: this.zapLedger,
+        entryKey: zapKey({
+          tenantId: context.activity.conversation.tenantId,
+          conversationId: context.activity.conversation.id,
+          cardId: cardId as string,
+          recipientId: target.receiverId,
+        }),
+        recipientId: target.receiverId,
+        getReceiver: () => getUser(adminKey, target.receiverId),
+        validateReceiver: receiver => validateSelfZap(currentUser, receiver),
+        pay: receiver =>
+          SendZap(
+            currentUser,
+            receiver as User,
+            'Zapped with a ⚡ reaction',
+            amount,
+            context,
+            false,
+            globalRewardName,
+          ),
+      });
+
+      if (outcome.status === 'paid') {
+        await context.sendActivity(
+          `⚡ Sent ${amount} ${globalRewardName} to ${outcome.label} for your reaction.`,
+        );
+      } else if (outcome.status !== 'skipped') {
+        // 'skipped' means this card was already paid; stay quiet so piling
+        // extra reactions onto a card does not spam the conversation.
+        await context.sendActivity(
+          `D'oh! Your ⚡ reaction zap to ${outcome.label} could not be completed.`,
+        );
+      }
+    } catch (error) {
+      console.error(
+        'Reaction zap failed:',
+        error instanceof Error ? error.message : error,
+      );
+      await context.sendActivity(
+        error instanceof Error
+          ? `D'oh! ${error.message}`
+          : "D'oh! Your ⚡ reaction zap could not be completed.",
+      );
+    }
   }
 }
 

--- a/src/teamsBot.ts
+++ b/src/teamsBot.ts
@@ -512,6 +512,9 @@ export class TeamsBot extends TeamsActivityHandler {
 
     const currentUser: User | undefined = context.turnState.get('user');
     if (!currentUser?.allowanceWallet?.inkey) {
+      await context.sendActivity(
+        "D'oh! You need a Zaplie allowance wallet before you can zap by reacting.",
+      );
       return;
     }
 
@@ -519,12 +522,23 @@ export class TeamsBot extends TeamsActivityHandler {
       const liveBalance = await getWalletBalance(
         currentUser.allowanceWallet.inkey,
       );
-      const amount = validateZapSubmit(
-        ZAP_REACTION_DEFAULT_SATS,
-        1,
-        liveBalance,
-        globalRewardName,
-      );
+      let amount: number;
+      try {
+        // validateZapSubmit throws user-facing messages, safe to relay as-is.
+        amount = validateZapSubmit(
+          ZAP_REACTION_DEFAULT_SATS,
+          1,
+          liveBalance,
+          globalRewardName,
+        );
+      } catch (validationError) {
+        await context.sendActivity(
+          validationError instanceof Error
+            ? `D'oh! ${validationError.message}`
+            : "D'oh! Your ⚡ reaction zap could not be completed.",
+        );
+        return;
+      }
       const outcome = await processZapRecipient({
         ledger: this.zapLedger,
         entryKey: zapKey({
@@ -560,14 +574,11 @@ export class TeamsBot extends TeamsActivityHandler {
         );
       }
     } catch (error) {
-      console.error(
-        'Reaction zap failed:',
-        error instanceof Error ? error.message : error,
-      );
+      // Not a validation error, so the message may carry internal details —
+      // log it and answer with a generic line.
+      console.error('Reaction zap failed:', error);
       await context.sendActivity(
-        error instanceof Error
-          ? `D'oh! ${error.message}`
-          : "D'oh! Your ⚡ reaction zap could not be completed.",
+        "D'oh! Your ⚡ reaction zap could not be completed. Please try again later.",
       );
     }
   }

--- a/src/teamsBot.ts
+++ b/src/teamsBot.ts
@@ -29,7 +29,7 @@ import { validateZapSubmit } from './commands/zapBudget';
 import {
   getZapTarget,
   registerZapTarget,
-  ZAP_REACTION_DEFAULT_SATS,
+  zapReactionSats,
   ZAP_REACTION_TYPES,
 } from './services/reactionZapTargets';
 import { ShowMyBalanceCommand } from './commands/showMyBalanceCommand';
@@ -489,8 +489,8 @@ export class TeamsBot extends TeamsActivityHandler {
   }
 
   // A ⚡ reaction on a zap card the bot sent pays the card's pre-filled
-  // recipient a small default amount. Teams only forwards reactions for the
-  // bot's own messages, so unregistered messages are ignored quietly.
+  // recipient the configured reaction amount. Teams only forwards reactions
+  // for the bot's own messages, so unregistered messages are ignored quietly.
   async handleZapReaction(context: TurnContext): Promise<void> {
     const reactions = context.activity.reactionsAdded ?? [];
     // Spike telemetry: classic Bot Framework docs only list the six legacy
@@ -519,6 +519,9 @@ export class TeamsBot extends TeamsActivityHandler {
     }
 
     try {
+      // Outside the inner catch on purpose: a bad ZAP_REACTION_SATS is an
+      // operator error, so it is logged, not relayed to the reactor.
+      const configuredAmount = zapReactionSats();
       const liveBalance = await getWalletBalance(
         currentUser.allowanceWallet.inkey,
       );
@@ -526,7 +529,7 @@ export class TeamsBot extends TeamsActivityHandler {
       try {
         // validateZapSubmit throws user-facing messages, safe to relay as-is.
         amount = validateZapSubmit(
-          ZAP_REACTION_DEFAULT_SATS,
+          configuredAmount,
           1,
           liveBalance,
           globalRewardName,

--- a/src/teamsBotReactions.test.ts
+++ b/src/teamsBotReactions.test.ts
@@ -153,7 +153,7 @@ describe('TeamsBot handleZapReaction', () => {
     expect(second.sendActivity).not.toHaveBeenCalled();
   });
 
-  test('a failed balance read answers with the error, not silence', async () => {
+  test('a failed balance read answers generically without internal details', async () => {
     registerZapTarget('conv-1', 'card-1', receiver.id);
     mockGetWalletBalance.mockRejectedValue(new Error('LNbits unavailable'));
     const errorSpy = jest
@@ -165,9 +165,39 @@ describe('TeamsBot handleZapReaction', () => {
 
     expect(mockSendZap).not.toHaveBeenCalled();
     expect(context.sendActivity).toHaveBeenCalledWith(
-      "D'oh! LNbits unavailable",
+      "D'oh! Your ⚡ reaction zap could not be completed. Please try again later.",
     );
+    expect(errorSpy).toHaveBeenCalled();
     errorSpy.mockRestore();
+  });
+
+  test('an insufficient balance relays the validation message', async () => {
+    registerZapTarget('conv-1', 'card-1', receiver.id);
+    mockGetWalletBalance.mockResolvedValue(0);
+    const context = buildReactionContext('26a1_highvoltagesymbol', 'card-1');
+
+    await bot.handleZapReaction(context);
+
+    expect(mockSendZap).not.toHaveBeenCalled();
+    expect(context.sendActivity).toHaveBeenCalledWith(
+      expect.stringContaining('your balance is 0'),
+    );
+  });
+
+  test('a reactor without an allowance wallet is told, not ignored', async () => {
+    registerZapTarget('conv-1', 'card-1', receiver.id);
+    const context = buildReactionContext('26a1_highvoltagesymbol', 'card-1');
+    (context.turnState as Map<string, unknown>).set('user', {
+      ...(reactor as unknown as Record<string, unknown>),
+      allowanceWallet: null,
+    });
+
+    await bot.handleZapReaction(context);
+
+    expect(mockSendZap).not.toHaveBeenCalled();
+    expect(context.sendActivity).toHaveBeenCalledWith(
+      "D'oh! You need a Zaplie allowance wallet before you can zap by reacting.",
+    );
   });
 });
 

--- a/src/teamsBotReactions.test.ts
+++ b/src/teamsBotReactions.test.ts
@@ -10,6 +10,7 @@ import {
 
 const originalPointsLabel = process.env.LNBITS_POINTS_LABEL;
 const originalAdminKey = process.env.LNBITS_ADMINKEY;
+const originalReactionSats = process.env.ZAP_REACTION_SATS;
 
 process.env.LNBITS_POINTS_LABEL = 'Sats';
 process.env.LNBITS_ADMINKEY = 'admin-key';
@@ -90,6 +91,7 @@ describe('TeamsBot handleZapReaction', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     resetZapTargetsForTests();
+    delete process.env.ZAP_REACTION_SATS;
     bot = new TeamsBot();
     mockGetWalletBalance.mockResolvedValue(1000);
     mockGetUser.mockResolvedValue(receiver);
@@ -99,6 +101,7 @@ describe('TeamsBot handleZapReaction', () => {
   afterAll(() => {
     restoreEnv('LNBITS_POINTS_LABEL', originalPointsLabel);
     restoreEnv('LNBITS_ADMINKEY', originalAdminKey);
+    restoreEnv('ZAP_REACTION_SATS', originalReactionSats);
   });
 
   test('a zap reaction on a registered card pays and confirms', async () => {
@@ -120,6 +123,45 @@ describe('TeamsBot handleZapReaction', () => {
     expect(context.sendActivity).toHaveBeenCalledWith(
       `⚡ Sent ${ZAP_REACTION_DEFAULT_SATS} Sats to Receiver for your reaction.`,
     );
+  });
+
+  test('the configured ZAP_REACTION_SATS is paid and confirmed', async () => {
+    process.env.ZAP_REACTION_SATS = '50';
+    registerZapTarget('conv-1', 'card-1', receiver.id);
+    const context = buildReactionContext('26a1_highvoltagesymbol', 'card-1');
+
+    await bot.handleZapReaction(context);
+
+    expect(mockSendZap).toHaveBeenCalledWith(
+      reactor,
+      receiver,
+      'Zapped with a ⚡ reaction',
+      50,
+      context,
+      false,
+      'Sats',
+    );
+    expect(context.sendActivity).toHaveBeenCalledWith(
+      '⚡ Sent 50 Sats to Receiver for your reaction.',
+    );
+  });
+
+  test('a misconfigured ZAP_REACTION_SATS pays nothing and hides the config detail', async () => {
+    process.env.ZAP_REACTION_SATS = 'lots';
+    registerZapTarget('conv-1', 'card-1', receiver.id);
+    const errorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    const context = buildReactionContext('26a1_highvoltagesymbol', 'card-1');
+
+    await bot.handleZapReaction(context);
+
+    expect(mockSendZap).not.toHaveBeenCalled();
+    expect(context.sendActivity).toHaveBeenCalledWith(
+      "D'oh! Your ⚡ reaction zap could not be completed. Please try again later.",
+    );
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
   });
 
   test('non-zap reaction types do not pay', async () => {

--- a/src/teamsBotReactions.test.ts
+++ b/src/teamsBotReactions.test.ts
@@ -1,0 +1,180 @@
+// teamsBotReactions.test.ts — ⚡ reaction on a bot zap card pays its recipient.
+import {
+  expect,
+  describe,
+  test,
+  beforeEach,
+  afterAll,
+  jest,
+} from '@jest/globals';
+
+const originalPointsLabel = process.env.LNBITS_POINTS_LABEL;
+const originalAdminKey = process.env.LNBITS_ADMINKEY;
+
+process.env.LNBITS_POINTS_LABEL = 'Sats';
+process.env.LNBITS_ADMINKEY = 'admin-key';
+
+jest.mock('./services/lnbitsService');
+jest.mock('./commands/sendZapCommand', () => {
+  const actual = jest.requireActual('./commands/sendZapCommand') as object;
+  return {
+    ...actual,
+    createZapCard: jest.fn(),
+    SendZap: jest.fn(),
+  };
+});
+
+import { getUser, getWalletBalance } from './services/lnbitsService';
+import { SendZap } from './commands/sendZapCommand';
+import {
+  registerZapTarget,
+  resetZapTargetsForTests,
+  ZAP_REACTION_DEFAULT_SATS,
+} from './services/reactionZapTargets';
+
+// require, not import: imports hoist above the jest.mock calls above.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { TeamsBot } = require('./teamsBot') as typeof import('./teamsBot');
+
+const mockGetUser = getUser as jest.MockedFunction<typeof getUser>;
+const mockGetWalletBalance = getWalletBalance as jest.MockedFunction<
+  typeof getWalletBalance
+>;
+const mockSendZap = SendZap as jest.MockedFunction<typeof SendZap>;
+
+const reactor = {
+  id: 'reactorId',
+  displayName: 'Reactor',
+  profileImg: '',
+  aadObjectId: 'aad-reactor',
+  email: 'reactor@test.com',
+  privateWallet: null,
+  allowanceWallet: {
+    id: 'wallet-reactor',
+    inkey: 'reactor-inkey',
+    adminkey: 'reactor-adminkey',
+  },
+} as unknown as User;
+
+const receiver = {
+  id: 'receiverId',
+  displayName: 'Receiver',
+  profileImg: '',
+  aadObjectId: 'aad-receiver',
+  email: 'receiver@test.com',
+  privateWallet: { id: 'wallet-receiver', inkey: 'receiver-inkey' },
+  allowanceWallet: null,
+} as unknown as User;
+
+function buildReactionContext(
+  reactionType: string,
+  replyToId: string | undefined,
+) {
+  const turnState = new Map<string, unknown>();
+  turnState.set('user', reactor);
+  return {
+    turnState,
+    activity: {
+      replyToId,
+      reactionsAdded: [{ type: reactionType }],
+      conversation: { id: 'conv-1', tenantId: 'tenant-1' },
+      from: { id: 'teams-reactor' },
+    },
+    sendActivity: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
+  } as unknown as import('botbuilder').TurnContext;
+}
+
+describe('TeamsBot handleZapReaction', () => {
+  let bot: InstanceType<typeof TeamsBot>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetZapTargetsForTests();
+    bot = new TeamsBot();
+    mockGetWalletBalance.mockResolvedValue(1000);
+    mockGetUser.mockResolvedValue(receiver);
+    mockSendZap.mockResolvedValue({} as never);
+  });
+
+  afterAll(() => {
+    restoreEnv('LNBITS_POINTS_LABEL', originalPointsLabel);
+    restoreEnv('LNBITS_ADMINKEY', originalAdminKey);
+  });
+
+  test('a zap reaction on a registered card pays and confirms', async () => {
+    registerZapTarget('conv-1', 'card-1', receiver.id);
+    const context = buildReactionContext('26a1_highvoltagesymbol', 'card-1');
+
+    await bot.handleZapReaction(context);
+
+    expect(mockSendZap).toHaveBeenCalledTimes(1);
+    expect(mockSendZap).toHaveBeenCalledWith(
+      reactor,
+      receiver,
+      'Zapped with a ⚡ reaction',
+      ZAP_REACTION_DEFAULT_SATS,
+      context,
+      false,
+      'Sats',
+    );
+    expect(context.sendActivity).toHaveBeenCalledWith(
+      `⚡ Sent ${ZAP_REACTION_DEFAULT_SATS} Sats to Receiver for your reaction.`,
+    );
+  });
+
+  test('non-zap reaction types do not pay', async () => {
+    registerZapTarget('conv-1', 'card-1', receiver.id);
+    const context = buildReactionContext('heart', 'card-1');
+
+    await bot.handleZapReaction(context);
+
+    expect(mockSendZap).not.toHaveBeenCalled();
+    expect(context.sendActivity).not.toHaveBeenCalled();
+  });
+
+  test('reactions on unregistered messages are ignored', async () => {
+    const context = buildReactionContext('26a1_highvoltagesymbol', 'card-x');
+
+    await bot.handleZapReaction(context);
+
+    expect(mockSendZap).not.toHaveBeenCalled();
+    expect(context.sendActivity).not.toHaveBeenCalled();
+  });
+
+  test('a second zap reaction on the same card stays silent and pays once', async () => {
+    registerZapTarget('conv-1', 'card-1', receiver.id);
+    const first = buildReactionContext('26a1_highvoltagesymbol', 'card-1');
+    const second = buildReactionContext('26a1_highvoltagesymbol', 'card-1');
+
+    await bot.handleZapReaction(first);
+    await bot.handleZapReaction(second);
+
+    expect(mockSendZap).toHaveBeenCalledTimes(1);
+    expect(second.sendActivity).not.toHaveBeenCalled();
+  });
+
+  test('a failed balance read answers with the error, not silence', async () => {
+    registerZapTarget('conv-1', 'card-1', receiver.id);
+    mockGetWalletBalance.mockRejectedValue(new Error('LNbits unavailable'));
+    const errorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    const context = buildReactionContext('26a1_highvoltagesymbol', 'card-1');
+
+    await bot.handleZapReaction(context);
+
+    expect(mockSendZap).not.toHaveBeenCalled();
+    expect(context.sendActivity).toHaveBeenCalledWith(
+      "D'oh! LNbits unavailable",
+    );
+    errorSpy.mockRestore();
+  });
+});
+
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+}


### PR DESCRIPTION
Fixes #306

## What changed
Phase 1 of reaction zaps: reacting with ⚡ to a zap card the bot sent (the "Zap a message" message extension or an assistant proposal) pays that card's prefilled recipient the configured reaction amount and confirms in the thread, e.g. `⚡ Sent 21 Sats to <name> for your reaction.`

- **The amount is configurable**: `ZAP_REACTION_SATS` app setting, default **21**. It is read per reaction, so changing the app setting takes effect without a code change. It is validated as a whole number between 1 and `MAX_ZAP_SATS` (10,000); a bad value throws before any LNbits call, pays nothing, and is logged as an operator error instead of being shown to the reactor. Documented in `docs/DEPLOYMENT.adoc`.
- Reuses the existing zap ledger: **one payment per card** no matter how many reactions arrive; self-zap blocked; live balance verified before paying.
- In-memory, bounded (500) target registry: after a restart, old cards simply stop reacting, which fails safe with no payments.
- User-safe messaging: validation errors (balance, amount) are relayed as written for users; internal errors are logged and answered with a generic line; a reactor without an allowance wallet is told instead of silently ignored.
- **Spike included**: logs the `type` of every incoming reaction. Classic Bot Framework docs only list the six legacy types; the new Teams SDK exposes expanded ids (⚡ = `26a1_highvoltagesymbol`). The log confirms what botbuilder 4.23 actually receives in our tenant. If a different id arrives, `ZAP_REACTION_TYPES` grows in one place.

## Phase-1 limitation (by Teams design)
Bots only receive reactions on **their own** messages ([docs](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/conversations/subscribe-to-conversation-events)). Reacting to a colleague's message does not reach the bot. Phase 2 (next PR, if the spike validates) will use Graph change notifications with RSC `ChannelMessage.Read.Group` to cover every channel message.

## Test plan for QA
1. In Teams, use "Zap a message" on a colleague's message to produce a zap card, then react to the card with ⚡: expect one payment of the configured amount (21 sats by default) to that colleague and a confirmation reply in the thread.
2. React again (same or another user): expect no second payment and no extra message.
3. React with a non-⚡ emoji: expect nothing.
4. React with ⚡ as a user with no allowance wallet: expect the "you need a Zaplie allowance wallet" message and no payment.
5. Set `ZAP_REACTION_SATS` to another value (say 50) and repeat step 1: expect 50 sats. Set it to something invalid and repeat: expect no payment and a generic reply.
6. Check the bot logs for the `Reactions received:` spike line and note the reaction `type` ids your tenant sends.

Unit tests (`npm test`): `teamsBotReactions.test.ts` covers pay-and-confirm, the configured amount, a misconfigured amount, dedupe, non-zap types, unregistered messages, generic error messaging, validation-message relay, and the no-wallet reply. `reactionZapTargets.test.ts` covers the `ZAP_REACTION_SATS` default, its bounds and its rejections.

## Remaining before ready
- [ ] Validate the spike in a real Teams tenant (confirm the reaction `type` ids).
- [ ] Screenshot of the reaction to confirmation flow for this description.
- [ ] Team decision: any reactor pays from their own wallet and only the first reactor pays. Confirm this is the wanted semantic.
- [ ] Follow-up (separate PR): expose the amount in the portal Settings page for `Zaplie.Admin`, the way the reward name and the automation reward amounts already work, so a tenant admin can change it without an app setting.
