### PR TITLE
fix: reject LNbits payments without a stable identifier

### DIFF
--- a/tabs/backend/lnbitsGatewayService.js
+++ b/tabs/backend/lnbitsGatewayService.js
@@ -148,21 +148,41 @@ const sanitizeWallet = (wallet) => ({
   deleted: wallet.deleted === true,
 });
 
-const sanitizePayment = (payment) => ({
-  checking_id: payment.checking_id || payment.payment_hash || payment.id || '',
-  payment_hash: payment.payment_hash,
-  // LNbits v1 dropped the boolean `pending` field in favour of `status`;
-  // derive it so in-flight payments are not misread as settled.
-  pending:
-    payment.pending === true ||
-    String(payment.status || '').toLowerCase() === 'pending',
-  amount: Number(payment.amount || 0),
-  fee: Number(payment.fee || 0),
-  memo: payment.memo || '',
-  time: payment.time,
-  extra: redactSensitive(payment.extra || {}),
-  wallet_id: payment.wallet_id,
-});
+const validPaymentId = (value) =>
+  typeof value === 'string' && value.length > 0 && value.length <= 256;
+
+const requirePaymentId = (payment) => {
+  const paymentId = [payment.checking_id, payment.payment_hash, payment.id].find(
+    validPaymentId,
+  );
+  if (!paymentId) {
+    throw new LnbitsGatewayError(
+      'LNbits payment response is missing a stable identifier',
+    );
+  }
+  return paymentId;
+};
+
+const sanitizePayment = (payment) => {
+  const paymentId = requirePaymentId(payment);
+  return {
+    checking_id: paymentId,
+    payment_hash: validPaymentId(payment.payment_hash)
+      ? payment.payment_hash
+      : undefined,
+    // LNbits v1 dropped the boolean `pending` field in favour of `status`;
+    // derive it so in-flight payments are not misread as settled.
+    pending:
+      payment.pending === true ||
+      String(payment.status || '').toLowerCase() === 'pending',
+    amount: Number(payment.amount || 0),
+    fee: Number(payment.fee || 0),
+    memo: payment.memo || '',
+    time: payment.time,
+    extra: redactSensitive(payment.extra || {}),
+    wallet_id: payment.wallet_id,
+  };
+};
 
 const listRawUsers = async () => {
   const body = await lnbitsRequest('/users/api/v1/user');
@@ -324,8 +344,6 @@ const payInvoice = async (wallet, paymentRequest) => {
     walletKey: wallet.adminkey,
     body: { out: true, bolt11: paymentRequest },
   });
-  const validPaymentId = (value) =>
-    typeof value === 'string' && value.length > 0 && value.length <= 256;
   const paymentId = validPaymentId(result.payment_hash)
     ? result.payment_hash
     : result.checking_id;

--- a/tabs/backend/lnbitsGatewayService.test.js
+++ b/tabs/backend/lnbitsGatewayService.test.js
@@ -68,6 +68,52 @@ test('payments without the removed pending flag derive it from status', () => {
   assert.equal(sanitizePayment(base).pending, false);
 });
 
+test('payment serialization requires a stable identifier and preserves state', () => {
+  const payment = sanitizePayment({
+    checking_id: 'checking-1',
+    payment_hash: 'hash-1',
+    id: 'legacy-1',
+    pending: true,
+    amount: -20,
+    fee: -1,
+    memo: 'thank you',
+    time: 123,
+    wallet_id: 'wallet-1',
+    extra: { adminkey: 'secret', recipientUserId: 'recipient-1' },
+  });
+
+  assert.deepEqual(payment, {
+    checking_id: 'checking-1',
+    payment_hash: 'hash-1',
+    pending: true,
+    amount: -20,
+    fee: -1,
+    memo: 'thank you',
+    time: 123,
+    wallet_id: 'wallet-1',
+    extra: { recipientUserId: 'recipient-1' },
+  });
+});
+
+test('payment serialization falls back to payment hash and legacy id', () => {
+  assert.equal(
+    sanitizePayment({ payment_hash: 'hash-1' }).checking_id,
+    'hash-1',
+  );
+  assert.equal(sanitizePayment({ id: 'legacy-1' }).checking_id, 'legacy-1');
+});
+
+test('payment serialization rejects records without a stable identifier', () => {
+  assert.throws(
+    () => sanitizePayment({ amount: 20 }),
+    /missing a stable identifier/,
+  );
+  assert.throws(
+    () => sanitizePayment({ checking_id: 'x'.repeat(257) }),
+    /missing a stable identifier/,
+  );
+});
+
 test('invoice creation returns the exact stable invoice identifier', async (t) => {
   const originalFetch = global.fetch;
   const originalEnvironment = {


### PR DESCRIPTION
Fixes #329

Part of splitting #287 into reviewable layers. Stacked on the sign-in state PR.

## What changed
- The LNbits gateway rejects payment records that lack a stable identifier: `sanitizePayment` now requires one of `checking_id`/`payment_hash`/`id` (string, ≤256 chars) and throws instead of serialising an empty `checking_id`.
- Keeps the `pending`-derived-from-`status` handling for LNbits v1 payloads that dropped the boolean `pending` field.

## Why
Downstream zap matching keys on `checking_id`; an empty identifier silently corrupted history matching.

## Test plan for QA
- `npm run test:backend` (tabs): new tests for identifier fallback order, rejection without a stable id, oversized ids, and status-derived pending.