### PR TITLE
fix: validate portal API responses

### DIFF
--- a/tabs/src/apiService.test.tsx
+++ b/tabs/src/apiService.test.tsx
@@ -1,0 +1,131 @@
+import axios from 'axios';
+import {
+  getAutomations,
+  getRewardAmounts,
+  getRewardName,
+  updateAutomations,
+  updateRewardAmounts,
+  updateRewardName,
+} from './apiService';
+
+jest.mock('axios');
+
+const mockGet = jest.mocked(axios.get);
+const mockPost = jest.mocked(axios.post);
+
+describe('reward name API', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('returns a trimmed non-empty reward name', async () => {
+    mockGet.mockResolvedValue({ data: { rewardName: '  Sats  ' } });
+
+    await expect(getRewardName()).resolves.toEqual({ rewardName: 'Sats' });
+  });
+
+  test.each([
+    undefined,
+    null,
+    {},
+    { rewardName: '' },
+    { rewardName: '   ' },
+    { rewardName: 20 },
+  ])('rejects an invalid reward name response: %p', async data => {
+    mockGet.mockResolvedValue({ data });
+
+    await expect(getRewardName()).rejects.toThrow(
+      'The reward name response was invalid.',
+    );
+  });
+
+  test('normalizes writes and validates the server response', async () => {
+    mockPost.mockResolvedValue({ data: { rewardName: 'Points' } });
+
+    await expect(updateRewardName('id-token', '  Points  ')).resolves.toEqual({
+      rewardName: 'Points',
+    });
+    expect(mockPost).toHaveBeenCalledWith(
+      '/api/reward-name',
+      { newRewardName: 'Points' },
+      { headers: { Authorization: 'Bearer id-token' } },
+    );
+  });
+
+  test('does not send an empty reward name', async () => {
+    await expect(updateRewardName('id-token', '   ')).rejects.toThrow(
+      'The reward name cannot be empty.',
+    );
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+});
+
+describe('reward amounts API', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('returns validated reward amounts on read and write', async () => {
+    const rewardAmounts = { pr_merged: 100, issue_closed: 50 };
+    mockGet.mockResolvedValue({ data: { rewardAmounts } });
+    mockPost.mockResolvedValue({ data: { message: 'ok', rewardAmounts } });
+
+    await expect(getRewardAmounts('id-token')).resolves.toEqual({
+      rewardAmounts,
+    });
+    await expect(
+      updateRewardAmounts('id-token', rewardAmounts),
+    ).resolves.toEqual({ rewardAmounts });
+  });
+
+  test.each([
+    undefined,
+    null,
+    {},
+    { rewardAmounts: null },
+    { rewardAmounts: [100] },
+    { rewardAmounts: { pr_merged: 'lots' } },
+    { rewardAmounts: { pr_merged: Number.NaN } },
+  ])('rejects an invalid reward amounts response: %p', async data => {
+    mockGet.mockResolvedValue({ data });
+
+    await expect(getRewardAmounts('id-token')).rejects.toThrow(
+      'The reward amounts response was invalid.',
+    );
+  });
+});
+
+describe('automations API', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('returns the validated repository list on read and write', async () => {
+    mockGet.mockResolvedValue({ data: { repos: ['owner/repo'] } });
+    mockPost.mockResolvedValue({
+      data: { message: 'ok', repos: ['owner/repo'] },
+    });
+
+    await expect(getAutomations('id-token')).resolves.toEqual({
+      repos: ['owner/repo'],
+    });
+    await expect(
+      updateAutomations('id-token', ['owner/repo']),
+    ).resolves.toEqual({ repos: ['owner/repo'] });
+  });
+
+  test.each([
+    undefined,
+    null,
+    {},
+    { repos: 'owner/repo' },
+    { repos: [''] },
+    { repos: [42] },
+  ])('rejects an invalid automations response: %p', async data => {
+    mockGet.mockResolvedValue({ data });
+
+    await expect(getAutomations('id-token')).rejects.toThrow(
+      'The automations response was invalid.',
+    );
+  });
+});

--- a/tabs/src/apiService.tsx
+++ b/tabs/src/apiService.tsx
@@ -1,100 +1,140 @@
-// filepath: /c:/projects/ZapVibes/tabs/src/apiService.tsx
 import axios from 'axios';
 
 const API_URL = '/api';
 
