### PR TITLE
fix: make portal account state fail closed

### DIFF
--- a/tabs/src/Rewards.tsx
+++ b/tabs/src/Rewards.tsx
@@ -19,7 +19,7 @@ const Rewards: React.FC = () => {
           paddingTop: 0,
         }}
       >
-        <RewardsComponent userId={'2984e3ac627e4fea9fd6dde9c4df83b5'} />
+        <RewardsComponent />
       </div>
     </div>
   );

--- a/tabs/src/components/PurchasePopup.module.css
+++ b/tabs/src/components/PurchasePopup.module.css
@@ -4,129 +4,120 @@
   left: 0;
   width: 100%;
   height: 100%;
-  background: rgba(0, 0, 0, 0.5);
+  background: rgba(0, 0, 0, 0.55);
   display: flex;
   justify-content: center;
   align-items: center;
+  padding: var(--space-4);
+  box-sizing: border-box;
+  z-index: 1000;
 }
 
 .popup {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: space-between;
-  padding: 26px 32px 32px;
-  gap: 20px;
+  padding: var(--space-6) var(--space-8) var(--space-8);
+  gap: var(--space-4);
   position: relative;
-  width: 348px;
-  height: 225px;
-  background: #2d2b2c;
+  width: min(400px, 100%);
+  background: var(--surface-raised);
   box-shadow:
     0px 0px 8px rgba(0, 0, 0, 0.12),
     0px 14px 250px rgba(0, 0, 0, 0.14);
-  border-radius: 4px;
+  border-radius: var(--radius-md);
+  box-sizing: border-box;
+  font-family: var(--font-family-base);
 }
 
 .title {
-  width: 284px;
-  height: 24px;
-  font-family: 'Segoe UI';
-  font-style: normal;
+  align-self: stretch;
   font-weight: 700;
-  font-size: 18px;
+  font-size: var(--font-size-lg);
   line-height: 24px;
   text-align: center;
-  color: #ffffff;
-  flex: none;
-  order: 0;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.message {
   align-self: stretch;
-  flex-grow: 0;
-  margin: 0px;
+  font-weight: 400;
+  font-size: var(--font-size-md);
+  line-height: 20px;
+  text-align: center;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.error {
+  margin: 0;
+  color: var(--danger);
+  text-align: center;
 }
 
 .buttonContainer {
   display: flex;
-  gap: 10px;
+  justify-content: center;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+  margin-top: var(--space-2);
 }
 
 .closeButton {
   box-sizing: border-box;
-  display: flex;
+  display: inline-flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  padding: 0px;
-  width: 96px;
+  min-width: 96px;
   height: 38px;
-  border: 1px solid #84cc16;
-  border-radius: 4px;
-  flex: none;
-  order: 0;
-  flex-grow: 0;
+  padding: 0 var(--space-4);
+  border: 1px solid var(--accent);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  font-family: var(--font-family-base);
+  font-weight: 600;
+  font-size: var(--font-size-sm);
+  color: var(--accent);
+  cursor: pointer;
+}
+
+.closeButton:hover {
+  background-color: rgba(132, 204, 22, 0.12);
 }
 
 .buyButton {
-  display: flex;
+  display: inline-flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  padding: 0px;
-  width: 96px;
+  min-width: 96px;
   height: 38px;
-  background: #84cc16;
-  border-radius: 4px;
-  flex: none;
-  order: 1;
-  flex-grow: 0;
+  padding: 0 var(--space-4);
+  background: var(--accent);
+  border: none;
+  border-radius: var(--radius-sm);
+  font-family: var(--font-family-base);
+  font-weight: 600;
+  font-size: var(--font-size-sm);
+  color: var(--accent-contrast);
+  cursor: pointer;
 }
 
-.buyButtonDisabled {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  padding: 0px;
-  width: 96px;
-  height: 38px;
-  background: #1f1f1f;
-  border-radius: 4px;
-  flex: none;
-  order: 1;
-  flex-grow: 0;
-  cursor: not-allowed;
-  pointer-events: none;
+.buyButton:hover {
+  background-color: var(--accent-hover);
 }
 
-.qrContainer {
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: flex-start;
-  padding: 11px 13px;
-  gap: 8px;
-  width: 234px;
-  height: 232px;
-  background: #ffffff;
-  border: 1px solid #f5f5f5;
-  border-radius: 24px;
-  flex: none;
-  order: 0;
-  flex-grow: 0;
+.closeButton:focus-visible,
+.buyButton:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
-.message {
-  width: 284px;
-  height: 20px;
-  font-family: 'Segoe UI';
-  font-style: normal;
-  font-weight: 400;
-  font-size: 14px;
-  line-height: 20px;
-  padding: 0px 0px;
-  text-align: center !important;
-  color: #d8d8d8;
-  flex: none;
-  order: 0;
-  align-self: stretch;
-  flex-grow: 0;
+@media (prefers-reduced-motion: no-preference) {
+  .closeButton,
+  .buyButton {
+    transition: background-color 0.15s ease;
+  }
 }

--- a/tabs/src/components/PurchasePopup.tsx
+++ b/tabs/src/components/PurchasePopup.tsx
@@ -1,76 +1,77 @@
-import React, { useEffect, useContext } from 'react';
+import React, { useContext, useState } from 'react';
 import styles from './PurchasePopup.module.css';
-
 import { RewardNameContext } from './RewardNameContext';
 
 interface PurchasePopupProps {
   onClose: () => void;
-  wallet: Wallet;
   hasEnoughSats: boolean;
   reward: Reward;
 }
 
 const PurchasePopup: React.FC<PurchasePopupProps> = ({
   onClose,
-  wallet,
   hasEnoughSats,
   reward,
 }) => {
-  const storeOwnerEmail = process.env.REACT_APP_LNBITS_STORE_OWNER_EMAIL;
-  console.log('Store Owner Email:', storeOwnerEmail);
+  const { rewardName } = useContext(RewardNameContext);
+  const [error, setError] = useState<string | null>(null);
+  const storeOwnerEmail =
+    process.env.REACT_APP_LNBITS_STORE_OWNER_EMAIL?.trim();
 
-  const handleOverlayClick = () => {
-    onClose();
-  };
-
-  const handlePopupClick = (e: React.MouseEvent) => {
-    e.stopPropagation();
-  };
-
-  const handleConfirmClick = () => {
-    if (storeOwnerEmail) {
-      const subject = encodeURIComponent(
-        `REWARD PURCHASE REQUEST: ${reward.name}`,
-      );
-      window.location.href = `mailto:${storeOwnerEmail}?subject=${subject}`;
-    } else {
-      console.error('Store owner email is not defined.');
+  const requestReward = () => {
+    if (!rewardName) {
+      setError('The reward name is unavailable. Try again later.');
+      return;
     }
-    onClose();
+
+    if (!storeOwnerEmail) {
+      setError('Reward requests are not configured for this environment.');
+      return;
+    }
+
+    const subject = encodeURIComponent(`REWARD REQUEST: ${reward.name}`);
+    const body = encodeURIComponent(
+      `I would like to request ${reward.name} (${reward.price} ${rewardName}).`,
+    );
+    window.location.assign(
+      `mailto:${storeOwnerEmail}?subject=${subject}&body=${body}`,
+    );
   };
-
-  const rewardNameContext = useContext(RewardNameContext);
-  const rewardsName = rewardNameContext?.rewardName || '';
-
-  // Log wallet ID and balance to the console
-  useEffect(() => {
-    console.log('Wallet ID:', wallet.id);
-    console.log('Balance:', wallet.balance_msat / 1000, rewardsName);
-  }, [wallet, rewardsName]);
-
-  if (!rewardNameContext) {
-    return null; // or handle the case where the context is not available
-  }
-
-  const message = hasEnoughSats
-    ? `Please confirm you would like to purchase this reward.`
-    : `D'oh! You do not have enough ${rewardsName} to redeem this reward yet.`;
 
   return (
-    <div className={styles.overlay} onClick={handleOverlayClick}>
-      <div className={styles.popup} onClick={handlePopupClick}>
-        <p className={styles.title}>
-          {hasEnoughSats ? 'Confirmation' : 'Oops!'}
+    <div
+      className={styles.overlay}
+      onClick={event => event.target === event.currentTarget && onClose()}
+    >
+      <div className={styles.popup} role="dialog" aria-modal="true">
+        <h2 className={styles.title}>
+          {hasEnoughSats ? 'Request reward' : 'Not enough balance'}
+        </h2>
+        <p className={styles.message}>
+          {hasEnoughSats
+            ? 'This sends a request to the rewards administrator. Your balance is not charged by this action.'
+            : 'You do not have enough balance to request this reward.'}
         </p>
-        <p className={styles.message}>{message}</p>{' '}
-        {/* Display the message based on the boolean value */}
+        {error && (
+          <p role="alert" className={styles.error}>
+            {error}
+          </p>
+        )}
         <div className={styles.buttonContainer}>
-          <button className={styles.closeButton} onClick={onClose}>
+          <button
+            type="button"
+            className={styles.closeButton}
+            onClick={onClose}
+          >
             {hasEnoughSats ? 'Cancel' : 'Close'}
           </button>
           {hasEnoughSats && (
-            <button onClick={handleConfirmClick} className={styles.buyButton}>
-              Confirm
+            <button
+              type="button"
+              onClick={requestReward}
+              className={styles.buyButton}
+            >
+              Email request
             </button>
           )}
         </div>

--- a/tabs/src/components/RewardsComponent.module.css
+++ b/tabs/src/components/RewardsComponent.module.css
@@ -1,208 +1,187 @@
 .mainContainer {
-  width: 1052px;
-  height: 565px;
+  width: 100%;
+  max-width: var(--content-max-width);
   position: relative;
   margin-left: auto;
   margin-right: auto;
-  border: 20px solid rgba(31, 31, 31, 1);
-  border-top: 0px;
   box-shadow:
     0px 1px 2px rgba(0, 0, 0, 0.14),
     0px 0px 1px rgba(0, 0, 0, 0.12);
-  border-radius: 4px;
-  background-color: #2d2b2c;
+  border-radius: var(--radius-md);
+  background-color: var(--surface-raised);
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
+  align-items: stretch;
   justify-content: flex-start;
-  padding: 20px;
+  padding: var(--space-6) var(--space-4);
   box-sizing: border-box;
-  gap: 20px;
+  gap: var(--space-4);
   text-align: left;
-  font-size: 12px;
-  color: #d6d6d6;
-  font-family: Inter;
-  user-select: none;
-  flex-direction: column;
-  align-items: flex-start;
-  justify-content: flex-start;
+  font-size: var(--font-size-sm);
+  color: var(--text-body);
+  font-family: var(--font-family-base);
 }
 
 .title {
-  width: 278px;
-  height: 17px;
-  font-family: 'Inter';
-  font-style: normal;
   font-weight: 700;
-  font-size: 14px;
-  line-height: 17px;
-  color: #ffffff;
-  flex: none;
-  order: 0;
+  font-size: var(--font-size-lg);
+  line-height: 24px;
+  color: var(--text-primary);
   align-self: stretch;
-  flex-grow: 0;
-  z-index: 0;
-  user-select: none;
 }
 
-.carousel {
-  display: flex;
-  overflow-x: auto;
-  gap: 10px;
+.rewardGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(260px, 100%), 1fr));
+  gap: var(--space-4);
   width: 100%;
-  height: 100%;
-  scroll-behavior: smooth;
-  padding-bottom: 20px;
-  scrollbar-width: thin;
-  scrollbar-color: #444 transparent;
-  margin-left: 0px;
-  padding-left: 0;
-  user-select: none;
-}
-
-/* For WebKit browsers (Chrome, Safari, etc.) */
-.carousel::-webkit-scrollbar {
-  height: 8px;
-  border-radius: 10px;
-}
-
-.carousel::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-.carousel::-webkit-scrollbar-thumb {
-  background-color: #444;
-  border-radius: 10px;
-  border: 2px solid transparent;
-}
-
-.carousel::-webkit-scrollbar-thumb:hover {
-  background-color: #555;
-}
-
-.carousel::-webkit-scrollbar-thumb:active {
-  background-color: #666;
+  min-width: 0;
 }
 
 .card {
-  width: 336px;
-  height: 100%;
-  background-color: rgba(31, 31, 31, 1);
-  border-radius: 4px;
-  padding: 0px;
+  min-width: 0;
+  background-color: var(--surface-page);
+  border-radius: var(--radius-md);
+  overflow: hidden;
   box-sizing: border-box;
-  flex-shrink: 0;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
-  user-select: none;
-}
-
-.cardImage {
-  width: 100%;
-  height: 130px;
-  object-fit: cover;
-  border-top-left-radius: 4px;
-  border-top-right-radius: 4px;
 }
 
 .cardTitle {
-  padding-left: 20px;
-  padding-right: 20px;
-  height: 40px;
+  padding: 0 var(--space-4);
+  margin: var(--space-3) 0 0;
+  min-height: 40px;
+  font-size: 16px;
+  font-weight: 700;
+  line-height: 22px;
+  color: var(--text-primary);
 }
 
 .cardDescription {
-  padding-left: 20px;
-  padding-right: 20px;
-  margin-top: 10px;
-  height: 60px;
+  padding: 0 var(--space-4);
+  margin: var(--space-2) 0 0;
+  min-height: 54px;
+  color: var(--text-muted);
+  font-size: var(--font-size-sm);
+  line-height: 18px;
 }
 
 .productDetails {
-  color: rgba(91, 95, 199, 1);
+  appearance: none;
+  background: none;
+  border: none;
+  text-align: left;
+  align-self: flex-start;
+  color: var(--link);
   cursor: pointer;
-  font-weight: 600;
-  user-select: none;
-  padding-left: 20px;
-  padding-right: 20px;
-  margin-top: 0px;
-  height: 20px;
+  font-family: var(--font-family-base);
+  font-size: var(--font-size-sm);
+  font-weight: 700;
+  padding: 0 var(--space-4);
+  margin: var(--space-2) 0 0;
 }
 
-.longDescription {
-  color: #d6d6d6;
-  margin-top: 10px;
-  padding-left: 20px;
-  padding-right: 20px;
-  height: 60px;
+.productDetails:hover {
+  text-decoration: underline;
+}
+
+.productDetails:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 .priceContainer {
   display: flex;
   justify-content: center;
-  align-items: center;
-  margin-top: 0px;
-  gap: 10px;
-  padding-left: 20px;
-  padding-right: 20px;
-  height: 40px;
+  align-items: baseline;
+  gap: var(--space-2);
+  padding: 0 var(--space-4);
+  margin-top: auto;
+  padding-top: var(--space-4);
 }
 
 .price {
-  color: #d6d6d6;
+  color: var(--text-primary);
   font-weight: 700;
-  font-size: 24px;
-  display: flex;
-  align-items: center;
+  font-size: var(--font-size-xl);
+  line-height: 30px;
+  margin: 0;
 }
 
 .sats {
-  color: #d6d6d6;
-  font-weight: normal;
-  font-size: 12px;
-  display: flex;
-  align-items: center;
+  color: var(--text-muted);
+  font-weight: 400;
+  font-size: var(--font-size-sm);
+  margin: 0;
 }
 
 .buyButton {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  padding: 0px;
-  font-family: 'Inter';
-  width: 128px;
-  height: 38px;
-  background: #84cc16;
-  border-radius: 4px;
-  flex: none;
-  order: 2;
-  flex-grow: 0;
-  cursor: pointer;
-  border: none;
-  margin-top: 20px;
   display: block;
-  margin-left: auto;
-  margin-right: auto;
-  margin-bottom: 20px;
-  font-size: 16px;
+  width: 80%;
+  height: 38px;
+  margin: var(--space-4) auto var(--space-4);
+  padding: 0;
+  background: var(--accent);
+  border: none;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-family: var(--font-family-base);
+  font-size: var(--font-size-md);
   font-weight: 600;
   text-align: center;
+  color: var(--accent-contrast);
+}
+
+.buyButton:hover {
+  background-color: var(--accent-hover);
+}
+
+.buyButton:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .buyButton,
+  .productDetails {
+    transition:
+      background-color 0.15s ease,
+      color 0.15s ease;
+  }
 }
 
 .rewardImage {
   width: 100%;
   height: 160px;
   object-fit: cover;
-  margin-bottom: 10px;
-  border-top-left-radius: 4px;
-  border-top-right-radius: 4px;
-  transition: height 0.3s ease;
-  max-height: 160px;
-  min-height: 160px;
+  margin-bottom: var(--space-2);
+  border-top-left-radius: var(--radius-md);
+  border-top-right-radius: var(--radius-md);
 }
 
 .noPointer {
   cursor: default;
+  width: 100%;
+  box-sizing: border-box;
+  padding: var(--space-6);
+  background-color: var(--surface-page);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  font-size: var(--font-size-md);
+  text-align: center;
+}
+
+.error {
+  margin: 0;
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid var(--danger);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+}
+
+@media (max-width: 480px) {
+  .mainContainer {
+    padding: var(--space-4) var(--space-3);
+  }
 }

--- a/tabs/src/components/RewardsComponent.test.tsx
+++ b/tabs/src/components/RewardsComponent.test.tsx
@@ -3,6 +3,10 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import RewardsComponent from './RewardsComponent';
 import { RewardNameContext } from './RewardNameContext';
 
+jest.mock('@azure/msal-react', () => ({
+  useMsal: () => ({ accounts: [] }),
+}));
+
 jest.mock('../services/lnbitsServiceLocal', () => ({
   getNostrRewards: jest.fn(),
   getUserWallets: jest.fn(),
@@ -14,11 +18,11 @@ describe('RewardsComponent', () => {
       <RewardNameContext.Provider
         value={{ rewardName: 'sats', setRewardName: jest.fn() }}
       >
-        <RewardsComponent userId="test-user" />
+        <RewardsComponent />
       </RewardNameContext.Provider>,
     );
 
-    expect(view).toMatch(/>\s*Rewards\s*<\/div>/);
+    expect(view).toMatch(/>\s*Rewards\s*<\/h1>/);
     expect(view).not.toContain('Provided By');
   });
 });

--- a/tabs/src/components/RewardsComponent.tsx
+++ b/tabs/src/components/RewardsComponent.tsx
@@ -1,175 +1,186 @@
 import React, {
   FunctionComponent,
-  useState,
-  useEffect,
-  useRef,
+  useCallback,
   useContext,
+  useEffect,
+  useState,
 } from 'react';
+import { useMsal } from '@azure/msal-react';
 import styles from './RewardsComponent.module.css';
 import {
   getNostrRewards,
+  getUsers,
   getUserWallets,
 } from '../services/lnbitsServiceLocal';
 import PurchasePopup from './PurchasePopup';
 import imagePlaceholder from '../images/imagePlaceholderNew.svg';
 import { RewardNameContext } from './RewardNameContext';
 
-const stallID = process.env.REACT_APP_LNBITS_STORE_ID as string;
+const storeId = process.env.REACT_APP_LNBITS_STORE_ID?.trim();
 
-const RewardsComponent: FunctionComponent<{
-  userId: string;
-}> = ({ userId }) => {
-  const [rewards, setRewards] = useState<Reward[]>([]); // Initialize as an empty array
-  const [isDragging, setIsDragging] = useState(false);
-  const [startPosition, setStartPosition] = useState(0);
-  const [scrollPosition, setScrollPosition] = useState(0);
-  const [showPopup, setShowPopup] = useState(false); // State to manage popup visibility
-  const [selectedReward, setSelectedReward] = useState<Reward | null>(null); // State to store the selected reward
-  const [userWallet, setUserWallet] = useState<Wallet | null>(null); // State to store the user's wallet
-  const [hasEnoughSats, setHasEnoughSats] = useState<boolean>(false); // State to store if user has enough Sats
-  const carouselRef = useRef<HTMLDivElement>(null);
+const safeProductUrl = (value: string): string | null => {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:'
+      ? url.toString()
+      : null;
+  } catch {
+    return null;
+  }
+};
 
-  useEffect(() => {
-    const fetchRewards = async () => {
-      const stallId = stallID;
+const RewardsComponent: FunctionComponent = () => {
+  const { accounts } = useMsal();
+  const { rewardName } = useContext(RewardNameContext);
+  const [rewards, setRewards] = useState<Reward[]>([]);
+  const [selectedReward, setSelectedReward] = useState<Reward | null>(null);
+  const [hasEnoughSats, setHasEnoughSats] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
-      try {
-        const rewardsData = await getNostrRewards(stallId);
+  const loadRewards = useCallback(async () => {
+    if (!storeId) {
+      setError('Rewards are not configured for this environment.');
+      setLoading(false);
+      return;
+    }
 
-        if (!rewardsData) {
-          throw new Error('No data returned from API');
-        }
-
-        setRewards(rewardsData);
-      } catch (error) {
-        console.error('Error fetching rewards:', error);
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await getNostrRewards(storeId);
+      if (!Array.isArray(response)) {
+        throw new Error('The rewards service returned an invalid response.');
       }
-    };
-
-    fetchRewards();
+      setRewards(response);
+    } catch (loadError) {
+      setError(
+        loadError instanceof Error
+          ? loadError.message
+          : 'Rewards are unavailable.',
+      );
+    } finally {
+      setLoading(false);
+    }
   }, []);
 
-  const handleMouseDown = (e: React.MouseEvent) => {
-    if (carouselRef.current) {
-      setIsDragging(true);
-      setStartPosition(e.pageX - carouselRef.current.offsetLeft);
-      setScrollPosition(carouselRef.current.scrollLeft);
-    }
-  };
+  useEffect(() => {
+    void loadRewards();
+  }, [loadRewards]);
 
-  const handleMouseMove = (e: React.MouseEvent) => {
-    if (isDragging && carouselRef.current) {
-      const x = e.pageX - carouselRef.current.offsetLeft;
-      const walk = (x - startPosition) * 1; // Scrolling speed factor
-      carouselRef.current.scrollLeft = scrollPosition - walk;
-    }
-  };
+  const handleRequestClick = async (price: number, reward: Reward) => {
+    setError(null);
 
-  const handleMouseUp = () => {
-    setIsDragging(false);
-  };
-
-  const handleProductDetailsClick = (url: string) => {
-    window.open(url, '_blank');
-  };
-
-  const formatPrice = (price: number) => {
-    return new Intl.NumberFormat('en-US').format(price);
-  };
-
-  const handleBuyClick = async (price: number, reward: Reward) => {
     try {
-      const wallets = await getUserWallets(userId);
-      console.log('wallets:-', wallets);
-      const privateWallet = wallets?.find(wallet => wallet.name === 'Private');
-      console.log('privateWallet:-', privateWallet);
-      if (privateWallet) {
-        setUserWallet(privateWallet);
-        setHasEnoughSats(privateWallet.balance_msat / 1000 >= price);
-        setSelectedReward(reward);
-        setShowPopup(true);
-      } else {
-        console.error('No private wallet found for the user');
+      const aadObjectId = accounts[0]?.localAccountId;
+      if (!aadObjectId) throw new Error('Sign in to request a reward.');
+
+      const users = await getUsers({ aadObjectId });
+      const matchingUsers = users.filter(
+        user => user.aadObjectId === aadObjectId,
+      );
+      if (matchingUsers.length !== 1) {
+        throw new Error("We couldn't match your signed-in account to Zaplie.");
       }
-    } catch (error) {
-      console.error('Error fetching user wallet:', error);
+
+      const currentUser = matchingUsers[0];
+      const wallets = await getUserWallets(currentUser.id);
+      const privateWallets = wallets.filter(
+        wallet => wallet.name.trim().toLowerCase() === 'private',
+      );
+      if (privateWallets.length !== 1) {
+        throw new Error('Your Private wallet is unavailable.');
+      }
+
+      const privateWallet = privateWallets[0];
+      if (!Number.isFinite(privateWallet.balance_msat)) {
+        throw new Error('Your Private wallet balance is unavailable.');
+      }
+
+      setHasEnoughSats(privateWallet.balance_msat / 1000 >= price);
+      setSelectedReward(reward);
+    } catch (requestError) {
+      setError(
+        requestError instanceof Error
+          ? requestError.message
+          : 'Unable to check reward eligibility.',
+      );
     }
   };
 
-  const handleClosePopup = () => {
-    setShowPopup(false);
-  };
-
-  const rewardNameContext = useContext(RewardNameContext);
-  const rewardName = rewardNameContext.rewardName;
-
-  // Only render rewards if they exist
   return (
-    <div className={styles.mainContainer}>
-      <div className={styles.title}>Rewards</div>
-      <div
-        className={styles.carousel}
-        ref={carouselRef}
-        onMouseDown={handleMouseDown}
-        onMouseMove={handleMouseMove}
-        onMouseUp={handleMouseUp}
-        onMouseLeave={handleMouseUp}
-        style={{ cursor: isDragging ? 'grabbing' : 'grab' }}
-      >
-        {rewards.length > 0 ? ( // Check if rewards array has elements
-          rewards.map(reward => (
-            <div key={reward.id} className={styles.card}>
-              <img
-                src={
-                  reward.image && reward.image.length > 0
-                    ? reward.image
-                    : imagePlaceholder
-                }
-                alt={reward.name}
-                className={styles.rewardImage}
-                style={{ height: '160px' }} // Fixed height
-              />
-              <h3 className={styles.cardTitle}>{reward.name}</h3>
-              <p className={styles.cardDescription}>
-                {reward.shortDescription.length > 140
-                  ? `${reward.shortDescription.substring(0, 140)}...`
-                  : reward.shortDescription}
-              </p>
-              {reward.link && reward.link.length > 0 && (
-                <p
-                  className={styles.productDetails}
-                  onClick={() => handleProductDetailsClick(reward.link)}
-                >
-                  Product details
+    <section className={styles.mainContainer} aria-busy={loading}>
+      <h1 className={styles.title}>Rewards</h1>
+      {error && (
+        <div className={styles.error} role="alert">
+          <span>{error}</span>
+          {storeId && (
+            <button type="button" onClick={() => void loadRewards()}>
+              Try again
+            </button>
+          )}
+        </div>
+      )}
+      {loading ? (
+        <p className={styles.noPointer}>Loading rewards…</p>
+      ) : rewards.length ? (
+        <div className={styles.rewardGrid}>
+          {rewards.map(reward => {
+            const productUrl = reward.link ? safeProductUrl(reward.link) : null;
+            return (
+              <article key={reward.id} className={styles.card}>
+                <img
+                  src={reward.image || imagePlaceholder}
+                  alt=""
+                  className={styles.rewardImage}
+                  draggable={false}
+                />
+                <h2 className={styles.cardTitle}>{reward.name}</h2>
+                <p className={styles.cardDescription}>
+                  {reward.shortDescription.length > 140
+                    ? `${reward.shortDescription.slice(0, 140)}…`
+                    : reward.shortDescription}
                 </p>
-              )}
-
-              <div className={styles.priceContainer}>
-                <p className={styles.price}>{formatPrice(reward.price)}</p>
-                <p className={styles.sats}>{rewardName}</p>
-              </div>
-              <button
-                className={styles.buyButton}
-                onClick={() => handleBuyClick(reward.price, reward)}
-              >
-                Buy
-              </button>
-            </div>
-          ))
-        ) : (
-          <p className={styles.noPointer}>No rewards available</p>
-        )}
-      </div>
-      {showPopup && userWallet && selectedReward && (
+                {productUrl && (
+                  <a
+                    className={styles.productDetails}
+                    href={productUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    Product details
+                  </a>
+                )}
+                <div className={styles.priceContainer}>
+                  <p className={styles.price}>
+                    {new Intl.NumberFormat('en-US').format(reward.price)}
+                  </p>
+                  <p className={styles.sats}>{rewardName}</p>
+                </div>
+                <button
+                  type="button"
+                  className={styles.buyButton}
+                  onClick={() => void handleRequestClick(reward.price, reward)}
+                  aria-label={`Request ${reward.name}`}
+                  disabled={!rewardName}
+                >
+                  {rewardName ? 'Request reward' : 'Reward name unavailable'}
+                </button>
+              </article>
+            );
+          })}
+        </div>
+      ) : !error ? (
+        <p className={styles.noPointer}>No rewards are available.</p>
+      ) : null}
+      {selectedReward && (
         <PurchasePopup
-          onClose={handleClosePopup}
-          wallet={userWallet}
+          onClose={() => setSelectedReward(null)}
           hasEnoughSats={hasEnoughSats}
           reward={selectedReward}
         />
-      )}{' '}
-      {/* Render popup if showPopup is true and userWallet is available */}
-    </div>
+      )}
+    </section>
   );
 };
 

--- a/tabs/src/components/UserListComponent.module.css
+++ b/tabs/src/components/UserListComponent.module.css
@@ -1,216 +1,191 @@
-.users {
-  align-self: stretch;
+.userslist {
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
   position: relative;
+  box-shadow:
+    0px 1px 2px rgba(0, 0, 0, 0.14),
+    0px 0px 1px rgba(0, 0, 0, 0.12);
+  border-radius: var(--radius-md);
+  background-color: var(--surface-raised);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  padding: var(--space-6) var(--space-6) var(--space-4);
+  box-sizing: border-box;
+  gap: var(--space-4);
+  text-align: left;
+  color: var(--text-primary);
+  font-family: var(--font-family-base);
+}
+
+.users {
+  margin: 0;
+  align-self: stretch;
+  font-size: var(--font-size-lg);
+  font-weight: 700;
+  color: var(--text-primary);
   text-transform: capitalize;
 }
-.stringTabTitle {
-  position: relative;
-  line-height: 20px;
-}
-.stringBadgeIconStack {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: center;
-}
-.borderBottom {
-  flex: 1;
-  position: relative;
-  border-radius: 2px 2px 0px 0px;
-  background-color: #5b5fc7;
-  height: 2px;
-  overflow: hidden;
-}
-.borderPaddingStack {
-  align-self: stretch;
-  overflow: hidden;
-  display: flex;
-  flex-direction: row;
-  align-items: flex-start;
-  justify-content: flex-start;
-}
-.base {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  justify-content: flex-start;
-  padding: 3px 0px 0px;
-  gap: 17px;
-}
-.tab {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  justify-content: flex-start;
-}
-.base1 {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  justify-content: flex-start;
-  padding: 3px 0px 0px;
-}
+
 .tabs {
   align-self: stretch;
-  border-bottom: 1px solid #1f1f1f;
+  border-bottom: 1px solid var(--border);
   display: flex;
   flex-direction: row;
-  align-items: flex-start;
-  justify-content: flex-start;
-  gap: 16px;
-  font-size: 14px;
-  color: #d8d8d8;
+  align-items: flex-end;
+  gap: var(--space-4);
+  font-size: var(--font-size-md);
+  color: var(--text-body);
 }
-.string {
-  width: 364px;
+
+.tab {
   position: relative;
-  line-height: 16px;
-  display: flex;
-  align-items: center;
-  flex-shrink: 0;
+  padding: var(--space-1) 0 var(--space-2);
+  line-height: 20px;
 }
-.string1 {
-  width: 198px;
-  position: relative;
-  display: flex;
-  align-items: center;
-  flex-shrink: 0;
+
+.tabActive {
+  color: var(--text-primary);
+  font-weight: 700;
 }
-.string2 {
-  width: 182px;
-  position: relative;
-  display: flex;
-  align-items: center;
-  flex-shrink: 0;
+
+.tabActive::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -1px;
+  height: 3px;
+  border-radius: 2px 2px 0 0;
+  background-color: var(--accent);
 }
-.string3 {
-  position: relative;
-  line-height: 16px;
-}
-.stringParent {
-  width: 844px;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: flex-start;
-  gap: 10px;
-}
-.headerContents {
-  flex: 1;
-  height: 32px;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: flex-start;
-  padding: 0px 10px;
-  box-sizing: border-box;
-}
-.headercell {
+
+.tableScroll {
   align-self: stretch;
-  background-color: #1f1f1f;
-  display: flex;
-  flex-direction: row;
-  align-items: flex-start;
-  justify-content: flex-start;
-  color: #d8d8d8;
+  width: 100%;
+  min-width: 0;
 }
-.avatarIcon {
-  width: 24px;
-  position: relative;
-  height: 24px;
-  object-fit: cover;
-}
-.userName {
-  flex: 1;
-  position: relative;
-}
-.personDetails {
-  flex: 1;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: flex-start;
-  gap: 10px;
-}
-.totalBalance {
-  width: 123px;
-  position: relative;
-  display: inline-block;
-  flex-shrink: 0;
-}
-.totalBalance1 {
-  width: 123px;
-  position: relative;
-  line-height: 10px;
-  display: inline-block;
-  color: #5b5fc7;
-  text-align: right;
-  flex-shrink: 0;
-}
-.totalBalance2 {
-  width: 103px;
-  position: relative;
-  line-height: 10px;
-  display: inline-block;
-  color: #5b5fc7;
-  text-align: right;
-  flex-shrink: 0;
-}
-.mainContentStack {
-  width: 844px;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: flex-start;
-  gap: 60px;
-}
-.actions {
-  align-self: stretch;
-  width: 40px;
-}
-.bodyContents {
-  flex: 1;
-  background-color: #1f1f1f;
-  height: 44px;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: space-between;
-  padding: 10px;
-  box-sizing: border-box;
-}
-.bodycell {
-  align-self: stretch;
-  height: 44px;
-  display: flex;
-  flex-direction: row;
-  align-items: flex-start;
-  justify-content: flex-start;
-}
-.bodyContents3 {
-  flex: 1;
-  background-color: #1f1f1f;
-  height: 44px;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: space-between;
-  padding: 10px;
-  box-sizing: border-box;
-  cursor: pointer;
-}
+
 .list {
+  min-width: 640px;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  font-size: var(--font-size-sm);
+}
+
+.headerRow,
+.bodyRow {
+  display: grid;
+  grid-template-columns:
+    minmax(220px, 1.6fr) minmax(110px, 0.8fr) minmax(130px, 1fr)
+    minmax(160px, 1fr);
+  column-gap: var(--space-3);
+  align-items: center;
+  padding: 0 var(--space-3);
+  background-color: var(--surface-page);
+}
+
+.headerRow {
+  min-height: 32px;
+  color: var(--text-muted);
+  font-weight: 700;
+  border-radius: var(--radius-sm) var(--radius-sm) 0 0;
+}
+
+.bodyRow {
+  min-height: 44px;
+  color: var(--text-body);
+}
+
+.bodyRow:hover {
+  background-color: #262626;
+}
+
+.bodyRow:last-child {
+  border-radius: 0 0 var(--radius-sm) var(--radius-sm);
+}
+
+.colUser {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  min-width: 0;
+}
+
+.colType,
+.colBalance,
+.colAllowance {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.avatarIcon {
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-full);
+  object-fit: cover;
+  flex-shrink: 0;
+  background-color: var(--border);
+}
+
+.userName {
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.amount {
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.amountMuted {
+  font-weight: 400;
+  color: var(--text-muted);
+}
+
+.stateMessage {
+  padding: var(--space-6);
+  font-family: var(--font-family-base);
+  font-size: var(--font-size-md);
+  color: var(--text-muted);
+}
+
+.stateError {
+  padding: var(--space-6);
+  font-family: var(--font-family-base);
+  font-size: var(--font-size-md);
+  color: var(--danger);
+}
+
+.poweredby {
   align-self: stretch;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  justify-content: flex-start;
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+}
+
+.poweredBy {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
   justify-content: flex-start;
-  gap: 1px;
-  font-size: 12px;
+  gap: var(--space-1);
 }
+
 .poweredBy1 {
   position: relative;
 }
+
 .logo1Icon {
   width: 80.4px;
   position: relative;
@@ -218,39 +193,68 @@
   overflow: hidden;
   flex-shrink: 0;
 }
-.poweredBy {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  justify-content: flex-start;
-  gap: 4px;
-}
-.poweredby {
-  align-self: stretch;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  justify-content: flex-start;
-  font-size: 10px;
-  color: #797979;
-}
-.userslist {
-  width: 100%;
-  position: relative;
-  box-shadow:
-    0px 1px 2px rgba(0, 0, 0, 0.14),
-    0px 0px 1px rgba(0, 0, 0, 0.12);
-  border-radius: 4px;
-  background-color: #2d2b2c;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  justify-content: flex-start;
-  padding: 20px;
-  box-sizing: border-box;
-  gap: 20px;
-  text-align: left;
-  font-size: 18px;
-  color: #fff;
-  font-family: Inter;
+
+@media (max-width: 640px) {
+  .userslist {
+    padding: var(--space-4);
+  }
+
+  .list {
+    min-width: 0;
+    gap: var(--space-3);
+  }
+
+  .headerRow {
+    display: none;
+  }
+
+  .bodyRow {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-areas:
+      'user user'
+      'type type'
+      'balance allowance';
+    gap: var(--space-3);
+    padding: var(--space-4);
+    border-radius: var(--radius-sm);
+  }
+
+  .colUser {
+    grid-area: user;
+  }
+
+  .colType {
+    grid-area: type;
+  }
+
+  .colBalance {
+    grid-area: balance;
+  }
+
+  .colAllowance {
+    grid-area: allowance;
+  }
+
+  .colType,
+  .colBalance,
+  .colAllowance {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+    overflow: visible;
+    white-space: normal;
+  }
+
+  .colType::before,
+  .colBalance::before,
+  .colAllowance::before {
+    content: attr(data-label);
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+    font-weight: 400;
+  }
+
+  .poweredby {
+    align-items: flex-start;
+  }
 }

--- a/tabs/src/components/UserListComponent.tsx
+++ b/tabs/src/components/UserListComponent.tsx
@@ -15,11 +15,10 @@ const UserListComponent: FunctionComponent = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [users, setUsers] = useState<User[]>([]);
-  const fetchCalled = useRef(false); // Ref to track if fetchUsers has been called
+  const fetchCalled = useRef(false);
   const { cache, setCache } = useCache();
 
   const fetchUsers = useCallback(async () => {
-    //Load users from Cache or parameter
     setLoading(true);
     setError(null);
 
@@ -34,42 +33,31 @@ const UserListComponent: FunctionComponent = () => {
         setCache('allUsers', allUsers);
       }
 
-      // Fetch wallets for each user
       const usersWithWallets = await Promise.all(
         allUsers.map(async user => {
-          try {
-            const wallets = await getUserWallets(user.id);
-
-            if (wallets && wallets.length > 0) {
-              const privateWallet = wallets.find(w =>
-                w.name.toLowerCase().includes('private'),
-              );
-              const allowanceWallet = wallets.find(w =>
-                w.name.toLowerCase().includes('allowance'),
-              );
-
-              return {
-                ...user,
-                privateWallet: privateWallet || null,
-                allowanceWallet: allowanceWallet || null,
-              };
-            }
-
-            return user;
-          } catch (err) {
-            console.error(
-              `[UserList] Error fetching wallets for user ${user.displayName}:`,
-              err,
+          const wallets = await getUserWallets(user.id);
+          const exactWallet = (name: string) => {
+            const matches = wallets.filter(
+              wallet => wallet.name.trim().toLowerCase() === name,
             );
-            return user;
-          }
+            return matches.length === 1 ? matches[0] : null;
+          };
+
+          return {
+            ...user,
+            privateWallet: exactWallet('private'),
+            allowanceWallet: exactWallet('allowance'),
+          };
         }),
       );
 
       setUsers(usersWithWallets);
     } catch (err) {
-      console.error('[UserList] Error:', err);
-      setError(err instanceof Error ? err.message : 'An error occurred');
+      setError(
+        err instanceof Error
+          ? err.message
+          : 'The user directory is unavailable.',
+      );
     } finally {
       setLoading(false);
     }
@@ -82,100 +70,112 @@ const UserListComponent: FunctionComponent = () => {
     }
   }, [fetchUsers]);
   const rewardNameContext = useContext(RewardNameContext);
-  if (!rewardNameContext) {
-    return null; // or handle the case where the context is not available
-  }
   const rewardsName = rewardNameContext.rewardName;
   if (loading) {
-    return <div>Loading...</div>;
+    return (
+      <div className={styles.stateMessage} role="status">
+        Loading...
+      </div>
+    );
   }
 
   if (error) {
-    return <div>{error}</div>;
+    return (
+      <div className={styles.stateError} role="alert">
+        <span>{error}</span>
+        <button type="button" onClick={() => void fetchUsers()}>
+          Try again
+        </button>
+      </div>
+    );
   }
 
   return (
-    <div className={styles.userslist}>
-      <b className={styles.users}>Users</b>
+    <section className={styles.userslist}>
+      <h2 className={styles.users}>Users</h2>
       <div className={styles.tabs}>
-        <div className={styles.tab}>
-          <div className={styles.base}>
-            <div className={styles.stringBadgeIconStack}>
-              <b className={styles.stringTabTitle}>All</b>
-            </div>
-            <div className={styles.borderPaddingStack}>
-              <div className={styles.borderBottom} />
-            </div>
-          </div>
+        <div
+          className={`${styles.tab} ${styles.tabActive}`}
+          aria-current="true"
+        >
+          All
         </div>
         <div className={styles.tab} style={{ display: 'none' }}>
-          <div className={styles.base1}>
-            <div className={styles.stringBadgeIconStack}>
-              <div className={styles.stringTabTitle}>Teammates</div>
-            </div>
-          </div>
+          Teammates
         </div>
         <div className={styles.tab} style={{ display: 'none' }}>
-          <div className={styles.base1}>
-            <div className={styles.stringBadgeIconStack}>
-              <div className={styles.stringTabTitle}>Copilots</div>
-            </div>
-          </div>
+          Copilots
         </div>
       </div>
-      <div className={styles.list}>
-        <div className={styles.headercell}>
-          <div className={styles.headerContents}>
-            <div className={styles.stringParent}>
-              <b className={styles.string}>User</b>
-              <b className={styles.string1}>User type</b>
-              <b className={styles.string2}>Balance</b>
-              <b className={styles.string3}>Allowance remaining</b>
-            </div>
+      <div className={styles.tableScroll}>
+        <div className={styles.list} role="table" aria-label="Users">
+          <div className={styles.headerRow} role="row">
+            <span role="columnheader" className={styles.colUser}>
+              User
+            </span>
+            <span role="columnheader" className={styles.colType}>
+              User type
+            </span>
+            <span role="columnheader" className={styles.colBalance}>
+              Balance
+            </span>
+            <span role="columnheader" className={styles.colAllowance}>
+              Allowance remaining
+            </span>
           </div>
-        </div>
-        {users
-          ?.sort((a, b) => a.displayName.localeCompare(b.displayName))
-          .map(user => (
-            <div key={user.id} className={styles.bodycell}>
-              <div className={styles.bodyContents}>
-                <div className={styles.mainContentStack}>
-                  <div className={styles.personDetails}>
-                    <img
-                      className={styles.avatarIcon}
-                      alt=""
-                      src={user.profileImg ? user.profileImg : 'profile.png'}
-                    />
-                    <div className={styles.userName}>
-                      {/* Show displayName if it's not a UUID-like ID, otherwise show email or 'Unknown' */}
-                      {user.displayName &&
-                      !user.displayName.match(/^[a-f0-9]{32}$/)
-                        ? user.displayName
-                        : user.email || 'Unknown'}
-                    </div>
-                  </div>
-                  <div className={styles.totalBalance}>
-                    {user.type ? user.type : 'Teammate'}
-                  </div>
-                  <b className={styles.totalBalance1}>
-                    {user.privateWallet
-                      ? `${Math.floor(
-                          user.privateWallet.balance_msat / 1000,
-                        )} ${rewardsName}`
-                      : 'N/A'}
-                  </b>
-                  <b className={styles.totalBalance2}>
-                    {user.allowanceWallet
-                      ? `${Math.floor(
-                          user.allowanceWallet.balance_msat / 1000,
-                        )} ${rewardsName}`
-                      : 'N/A'}
-                  </b>
-                </div>
-                <div className={styles.actions} />
+          {[...users]
+            .sort((a, b) => a.displayName.localeCompare(b.displayName))
+            .map(user => (
+              <div key={user.id} className={styles.bodyRow} role="row">
+                <span role="cell" className={styles.colUser}>
+                  <img
+                    className={styles.avatarIcon}
+                    alt=""
+                    src={user.profileImg ? user.profileImg : 'profile.png'}
+                  />
+                  <span className={styles.userName}>
+                    {user.displayName &&
+                    !user.displayName.match(/^[a-f0-9]{32}$/)
+                      ? user.displayName
+                      : user.email || 'Unknown'}
+                  </span>
+                </span>
+                <span
+                  role="cell"
+                  className={styles.colType}
+                  data-label="User type"
+                >
+                  {user.type || 'Not specified'}
+                </span>
+                <span
+                  role="cell"
+                  data-label="Balance"
+                  className={`${styles.colBalance} ${
+                    user.privateWallet ? styles.amount : styles.amountMuted
+                  }`}
+                >
+                  {user.privateWallet
+                    ? `${Math.floor(
+                        user.privateWallet.balance_msat / 1000,
+                      ).toLocaleString()} ${rewardsName}`
+                    : 'Unavailable'}
+                </span>
+                <span
+                  role="cell"
+                  data-label="Allowance remaining"
+                  className={`${styles.colAllowance} ${
+                    user.allowanceWallet ? styles.amount : styles.amountMuted
+                  }`}
+                >
+                  {user.allowanceWallet
+                    ? `${Math.floor(
+                        user.allowanceWallet.balance_msat / 1000,
+                      ).toLocaleString()} ${rewardsName}`
+                    : 'Unavailable'}
+                </span>
               </div>
-            </div>
-          ))}
+            ))}
+        </div>
       </div>
       <div className={styles.poweredby}>
         <div className={styles.poweredBy}>
@@ -183,7 +183,7 @@ const UserListComponent: FunctionComponent = () => {
           <img className={styles.logo1Icon} alt="" src="LNbits.png" />
         </div>
       </div>
-    </div>
+    </section>
   );
 };
 

--- a/tabs/src/components/WalletInfoCard.css
+++ b/tabs/src/components/WalletInfoCard.css
@@ -1,70 +1,152 @@
 .wallet-info {
-  background-color: #333;
-  color: #f0f0f0;
-  padding: 15px;
-  border-radius: 10px;
-  min-width: 900px;
+  background-color: var(--surface-raised);
+  color: var(--text-body);
+  padding: var(--space-4);
+  border-radius: var(--radius-md);
+  box-shadow:
+    0px 1px 2px rgba(0, 0, 0, 0.14),
+    0px 0px 1px rgba(0, 0, 0, 0.12);
+  width: 100%;
+  box-sizing: border-box;
   margin: 0;
   text-align: left;
-  font-size: 14px;
+  font-size: var(--font-size-md);
+  font-family: var(--font-family-base);
 }
 
-.wallet-total {
-  display: flex;
-  justify-content: space-between;
-  margin-top: 20px;
-}
-
-.wallet-total h1 {
+.wallet-info h4 {
   margin: 0;
-  color: #84cc16;
+  font-size: var(--font-size-md);
+  font-weight: 700;
+  line-height: 20px;
+  color: var(--text-primary);
 }
 
-.wallet-actions {
-  display: flex; /* Enables flexbox */
-  gap: 20px;
-  margin-top: 20px;
+.wallet-info > p {
+  margin: var(--space-1) 0 0;
+  color: var(--text-muted);
+  font-size: var(--font-size-md);
 }
 
-.receive-btn {
-  padding: 10px 20px;
-  border: none;
-  background-color: #84cc16;
-  color: #000;
-  cursor: pointer;
-  border-radius: 5px;
-  font-weight: 600;
+.wallet-info .horizontal-container {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  min-height: 64px;
+  margin-top: var(--space-2);
+  color: var(--text-muted);
 }
 
-.send-btn {
-  padding: 10px 20px;
-  border: 1px solid #84cc16;
-  background-color: transparent;
-  color: #84cc16;
-  cursor: pointer;
-  border-radius: 5px;
-  font-weight: 600;
+.wallet-info .horizontal-container h1 {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: var(--font-size-hero);
+  font-weight: 500;
+  line-height: 1.15;
 }
 
-.horizontal-container {
-  display: flex; /* Enables flexbox */
-  color: #84cc16;
-}
-.horizontal-container h1 {
-  color: rgba(255, 255, 255, 1);
-  font-size: 48px;
-}
-
-.item {
-  padding: 5px;
-  border-radius: 5px;
-  color: white;
+.wallet-info .item {
+  padding: var(--space-1);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
   align-self: baseline;
 }
 
-.receive-btn:disabled,
-.send-btn:disabled {
+.wallet-info .wallet-loading,
+.wallet-info .wallet-error-state p {
+  margin: var(--space-2) 0;
+  color: var(--text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.wallet-info .wallet-error-state {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  width: 100%;
+}
+
+.wallet-info .wallet-error-state p {
+  color: var(--danger);
+}
+
+.wallet-info .wallet-retry-btn {
+  width: auto;
+  padding: 8px var(--space-3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background-color: transparent;
+  color: var(--accent);
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.wallet-info .wallet-buttons {
+  display: flex;
+  justify-content: flex-start;
+  flex-wrap: wrap;
+  gap: var(--space-4);
+  margin-top: var(--space-4);
+}
+
+.wallet-info .receive-btn,
+.wallet-info .send-btn {
+  box-sizing: border-box;
+  display: inline-flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 122px;
+  height: 38px;
+  padding: 0;
+  border: 1px solid var(--accent);
+  border-radius: var(--radius-sm);
+  background-color: transparent;
+  color: var(--accent);
+  font-family: var(--font-family-base);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.wallet-info .receive-btn:hover,
+.wallet-info .send-btn:hover,
+.wallet-info .wallet-retry-btn:hover {
+  background-color: rgba(132, 204, 22, 0.12);
+  color: var(--accent);
+}
+
+.wallet-info .receive-btn:focus-visible,
+.wallet-info .send-btn:focus-visible,
+.wallet-info .wallet-retry-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.wallet-info .receive-btn:disabled,
+.wallet-info .send-btn:disabled {
   pointer-events: none;
   opacity: 0.6;
   cursor: not-allowed;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .wallet-info .receive-btn,
+  .wallet-info .send-btn,
+  .wallet-info .wallet-retry-btn {
+    transition: background-color 0.15s ease;
+  }
+}
+
+@media (max-width: 480px) {
+  .wallet-info .horizontal-container h1 {
+    font-size: 36px;
+  }
+
+  .wallet-info .receive-btn,
+  .wallet-info .send-btn {
+    flex: 1 1 auto;
+  }
 }

--- a/tabs/src/components/WalletInfoCard.test.tsx
+++ b/tabs/src/components/WalletInfoCard.test.tsx
@@ -1,0 +1,205 @@
+import React, { act } from 'react';
+import { createRoot, Root } from 'react-dom/client';
+import WalletYourWalletInfoCard from './WalletInfoCard';
+import { RewardNameContext } from './RewardNameContext';
+
+const mockUseMsal = jest.fn();
+const mockGetUsers = jest.fn<Promise<User[]>, [{ aadObjectId: string }]>();
+const mockGetUserWallets = jest.fn<Promise<Wallet[]>, [string]>();
+
+jest.mock('@azure/msal-react', () => ({
+  useMsal: () => mockUseMsal(),
+}));
+
+jest.mock('../services/lnbitsServiceLocal', () => ({
+  getUsers: (filter: { aadObjectId: string }) => mockGetUsers(filter),
+  getUserWallets: (userId: string) => mockGetUserWallets(userId),
+}));
+
+jest.mock('./ReceivePayment', () => ({
+  __esModule: true,
+  default: ({ currentUserLNbitDetails }: { currentUserLNbitDetails: User }) => (
+    <div data-testid="receive-user">
+      {currentUserLNbitDetails.privateWallet?.id}
+    </div>
+  ),
+}));
+
+jest.mock('./SendPayment', () => ({
+  __esModule: true,
+  default: ({ currentUserLNbitDetails }: { currentUserLNbitDetails: User }) => (
+    <div data-testid="send-user">
+      {currentUserLNbitDetails.privateWallet?.id}
+    </div>
+  ),
+}));
+
+const user: User = {
+  id: 'user-1',
+  displayName: 'Alex Rivera',
+  profileImg: '',
+  aadObjectId: 'aad-1',
+  email: 'alex@example.test',
+  type: 'Teammate',
+  privateWallet: null,
+  allowanceWallet: null,
+};
+
+const exactPrivateWallet: Wallet = {
+  id: 'private-1',
+  name: 'Private',
+  user: user.id,
+  balance_msat: 20_000,
+  deleted: false,
+};
+
+const similarlyNamedWallet: Wallet = {
+  id: 'private-archive',
+  name: 'Private archive',
+  user: user.id,
+  balance_msat: 999_000,
+  deleted: false,
+};
+
+let container: HTMLDivElement;
+let root: Root;
+
+const mountWallet = () => {
+  root.render(
+    <RewardNameContext.Provider
+      value={{ rewardName: 'Sats', setRewardName: jest.fn() }}
+    >
+      <WalletYourWalletInfoCard />
+    </RewardNameContext.Provider>,
+  );
+};
+
+const renderWallet = async () => {
+  await act(async () => {
+    mountWallet();
+  });
+};
+
+const settle = async () => {
+  await act(async () => {
+    await new Promise(resolve => setTimeout(resolve, 0));
+  });
+};
+
+const eventually = async (assertion: () => void) => {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await settle();
+    }
+  }
+  throw lastError;
+};
+
+const getButton = (label: string) => {
+  const button = Array.from(container.querySelectorAll('button')).find(
+    candidate => candidate.textContent?.trim() === label,
+  );
+  if (!button) throw new Error(`Button "${label}" was not rendered.`);
+  return button;
+};
+
+describe('WalletInfoCard', () => {
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    jest.clearAllMocks();
+    mockUseMsal.mockReturnValue({
+      accounts: [{ localAccountId: 'aad-1' }],
+    });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  test('shows loading without a fake zero and disables wallet actions', async () => {
+    mockGetUsers.mockReturnValue(new Promise(() => undefined));
+
+    await renderWallet();
+
+    expect(container.querySelector('[role="status"]')?.textContent).toBe(
+      'Loading wallet...',
+    );
+    expect(container.querySelector('h1')).toBeNull();
+    expect(getButton('Receive').disabled).toBe(true);
+    expect(getButton('Send').disabled).toBe(true);
+  });
+
+  test('uses the authenticated user and the exact Private wallet', async () => {
+    mockGetUsers.mockResolvedValue([user]);
+    mockGetUserWallets.mockResolvedValue([
+      similarlyNamedWallet,
+      exactPrivateWallet,
+    ]);
+
+    await renderWallet();
+    await eventually(() => {
+      expect(container.querySelector('h1')?.textContent).toBe('20');
+    });
+
+    expect(mockGetUsers).toHaveBeenCalledWith({ aadObjectId: 'aad-1' });
+    expect(mockGetUserWallets).toHaveBeenCalledWith('user-1');
+    expect(getButton('Receive').disabled).toBe(false);
+    expect(getButton('Send').disabled).toBe(false);
+
+    await act(async () => {
+      getButton('Receive').click();
+    });
+    expect(
+      container.querySelector('[data-testid="receive-user"]')?.textContent,
+    ).toBe('private-1');
+  });
+
+  test('shows an error and retries when the exact Private wallet is missing', async () => {
+    mockGetUsers.mockResolvedValue([user]);
+    mockGetUserWallets
+      .mockResolvedValueOnce([similarlyNamedWallet])
+      .mockResolvedValueOnce([exactPrivateWallet]);
+
+    await renderWallet();
+    await eventually(() => {
+      expect(container.querySelector('[role="alert"]')?.textContent).toBe(
+        "We couldn't find your Private wallet.",
+      );
+    });
+    expect(container.querySelector('h1')).toBeNull();
+    expect(getButton('Receive').disabled).toBe(true);
+
+    await act(async () => {
+      getButton('Try again').click();
+    });
+    await eventually(() => {
+      expect(container.querySelector('h1')?.textContent).toBe('20');
+    });
+    expect(mockGetUserWallets).toHaveBeenCalledTimes(2);
+  });
+
+  test('does not query wallets without an authenticated account', async () => {
+    mockUseMsal.mockReturnValue({ accounts: [] });
+
+    await renderWallet();
+
+    expect(container.querySelector('[role="alert"]')?.textContent).toBe(
+      'Sign in to load your wallet.',
+    );
+    expect(mockGetUsers).not.toHaveBeenCalled();
+    expect(mockGetUserWallets).not.toHaveBeenCalled();
+  });
+});

--- a/tabs/src/components/WalletInfoCard.tsx
+++ b/tabs/src/components/WalletInfoCard.tsx
@@ -1,148 +1,197 @@
-import React, { useEffect, useState, useContext, useCallback } from 'react';
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import './WalletInfoCard.css';
-import ArrowClockwise from '../images/ArrowClockwise.svg';
 import { getUsers, getUserWallets } from '../services/lnbitsServiceLocal';
 import { useMsal } from '@azure/msal-react';
 import SendPayment from './SendPayment';
 import ReceivePayment from './ReceivePayment';
 import { RewardNameContext } from './RewardNameContext';
 
-const WalletYourWalletInfoCard: React.FC = () => {
-  const [balance, setBalance] = useState<number>();
+type WalletState =
+  | { status: 'loading' }
+  | { status: 'error'; message: string }
+  | { status: 'ready'; balance: number; user: User };
 
+const walletNameIsPrivate = (wallet: Wallet) =>
+  wallet.name.trim().toLowerCase() === 'private';
+
+const WalletYourWalletInfoCard: React.FC = () => {
+  const { accounts } = useMsal();
+  const aadObjectId = accounts[0]?.localAccountId;
+  const [walletState, setWalletState] = useState<WalletState>({
+    status: 'loading',
+  });
   const [isReceivePopupOpen, setIsReceivePopupOpen] = useState(false);
   const [isSendPopupOpen, setIsSendPopupOpen] = useState(false);
-  const { accounts } = useMsal();
-  const account = accounts[0];
-  const [myLNbitDetails, setMyLNbitDetails] = useState<User>();
+  const requestIdRef = useRef(0);
+  const {
+    rewardName,
+    isLoading: isRewardNameLoading = false,
+    error: rewardNameError = null,
+  } = useContext(RewardNameContext);
 
-  const fetchAmountReceived = useCallback(async () => {
-    if (!account?.localAccountId) return;
+  const loadWallet = useCallback(async () => {
+    const requestId = ++requestIdRef.current;
+    setWalletState({ status: 'loading' });
+    setIsReceivePopupOpen(false);
+    setIsSendPopupOpen(false);
 
-    const currentUserLNbitDetails = await getUsers({
-      aadObjectId: account.localAccountId,
-    });
+    if (!aadObjectId) {
+      setWalletState({
+        status: 'error',
+        message: 'Sign in to load your wallet.',
+      });
+      return;
+    }
 
-    if (currentUserLNbitDetails && currentUserLNbitDetails.length > 0) {
-      const user = currentUserLNbitDetails[0];
+    try {
+      const users = await getUsers({ aadObjectId });
+      const matchingUsers = users.filter(
+        user => user.aadObjectId === aadObjectId,
+      );
 
-      // Fetch user's wallets
-      const userWallets = await getUserWallets(user.id);
+      if (requestId !== requestIdRef.current) return;
+      if (matchingUsers.length !== 1) {
+        setWalletState({
+          status: 'error',
+          message: "We couldn't match your signed-in account to a wallet.",
+        });
+        return;
+      }
 
-      if (userWallets && userWallets.length > 0) {
-        // Find the Private wallet
-        const privateWallet = userWallets.find(w =>
-          w.name.toLowerCase().includes('private'),
-        );
+      const user = matchingUsers[0];
+      const wallets = await getUserWallets(user.id);
+      if (requestId !== requestIdRef.current) return;
 
-        if (privateWallet) {
-          // Update user object with the wallet
-          user.privateWallet = privateWallet;
-          setMyLNbitDetails(user);
+      const privateWallets = wallets.filter(walletNameIsPrivate);
+      if (privateWallets.length !== 1) {
+        setWalletState({
+          status: 'error',
+          message: "We couldn't find your Private wallet.",
+        });
+        return;
+      }
 
-          // Set balance
-          const bal = (privateWallet.balance_msat ?? 0) / 1000;
-          setBalance(bal);
-        }
+      const privateWallet = privateWallets[0];
+      if (!Number.isFinite(privateWallet.balance_msat)) {
+        setWalletState({
+          status: 'error',
+          message: "We couldn't read your Private wallet balance.",
+        });
+        return;
+      }
+
+      setWalletState({
+        status: 'ready',
+        balance: privateWallet.balance_msat / 1000,
+        user: { ...user, privateWallet },
+      });
+    } catch {
+      if (requestId === requestIdRef.current) {
+        setWalletState({
+          status: 'error',
+          message: "We couldn't load your wallet. Try again.",
+        });
       }
     }
-  }, [account?.localAccountId]);
+  }, [aadObjectId]);
 
   useEffect(() => {
-    fetchAmountReceived();
-  }, [fetchAmountReceived]);
-  const handleOpenReceivePopup = () => {
-    setIsReceivePopupOpen(true);
-  };
+    void loadWallet();
 
-  const handleCloseReceivePopup = () => {
-    setIsReceivePopupOpen(false);
-  };
+    return () => {
+      requestIdRef.current += 1;
+    };
+  }, [loadWallet]);
 
-  const handleOpenSendPopup = () => {
-    setIsSendPopupOpen(true);
-  };
-
-  const handleCloseSendPopup = () => {
-    setIsSendPopupOpen(false);
-  };
-
-  const rewardNameContext = useContext(RewardNameContext);
-  if (!rewardNameContext) {
-    return null; // or handle the case where the context is not available
-  }
-  const rewardsName = rewardNameContext.rewardName;
-
-  // Buttons should be disabled if balance is undefined (still loading)
-  const isLoading = false; // balance === undefined;
+  const walletReady = walletState.status === 'ready';
+  const currentUser = walletReady ? walletState.user : null;
 
   return (
     <div className="wallet-info">
       <h4>Your wallet</h4>
       <p>Amount received from other users:</p>
-      <div className="horizontal-container">
-        <div className="item">
-          {' '}
-          <h1>{balance?.toLocaleString() ?? '0'}</h1>
-        </div>
-        <div className="item">{rewardsName}</div>
-        <div
-          className="col-md-1 item"
-          style={{ paddingTop: '30px', paddingLeft: '10px' }}
-        >
-          <button style={{ display: 'none' }} className="refreshImageIcon">
-            <img
-              src={ArrowClockwise}
-              alt="icon"
-              style={{ width: 30, height: 30 }}
-            />
-          </button>
-        </div>
-      </div>
-      <div className="wallet-buttons">
-        <div>
-          {' '}
-          <button
-            onClick={handleOpenReceivePopup}
-            className="receive-btn"
-            disabled={isLoading}
-          >
-            Receive
-          </button>
-        </div>
-        <div>
-          <button
-            onClick={handleOpenSendPopup}
-            className="send-btn"
-            disabled={isLoading}
-          >
-            Send
-          </button>
-        </div>
-        {isReceivePopupOpen && (
-          <div className="overlay" onClick={handleCloseReceivePopup}>
-            <div className="popup" onClick={e => e.stopPropagation()}>
-              <ReceivePayment
-                onClose={handleCloseReceivePopup}
-                currentUserLNbitDetails={myLNbitDetails!}
-              />
-            </div>
-          </div>
-        )}
 
-        {isSendPopupOpen && (
-          <div className="overlay" onClick={handleCloseSendPopup}>
-            <div className="popup" onClick={e => e.stopPropagation()}>
-              <SendPayment
-                onClose={handleCloseSendPopup}
-                currentUserLNbitDetails={myLNbitDetails!}
+      <div
+        className="horizontal-container"
+        aria-busy={walletState.status === 'loading'}
+      >
+        {walletState.status === 'loading' ? (
+          <p className="wallet-loading" role="status">
+            Loading wallet...
+          </p>
+        ) : walletState.status === 'error' ? (
+          <div className="wallet-error-state">
+            <p role="alert">{walletState.message}</p>
+            <button
+              type="button"
+              className="wallet-retry-btn"
+              onClick={loadWallet}
+            >
+              Try again
+            </button>
+          </div>
+        ) : (
+          <>
+            <div className="item">
+              <h1>{walletState.balance.toLocaleString()}</h1>
+            </div>
+            <div className="item">
+              {rewardName ??
+                (isRewardNameLoading
+                  ? 'Loading reward name...'
+                  : rewardNameError
+                    ? 'Reward name unavailable'
+                    : '')}
+            </div>
+          </>
+        )}
+      </div>
+
+      <div className="wallet-buttons">
+        <button
+          type="button"
+          onClick={() => setIsReceivePopupOpen(true)}
+          className="receive-btn"
+          disabled={!walletReady}
+        >
+          Receive
+        </button>
+        <button
+          type="button"
+          onClick={() => setIsSendPopupOpen(true)}
+          className="send-btn"
+          disabled={!walletReady}
+        >
+          Send
+        </button>
+
+        {isReceivePopupOpen && currentUser ? (
+          <div className="overlay" onClick={() => setIsReceivePopupOpen(false)}>
+            <div className="popup" onClick={event => event.stopPropagation()}>
+              <ReceivePayment
+                onClose={() => setIsReceivePopupOpen(false)}
+                currentUserLNbitDetails={currentUser}
               />
             </div>
           </div>
-        )}
-        <div className="col-md-6">
-          <span></span>
-        </div>
+        ) : null}
+
+        {isSendPopupOpen && currentUser ? (
+          <div className="overlay" onClick={() => setIsSendPopupOpen(false)}>
+            <div className="popup" onClick={event => event.stopPropagation()}>
+              <SendPayment
+                onClose={() => setIsSendPopupOpen(false)}
+                currentUserLNbitDetails={currentUser}
+              />
+            </div>
+          </div>
+        ) : null}
       </div>
     </div>
   );


### PR DESCRIPTION
Fixes #285

Part of splitting #287 into reviewable layers. Stacked on the API contracts PR.

## What changed
- Account-facing views fail closed: a missing/invalid reward name or balance now renders an explicit error state with retry instead of defaulting to `sats`/zero (`RewardsComponent`, `PurchasePopup`, `UserListComponent`, `WalletInfoCard`).
- `WalletInfoCard` validates `balance_msat` is a finite number and detects wallets with conflicting owners instead of picking the first match.

## Test plan for QA
- `npm test` (tabs): new `WalletInfoCard.test.tsx` plus updated component tests for the error/retry states and unique-wallet resolution.