-export const getRewardName = async () => {
-  try {
-    console.log('Fetching reward name');
-    const response = await axios.get(`${API_URL}/reward-name`);
-    return response.data;
-  } catch (error) {
-    console.error('Error fetching reward name:', error);
-    throw error;
+export interface RewardNameResponse {
+  rewardName: string;
+}
+
+const parseRewardNameResponse = (data: unknown): RewardNameResponse => {
+  if (!data || typeof data !== 'object') {
+    throw new Error('The reward name response was invalid.');
   }
+
+  const rewardName = (data as { rewardName?: unknown }).rewardName;
+  if (typeof rewardName !== 'string' || !rewardName.trim()) {
+    throw new Error('The reward name response was invalid.');
+  }
+
+  return { rewardName: rewardName.trim() };
+};
+
+export const getRewardName = async (): Promise<RewardNameResponse> => {
+  const response = await axios.get(`${API_URL}/reward-name`);
+  return parseRewardNameResponse(response.data);
 };
 
 export const updateRewardName = async (
   idToken: string,
   newRewardName: string,
-) => {
-  try {
-    const response = await axios.post(
-      `${API_URL}/reward-name`,
-      { newRewardName },
-      {
-        headers: {
-          Authorization: `Bearer ${idToken}`,
-        },
+): Promise<RewardNameResponse> => {
+  const normalizedRewardName = newRewardName.trim();
+  if (!normalizedRewardName) {
+    throw new Error('The reward name cannot be empty.');
+  }
+
+  const response = await axios.post(
+    `${API_URL}/reward-name`,
+    { newRewardName: normalizedRewardName },
+    {
+      headers: {
+        Authorization: `Bearer ${idToken}`,
       },
-    );
-    return response.data;
-  } catch (error) {
-    console.error('Error updating reward name:', error);
-    throw error;
-  }
-};
-export const getRewardAmounts = async (idToken: string) => {
-  try {
-    const response = await axios.get(`${API_URL}/reward-amounts`, {
-      headers: { Authorization: `Bearer ${idToken}` },
-    });
-    return response.data;
-  } catch (error) {
-    console.error('Error fetching reward amounts:', error);
-    throw error;
-  }
+    },
+  );
+  return parseRewardNameResponse(response.data);
 };
 
-// Config writes authenticate with the caller's MSAL idToken; the backend
-// requires the Zaplie.Admin app role carried in its roles claim.
+export interface RewardAmountsResponse {
+  rewardAmounts: Record<string, number>;
+}
+
+export interface AutomationsResponse {
+  repos: string[];
+}
+
+const parseRewardAmountsResponse = (data: unknown): RewardAmountsResponse => {
+  if (!data || typeof data !== 'object') {
+    throw new Error('The reward amounts response was invalid.');
+  }
+
+  const rewardAmounts = (data as { rewardAmounts?: unknown }).rewardAmounts;
+  if (
+    !rewardAmounts ||
+    typeof rewardAmounts !== 'object' ||
+    Array.isArray(rewardAmounts) ||
+    !Object.values(rewardAmounts).every(
+      value => typeof value === 'number' && Number.isFinite(value),
+    )
+  ) {
+    throw new Error('The reward amounts response was invalid.');
+  }
+
+  return { rewardAmounts: rewardAmounts as Record<string, number> };
+};
+
+const parseAutomationsResponse = (data: unknown): AutomationsResponse => {
+  if (!data || typeof data !== 'object') {
+    throw new Error('The automations response was invalid.');
+  }
+
+  const repos = (data as { repos?: unknown }).repos;
+  if (
+    !Array.isArray(repos) ||
+    !repos.every(repo => typeof repo === 'string' && repo.length > 0)
+  ) {
+    throw new Error('The automations response was invalid.');
+  }
+
+  return { repos };
+};
+
+export const getRewardAmounts = async (
+  idToken: string,
+): Promise<RewardAmountsResponse> => {
+  const response = await axios.get(`${API_URL}/reward-amounts`, {
+    headers: { Authorization: `Bearer ${idToken}` },
+  });
+  return parseRewardAmountsResponse(response.data);
+};
+
 export const updateRewardAmounts = async (
   idToken: string,
   rewardAmounts: Record<string, number>,
-) => {
-  try {
-    const response = await axios.post(
-      `${API_URL}/reward-amounts`,
-      { rewardAmounts },
-      {
-        headers: {
-          Authorization: `Bearer ${idToken}`,
-        },
+): Promise<RewardAmountsResponse> => {
+  const response = await axios.post(
+    `${API_URL}/reward-amounts`,
+    { rewardAmounts },
+    {
+      headers: {
+        Authorization: `Bearer ${idToken}`,
       },
-    );
-    return response.data;
-  } catch (error) {
-    console.error('Error updating reward amounts:', error);
-    throw error;
-  }
+    },
+  );
+  return parseRewardAmountsResponse(response.data);
 };
 
-export const getAutomations = async (idToken: string) => {
-  try {
-    const response = await axios.get(`${API_URL}/automations`, {
-      headers: { Authorization: `Bearer ${idToken}` },
-    });
-    return response.data;
-  } catch (error) {
-    console.error('Error fetching automations:', error);
-    throw error;
-  }
+export const getAutomations = async (
+  idToken: string,
+): Promise<AutomationsResponse> => {
+  const response = await axios.get(`${API_URL}/automations`, {
+    headers: { Authorization: `Bearer ${idToken}` },
+  });
+  return parseAutomationsResponse(response.data);
 };
 
-export const updateAutomations = async (idToken: string, repos: string[]) => {
-  try {
-    const response = await axios.post(
-      `${API_URL}/automations`,
-      { repos },
-      {
-        headers: {
-          Authorization: `Bearer ${idToken}`,
-        },
+export const updateAutomations = async (
+  idToken: string,
+  repos: string[],
+): Promise<AutomationsResponse> => {
+  const response = await axios.post(
+    `${API_URL}/automations`,
+    { repos },
+    {
+      headers: {
+        Authorization: `Bearer ${idToken}`,
       },
-    );
-    return response.data;
-  } catch (error) {
-    console.error('Error updating automations:', error);
-    throw error;
-  }
+    },
+  );
+  return parseAutomationsResponse(response.data);
 };

--- a/tabs/src/components/RewardNameContext.test.tsx
+++ b/tabs/src/components/RewardNameContext.test.tsx
@@ -1,0 +1,127 @@
+import React, { act, useContext } from 'react';
+import { createRoot, Root } from 'react-dom/client';
+import { RewardNameContext, RewardNameProvider } from './RewardNameContext';
+
+const mockGetRewardName = jest.fn();
+
+jest.mock('../apiService', () => ({
+  getRewardName: () => mockGetRewardName(),
+}));
+
+const Consumer = () => {
+  const { rewardName, isLoading, error, retry } = useContext(RewardNameContext);
+
+  return (
+    <div>
+      <span data-testid="child">Portal content</span>
+      <span data-testid="reward-name">{rewardName ?? ''}</span>
+      <span data-testid="loading">{isLoading ? 'loading' : 'ready'}</span>
+      {error ? <span role="alert">{error.message}</span> : null}
+      <button type="button" onClick={retry}>
+        Retry
+      </button>
+    </div>
+  );
+};
+
+let container: HTMLDivElement;
+let root: Root;
+
+const mountProvider = () => {
+  root.render(
+    <RewardNameProvider>
+      <Consumer />
+    </RewardNameProvider>,
+  );
+};
+
+const renderProvider = async () => {
+  await act(async () => {
+    mountProvider();
+  });
+};
+
+const settle = async () => {
+  await act(async () => {
+    await new Promise(resolve => setTimeout(resolve, 0));
+  });
+};
+
+const eventually = async (assertion: () => void) => {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await settle();
+    }
+  }
+  throw lastError;
+};
+
+describe('RewardNameProvider', () => {
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    jest.clearAllMocks();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  test('keeps portal content mounted while the reward name loads', async () => {
+    mockGetRewardName.mockReturnValue(new Promise(() => undefined));
+
+    await renderProvider();
+
+    expect(container.querySelector('[data-testid="child"]')?.textContent).toBe(
+      'Portal content',
+    );
+    expect(
+      container.querySelector('[data-testid="loading"]')?.textContent,
+    ).toBe('loading');
+    expect(
+      container.querySelector('[data-testid="reward-name"]')?.textContent,
+    ).toBe('');
+  });
+
+  test('exposes a failed request and retries it without inventing a value', async () => {
+    mockGetRewardName
+      .mockRejectedValueOnce(new Error('Configuration unavailable'))
+      .mockResolvedValueOnce({ rewardName: 'Sats' });
+
+    await renderProvider();
+    await eventually(() => {
+      expect(container.querySelector('[role="alert"]')?.textContent).toBe(
+        'Configuration unavailable',
+      );
+    });
+    expect(
+      container.querySelector('[data-testid="reward-name"]')?.textContent,
+    ).toBe('');
+
+    await act(async () => {
+      const retryButton = container.querySelector('button');
+      if (!retryButton) throw new Error('Retry button was not rendered.');
+      retryButton.click();
+    });
+
+    await eventually(() => {
+      expect(
+        container.querySelector('[data-testid="reward-name"]')?.textContent,
+      ).toBe('Sats');
+    });
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+    expect(mockGetRewardName).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tabs/src/components/RewardNameContext.tsx
+++ b/tabs/src/components/RewardNameContext.tsx
@@ -1,42 +1,80 @@
-import React, { createContext, useState, useEffect, ReactNode } from 'react';
+import React, {
+  createContext,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  ReactNode,
+} from 'react';
 import { getRewardName } from '../apiService';
 
 interface RewardNameContextProps {
   rewardName: string | null;
-  setRewardName: React.Dispatch<React.SetStateAction<string>>;
+  setRewardName: React.Dispatch<React.SetStateAction<string | null>>;
+  isLoading?: boolean;
+  error?: Error | null;
+  retry?: () => void;
 }
 
-// Create the context
 export const RewardNameContext = createContext<RewardNameContextProps>({
   rewardName: null,
   setRewardName: () => {},
+  isLoading: true,
+  error: null,
+  retry: () => {},
 });
 
 export const RewardNameProvider: React.FC<{ children: ReactNode }> = ({
   children,
 }) => {
-  const [rewardName, setRewardName] = useState<string>('');
+  const [rewardName, setRewardName] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const requestIdRef = useRef(0);
 
-  useEffect(() => {
-    const fetchRewardName = async () => {
-      try {
-        const data = await getRewardName();
-        console.log('Fetched Reward Name:', data); // Debugging log
-        setRewardName(data?.rewardName || 'sats'); // Fallback in case of missing data
-      } catch (error) {
-        console.error('Error fetching reward name:', error);
+  const loadRewardName = useCallback(async () => {
+    const requestId = ++requestIdRef.current;
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const data = await getRewardName();
+      if (requestId === requestIdRef.current) {
+        setRewardName(data.rewardName);
       }
-    };
-
-    fetchRewardName();
+    } catch (loadError) {
+      if (requestId === requestIdRef.current) {
+        setError(
+          loadError instanceof Error
+            ? loadError
+            : new Error('The reward name could not be loaded.'),
+        );
+      }
+    } finally {
+      if (requestId === requestIdRef.current) {
+        setIsLoading(false);
+      }
+    }
   }, []);
 
-  if (!rewardName) {
-    return null; // Return null if rewardName is not set yet
-  }
+  useEffect(() => {
+    void loadRewardName();
+
+    return () => {
+      requestIdRef.current += 1;
+    };
+  }, [loadRewardName]);
 
   return (
-    <RewardNameContext.Provider value={{ rewardName, setRewardName }}>
+    <RewardNameContext.Provider
+      value={{
+        rewardName,
+        setRewardName,
+        isLoading,
+        error,
+        retry: loadRewardName,
+      }}
+    >
       {children}
     </RewardNameContext.Provider>
   );

--- a/tabs/src/components/RewardsNameSetting.test.tsx
+++ b/tabs/src/components/RewardsNameSetting.test.tsx
@@ -1,0 +1,193 @@
+import React, { act } from 'react';
+import { createRoot, Root } from 'react-dom/client';
+import CurrencySetting from './RewardsNameSetting';
+import { RewardNameContext } from './RewardNameContext';
+
+const mockUseMsal = jest.fn();
+const mockAcquireIdToken = jest.fn();
+const mockUpdateRewardName = jest.fn();
+const mockToastSuccess = jest.fn();
+const mockToastError = jest.fn();
+
+jest.mock('@azure/msal-react', () => ({
+  useMsal: () => mockUseMsal(),
+}));
+
+jest.mock('../services/adminRole', () => ({
+  acquireIdToken: () => mockAcquireIdToken(),
+  isZaplieAdmin: () => true,
+}));
+
+jest.mock('../apiService', () => ({
+  updateRewardName: (idToken: string, rewardName: string) =>
+    mockUpdateRewardName(idToken, rewardName),
+}));
+
+jest.mock('react-toastify', () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+let container: HTMLDivElement;
+let root: Root;
+
+const mountSetting = (value: React.ContextType<typeof RewardNameContext>) => {
+  root.render(
+    <RewardNameContext.Provider value={value}>
+      <CurrencySetting />
+    </RewardNameContext.Provider>,
+  );
+};
+
+const renderSetting = async (
+  value: React.ContextType<typeof RewardNameContext>,
+) => {
+  await act(async () => {
+    mountSetting(value);
+  });
+};
+
+const settle = async () => {
+  await act(async () => {
+    await new Promise(resolve => setTimeout(resolve, 0));
+  });
+};
+
+const eventually = async (assertion: () => void) => {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await settle();
+    }
+  }
+  throw lastError;
+};
+
+const getButton = (label: string) => {
+  const button = Array.from(container.querySelectorAll('button')).find(
+    candidate => candidate.textContent?.trim() === label,
+  );
+  if (!button) throw new Error(`Button "${label}" was not rendered.`);
+  return button;
+};
+
+const setInputValue = (input: HTMLInputElement, value: string) => {
+  const setter = Object.getOwnPropertyDescriptor(
+    HTMLInputElement.prototype,
+    'value',
+  )?.set;
+  if (!setter) throw new Error('The input value setter is unavailable.');
+  setter.call(input, value);
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+};
+
+describe('RewardsNameSetting', () => {
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    jest.clearAllMocks();
+    mockAcquireIdToken.mockResolvedValue('id-token');
+    mockUseMsal.mockReturnValue({
+      instance: {},
+      accounts: [{ localAccountId: 'aad-1' }],
+    });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  test('shows the configuration failure and exposes retry', async () => {
+    const retry = jest.fn();
+
+    await renderSetting({
+      rewardName: null,
+      setRewardName: jest.fn(),
+      isLoading: false,
+      error: new Error('Configuration unavailable'),
+      retry,
+    });
+
+    expect(container.querySelector('[role="alert"]')?.textContent).toBe(
+      "We couldn't load the current reward name.",
+    );
+    await act(async () => {
+      getButton('Try again').click();
+    });
+    expect(retry).toHaveBeenCalledTimes(1);
+  });
+
+  test('normalizes and saves an admin edit into shared context', async () => {
+    const setRewardName = jest.fn();
+    mockUpdateRewardName.mockResolvedValue({ rewardName: 'Points' });
+
+    await renderSetting({
+      rewardName: 'Sats',
+      setRewardName,
+      isLoading: false,
+      error: null,
+      retry: jest.fn(),
+    });
+
+    await act(async () => {
+      getButton('Edit').click();
+    });
+    const input = container.querySelector('input');
+    if (!input) throw new Error('Reward name input was not rendered.');
+    await act(async () => {
+      setInputValue(input, '  Points  ');
+    });
+    await act(async () => {
+      getButton('Save').click();
+    });
+
+    await eventually(() => {
+      expect(mockUpdateRewardName).toHaveBeenCalledWith('id-token', 'Points');
+    });
+    expect(setRewardName).toHaveBeenCalledWith('Points');
+    expect(container.querySelector('[role="status"]')?.textContent).toBe(
+      'Reward name saved.',
+    );
+  });
+
+  test('keeps a failed save visible and editable', async () => {
+    mockUpdateRewardName.mockRejectedValue(new Error('backend unavailable'));
+
+    await renderSetting({
+      rewardName: 'Sats',
+      setRewardName: jest.fn(),
+      isLoading: false,
+      error: null,
+      retry: jest.fn(),
+    });
+
+    await act(async () => {
+      getButton('Edit').click();
+    });
+    await act(async () => {
+      getButton('Save').click();
+    });
+    await eventually(() => {
+      expect(container.querySelector('[role="alert"]')?.textContent).toBe(
+        "We couldn't save the reward name. Try again.",
+      );
+    });
+    expect(
+      (container.querySelector('input') as HTMLInputElement).disabled,
+    ).toBe(false);
+    expect(mockToastError).toHaveBeenCalledWith('Error updating reward name.');
+  });
+});

--- a/tabs/src/components/RewardsNameSetting.tsx
+++ b/tabs/src/components/RewardsNameSetting.tsx
@@ -1,4 +1,3 @@
-// filepath: /c:/projects/ZapVibes/tabs/src/components/RewardsNameSetting.tsx
 import React, {
   FunctionComponent,
   useState,
@@ -6,7 +5,7 @@ import React, {
   useContext,
 } from 'react';
 import styles from './setting.module.css';
-import { getRewardName, updateRewardName } from '../apiService';
+import { updateRewardName } from '../apiService';
 import { toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import { RewardNameContext } from './RewardNameContext';
@@ -15,30 +14,42 @@ import { acquireIdToken, isZaplieAdmin } from '../services/adminRole';
 
 const CurrencySetting: FunctionComponent = () => {
   const [isEditing, setIsEditing] = useState(false);
-  const [currency, setCurrency] = useState(''); // Default value
-  const { setRewardName } = useContext(RewardNameContext);
+  const [currency, setCurrency] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [justSaved, setJustSaved] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const {
+    rewardName,
+    setRewardName,
+    isLoading = false,
+    error: loadError = null,
+    retry,
+  } = useContext(RewardNameContext);
   const { instance, accounts } = useMsal();
   const isAdmin = isZaplieAdmin(accounts[0]);
 
   useEffect(() => {
-    const fetchRewardName = async () => {
-      try {
-        const data = await getRewardName();
-        setCurrency(data.rewardName);
-      } catch (error) {
-        console.error('Error fetching reward name:', error);
-      }
-    };
-
-    fetchRewardName();
-  }, []);
+    if (rewardName !== null) {
+      setCurrency(rewardName);
+    }
+  }, [rewardName]);
 
   const handleEditClick = () => {
+    setJustSaved(false);
+    setSaveError(null);
     setIsEditing(true);
   };
 
   const handleSaveClick = async () => {
-    setIsEditing(false);
+    const normalizedRewardName = currency.trim();
+    if (!normalizedRewardName) {
+      setSaveError('Enter a reward name before saving.');
+      return;
+    }
+
+    setSaving(true);
+    setSaveError(null);
+    setJustSaved(false);
     try {
       const account = accounts[0];
       if (!account) {
@@ -46,42 +57,129 @@ const CurrencySetting: FunctionComponent = () => {
       }
       const data = await updateRewardName(
         await acquireIdToken(instance, account),
-        currency,
+        normalizedRewardName,
       );
-      console.log('Reward name saved:', data.rewardName);
-      setRewardName(data.rewardName); // Update the context
+      setCurrency(data.rewardName);
+      setRewardName(data.rewardName);
+      setIsEditing(false);
+      setJustSaved(true);
       toast.success('Reward name has been updated successfully!');
-    } catch (error) {
-      console.error('Error updating reward name:', error);
+    } catch {
+      setSaveError("We couldn't save the reward name. Try again.");
       toast.error('Error updating reward name.');
+    } finally {
+      setSaving(false);
     }
   };
 
   return (
-    <div className={styles.currencySetting}>
-      <label className={styles.label}>Reward Name</label>
-      <div className={styles.inputGroup}>
-        <input
-          type="text"
-          value={currency}
-          onChange={e => setCurrency(e.target.value)}
-          disabled={!isEditing}
-          className={`${styles.textBox} ${isEditing ? styles.editing : ''}`}
-          title="Reward name"
-          placeholder="Enter currency"
-        />
-        {isAdmin &&
-          (!isEditing ? (
-            <button onClick={handleEditClick} className={styles.editButton}>
-              Edit
-            </button>
-          ) : (
-            <button onClick={handleSaveClick} className={styles.saveButton}>
-              Save
-            </button>
-          ))}
+    <section className={styles.section} aria-labelledby="rewards-heading">
+      <div className={styles.sectionHeader}>
+        <h2 id="rewards-heading" className={styles.heading}>
+          Rewards
+        </h2>
+        <p className={styles.intro}>
+          Choose what reward points are called across Zaplie.
+        </p>
       </div>
-    </div>
+
+      <div className={styles.card} aria-busy={isLoading || saving}>
+        <label className={styles.fieldLabel} htmlFor="reward-name-input">
+          Reward name
+        </label>
+
+        {isLoading && rewardName === null ? (
+          <>
+            <span className={styles.inputSkeleton} aria-hidden="true" />
+            <span className={styles.visuallyHidden} role="status">
+              Loading reward name…
+            </span>
+          </>
+        ) : rewardName !== null ? (
+          <div className={styles.inputRow}>
+            <input
+              id="reward-name-input"
+              type="text"
+              value={currency}
+              onChange={event => {
+                setCurrency(event.target.value);
+                setSaveError(null);
+                setJustSaved(false);
+              }}
+              disabled={!isEditing || saving}
+              className={`${styles.textBox} ${isEditing ? styles.editing : ''}`}
+              title="Reward name"
+              placeholder="Enter reward name"
+              aria-invalid={saveError ? 'true' : undefined}
+            />
+            {isAdmin &&
+              (saving ? (
+                <button
+                  type="button"
+                  disabled
+                  aria-busy="true"
+                  className={styles.primaryButton}
+                >
+                  Saving…
+                </button>
+              ) : !isEditing ? (
+                <button
+                  type="button"
+                  onClick={handleEditClick}
+                  className={styles.secondaryButton}
+                >
+                  Edit
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  onClick={handleSaveClick}
+                  className={styles.primaryButton}
+                  disabled={saving}
+                >
+                  Save
+                </button>
+              ))}
+          </div>
+        ) : null}
+
+        {loadError ? (
+          <>
+            <p className={styles.errorText} role="alert">
+              We couldn't load the current reward name.
+            </p>
+            {retry ? (
+              <button
+                type="button"
+                onClick={retry}
+                className={styles.secondaryButton}
+                disabled={isLoading}
+              >
+                Try again
+              </button>
+            ) : null}
+          </>
+        ) : null}
+
+        {saveError ? (
+          <p className={styles.errorText} role="alert">
+            {saveError}
+          </p>
+        ) : null}
+
+        {justSaved && !isEditing && !saving ? (
+          <p className={styles.successText} role="status">
+            Reward name saved.
+          </p>
+        ) : null}
+
+        {!isAdmin && !isLoading && rewardName !== null ? (
+          <p className={styles.helperText}>
+            Only Zaplie admins can change the reward name.
+          </p>
+        ) : null}
+      </div>
+    </section>
   );
 };
 

--- a/tabs/src/components/setting.module.css
+++ b/tabs/src/components/setting.module.css
@@ -118,3 +118,179 @@
 .saveButton:hover {
   background-color: #6ba513;
 }
+
+.section {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.sectionHeader {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.heading {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: var(--font-size-md);
+  font-weight: 700;
+  line-height: 1.3;
+}
+
+.intro {
+  max-width: 62ch;
+  margin: 0;
+  color: var(--text-muted);
+  font-size: var(--font-size-sm);
+  line-height: 1.5;
+}
+
+.card {
+  width: 100%;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-2);
+  padding: var(--space-4);
+  background-color: var(--surface-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  box-shadow:
+    0px 1px 2px rgba(0, 0, 0, 0.14),
+    0px 0px 1px rgba(0, 0, 0, 0.12);
+}
+
+.fieldLabel {
+  color: var(--text-muted);
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  line-height: 1.4;
+}
+
+.inputRow {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.primaryButton,
+.secondaryButton {
+  width: auto;
+  flex: none;
+  min-width: 96px;
+  padding: 9px var(--space-4);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-family-base);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  line-height: 1.2;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.primaryButton {
+  border: 1px solid transparent;
+  background-color: var(--accent);
+  color: var(--accent-contrast);
+}
+
+.primaryButton:hover:enabled {
+  background-color: var(--accent-hover);
+}
+
+.primaryButton:disabled {
+  opacity: 0.65;
+  cursor: progress;
+}
+
+.secondaryButton {
+  border: 1px solid var(--border);
+  background-color: transparent;
+  color: var(--accent);
+}
+
+.secondaryButton:hover {
+  background-color: var(--surface-page);
+  border-color: var(--accent);
+}
+
+.primaryButton:focus-visible,
+.secondaryButton:focus-visible {
+  outline: 2px solid var(--text-primary);
+  outline-offset: 2px;
+}
+
+.inputSkeleton {
+  display: block;
+  width: 100%;
+  max-width: 360px;
+  height: 40px;
+  border-radius: var(--radius-sm);
+  background-color: var(--border);
+  animation: settingPulse 1.4s ease-in-out infinite;
+}
+
+.errorText {
+  margin: 0;
+  color: var(--danger);
+  font-size: var(--font-size-sm);
+  line-height: 1.45;
+}
+
+.successText {
+  margin: 0;
+  color: var(--accent);
+  font-size: var(--font-size-sm);
+  line-height: 1.45;
+}
+
+.helperText {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: var(--font-size-sm);
+  line-height: 1.45;
+}
+
+.visuallyHidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@keyframes settingPulse {
+  0%,
+  100% {
+    opacity: 0.5;
+  }
+
+  50% {
+    opacity: 0.9;
+  }
+}
+
+@media (max-width: 480px) {
+  .primaryButton,
+  .secondaryButton {
+    width: 100%;
+    flex: 1 1 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .inputSkeleton {
+    animation: none;
+    opacity: 0.7;
+  }
+}

--- a/tabs/src/index.tsx
+++ b/tabs/src/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import './styles/tokens.css';
 import {
   EventType,
   EventMessage,

--- a/tabs/src/services/automationsStatsService.ts
+++ b/tabs/src/services/automationsStatsService.ts
@@ -28,6 +28,92 @@ export interface AutomationsStats {
   recentPayments: AutomationHistoryItem[];
 }
 
+const isFiniteNumber = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value);
+
+const isNullableString = (value: unknown): value is string | null =>
+  value === null || typeof value === 'string';
+
+const isAudience = (value: unknown): value is AutomationAudience =>
+  value === 'teammates' || value === 'copilots' || value === 'customers';
+
+const isRecipient = (value: unknown): value is AutomationRecipient => {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const candidate = value as Partial<AutomationRecipient>;
+  return (
+    typeof candidate.id === 'string' &&
+    typeof candidate.displayName === 'string' &&
+    isAudience(candidate.audience) &&
+    isFiniteNumber(candidate.paymentCount) &&
+    isFiniteNumber(candidate.paidSats) &&
+    isNullableString(candidate.lastPaidAt)
+  );
+};
+
+const isHistoryItem = (value: unknown): value is AutomationHistoryItem => {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const candidate = value as Partial<AutomationHistoryItem>;
+  const recipient = candidate.recipient;
+  return (
+    typeof candidate.id === 'string' &&
+    isFiniteNumber(candidate.amountSats) &&
+    typeof candidate.memo === 'string' &&
+    typeof candidate.source === 'string' &&
+    isNullableString(candidate.paidAt) &&
+    Boolean(recipient) &&
+    typeof recipient?.id === 'string' &&
+    typeof recipient.displayName === 'string' &&
+    isAudience(recipient.audience)
+  );
+};
+
+const isNumberRecord = (value: unknown): value is Record<string, number> =>
+  Boolean(value) &&
+  typeof value === 'object' &&
+  !Array.isArray(value) &&
+  Object.values(value as Record<string, unknown>).every(isFiniteNumber);
+
+export const parseAutomationsStats = (value: unknown): AutomationsStats => {
+  if (!value || typeof value !== 'object') {
+    throw new Error('Automations stats response is malformed.');
+  }
+
+  const candidate = value as Partial<AutomationsStats>;
+  const engagement = candidate.engagementByAudience;
+  const audiences: AutomationAudience[] = [
+    'teammates',
+    'copilots',
+    'customers',
+  ];
+  const validEngagement =
+    engagement &&
+    audiences.every(
+      audience =>
+        Array.isArray(engagement[audience]) &&
+        engagement[audience].every(isRecipient),
+    );
+  const validHistory =
+    Array.isArray(candidate.recentPayments) &&
+    candidate.recentPayments.every(isHistoryItem);
+
+  if (
+    !isFiniteNumber(candidate.paidSatsThisMonth) ||
+    !isFiniteNumber(candidate.paymentsThisMonth) ||
+    !isNumberRecord(candidate.runsByEventType) ||
+    !validEngagement ||
+    !validHistory
+  ) {
+    throw new Error('Automations stats response is malformed.');
+  }
+
+  return candidate as AutomationsStats;
+};
+
 // idToken (not the Graph access token): its audience is this app's own AAD
 // client id, which is what the tab backend validates against the Entra JWKS.
 export const getAutomationsStats = async (
@@ -36,5 +122,5 @@ export const getAutomationsStats = async (
   const response = await axios.get('/api/automations-stats', {
     headers: { Authorization: `Bearer ${idToken}` },
   });
-  return response.data;
+  return parseAutomationsStats(response.data);
 };

--- a/tabs/src/services/reportsService.ts
+++ b/tabs/src/services/reportsService.ts
@@ -10,11 +10,40 @@ export interface ReportsData {
   totalAutomatedCount: number;
 }
 
+const isFiniteNumber = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value);
+
+export const parseReportsData = (value: unknown): ReportsData => {
+  if (!value || typeof value !== 'object') {
+    throw new Error('Reports response is malformed.');
+  }
+
+  const candidate = value as Partial<ReportsData>;
+  const hasNumberSeries = (series: unknown): series is number[] =>
+    Array.isArray(series) && series.every(isFiniteNumber);
+
+  if (
+    !Number.isInteger(candidate.weeks) ||
+    !hasNumberSeries(candidate.zapsWeekly) ||
+    !hasNumberSeries(candidate.automationWeekly) ||
+    candidate.zapsWeekly.length !== candidate.weeks ||
+    candidate.automationWeekly.length !== candidate.weeks ||
+    !isFiniteNumber(candidate.totalZapSats) ||
+    !isFiniteNumber(candidate.totalZapCount) ||
+    !isFiniteNumber(candidate.totalAutomatedSats) ||
+    !isFiniteNumber(candidate.totalAutomatedCount)
+  ) {
+    throw new Error('Reports response is malformed.');
+  }
+
+  return candidate as ReportsData;
+};
+
 // idToken (not the Graph access token): its audience is this app's own AAD
 // client id, which is what the tab backend validates against the Entra JWKS.
 export const getReports = async (idToken: string): Promise<ReportsData> => {
   const response = await axios.get('/api/reports', {
     headers: { Authorization: `Bearer ${idToken}` },
   });
-  return response.data;
+  return parseReportsData(response.data);
 };

--- a/tabs/src/services/serviceContracts.test.ts
+++ b/tabs/src/services/serviceContracts.test.ts
@@ -1,0 +1,53 @@
+import { parseAutomationsStats } from './automationsStatsService';
+import { parseReportsData } from './reportsService';
+import { parseCreatedWebhookKey, parseWebhookKeys } from './webhookKeysService';
+
+describe('service response contracts', () => {
+  test('rejects malformed reports instead of passing undefined series to charts', () => {
+    expect(() => parseReportsData({})).toThrow(
+      'Reports response is malformed.',
+    );
+    expect(() =>
+      parseReportsData({
+        weeks: 2,
+        zapsWeekly: [10],
+        automationWeekly: [5, 8],
+        totalZapSats: 10,
+        totalZapCount: 1,
+        totalAutomatedSats: 13,
+        totalAutomatedCount: 2,
+      }),
+    ).toThrow('Reports response is malformed.');
+  });
+
+  test('rejects missing automation arrays before rendering filters', () => {
+    expect(() => parseAutomationsStats({})).toThrow(
+      'Automations stats response is malformed.',
+    );
+    expect(() =>
+      parseAutomationsStats({
+        paidSatsThisMonth: 1,
+        paymentsThisMonth: 1,
+        runsByEventType: { pull_request: '1' },
+        engagementByAudience: {
+          teammates: [],
+          copilots: [],
+          customers: [],
+        },
+        recentPayments: [],
+      }),
+    ).toThrow('Automations stats response is malformed.');
+  });
+
+  test('rejects a webhook response without a keys array', () => {
+    expect(() => parseWebhookKeys({})).toThrow(
+      'Webhook keys response is malformed.',
+    );
+    expect(() => parseWebhookKeys({ keys: [{}] })).toThrow(
+      'Webhook keys response is malformed.',
+    );
+    expect(() => parseCreatedWebhookKey({ id: 'key-id' })).toThrow(
+      'Created webhook key response is malformed.',
+    );
+  });
+});

--- a/tabs/src/services/webhookKeysService.ts
+++ b/tabs/src/services/webhookKeysService.ts
@@ -10,6 +10,52 @@ export interface WebhookKey {
   revokedAt: string | null;
 }
 
+interface CreatedWebhookKey {
+  key: string;
+  id: string;
+}
+
+const isWebhookKey = (value: unknown): value is WebhookKey => {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const candidate = value as Partial<WebhookKey>;
+  return (
+    typeof candidate.id === 'string' &&
+    typeof candidate.label === 'string' &&
+    typeof candidate.last4 === 'string' &&
+    typeof candidate.createdAt === 'string' &&
+    (candidate.revokedAt === null || typeof candidate.revokedAt === 'string')
+  );
+};
+
+export const parseWebhookKeys = (value: unknown): WebhookKey[] => {
+  if (!value || typeof value !== 'object') {
+    throw new Error('Webhook keys response is malformed.');
+  }
+
+  const keys = (value as { keys?: unknown }).keys;
+  if (!Array.isArray(keys) || !keys.every(isWebhookKey)) {
+    throw new Error('Webhook keys response is malformed.');
+  }
+
+  return keys;
+};
+
+export const parseCreatedWebhookKey = (value: unknown): CreatedWebhookKey => {
+  if (!value || typeof value !== 'object') {
+    throw new Error('Created webhook key response is malformed.');
+  }
+
+  const candidate = value as Partial<CreatedWebhookKey>;
+  if (typeof candidate.key !== 'string' || typeof candidate.id !== 'string') {
+    throw new Error('Created webhook key response is malformed.');
+  }
+
+  return { key: candidate.key, id: candidate.id };
+};
+
 // idToken (not the Graph access token): its audience is this app's own AAD
 // client id, which is what the tab backend validates against the Entra JWKS.
 export const getWebhookKeys = async (
@@ -18,19 +64,19 @@ export const getWebhookKeys = async (
   const response = await axios.get(API_URL, {
     headers: { Authorization: `Bearer ${idToken}` },
   });
-  return response.data.keys;
+  return parseWebhookKeys(response.data);
 };
 
 export const createWebhookKey = async (
   idToken: string,
   label: string,
-): Promise<{ key: string; id: string }> => {
+): Promise<CreatedWebhookKey> => {
   const response = await axios.post(
     API_URL,
     { label },
     { headers: { Authorization: `Bearer ${idToken}` } },
   );
-  return response.data;
+  return parseCreatedWebhookKey(response.data);
 };
 
 export const revokeWebhookKey = async (

--- a/tabs/src/styles/tokens.css
+++ b/tabs/src/styles/tokens.css
@@ -1,0 +1,42 @@
+:root {
+  --surface-page: #1f1f1f;
+  --surface-card: #212121;
+  --surface-raised: #2d2b2c;
+
+  --text-primary: #ffffff;
+  --text-body: #d8d8d8;
+  --text-muted: #9a9a9a;
+
+  --accent: #84cc16;
+  --accent-hover: #65a30d;
+  --accent-deep: #5a9311;
+  --accent-contrast: #1f1f1f;
+
+  --link: #5b5fc7;
+  --danger: #ff6b6b;
+  --border: #424242;
+
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 16px;
+  --radius-full: 100px;
+
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-6: 24px;
+  --space-8: 32px;
+
+  --font-family-base:
+    'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto',
+    'Helvetica Neue', sans-serif;
+  --font-size-xs: 10px;
+  --font-size-sm: 12px;
+  --font-size-md: 14px;
+  --font-size-lg: 18px;
+  --font-size-xl: 24px;
+  --font-size-hero: 48px;
+
+  --content-max-width: 1200px;
+}


### PR DESCRIPTION
Part of splitting #287 into reviewable layers. Stacked on the payment identifier PR.

## What changed
- Service boundaries validate what the portal API actually returned instead of trusting casts: `reportsService`, `automationsStatsService`, `webhookKeysService` and every `apiService` endpoint (reward name, reward amounts, automations) get strict parsers that throw on malformed payloads.
- `RewardNameContext` exposes `isLoading`/`error`/`retry` (optional, non-breaking) so consumers can render explicit states instead of a null reward name; `RewardsNameSetting` is rebuilt on those states.
- Introduces `tabs/src/styles/tokens.css` (design tokens) plus the `setting.module.css` classes the rebuilt `RewardsNameSetting` renders with, so this PR is fully self-contained.

## Test plan for QA
- `npm test` (tabs): new `serviceContracts.test.ts` and extended `apiService.test.tsx` cover each parser's accept/reject paths; `RewardNameContext.test.tsx` covers the loading/error/retry lifecycle.
