### PR TITLE
fix: verify wallet transaction history

### DIFF
--- a/tabs/src/components/WalletTransactionHistory.module.css
+++ b/tabs/src/components/WalletTransactionHistory.module.css
@@ -1,509 +1,71 @@
-.transaction-tabs {
-  display: flex;
-  gap: 20px;
-  margin-bottom: 20px;
-}
-
-button {
-  padding: 10px;
-  background-color: #444;
-  color: #fff;
-  border: none;
-  border-radius: 5px;
-  cursor: pointer;
-}
-
-button.active {
-  background-color: #84cc16;
-}
-
-.stringTabTitle {
-  position: relative;
-  line-height: 20px;
-}
-.stringBadgeIconStack {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: center;
-}
-.borderBottom {
-  flex: 1;
-  position: relative;
-  border-radius: 2px 2px 0px 0px;
-  background-color: #5b5fc7;
-  height: 2px;
-  overflow: hidden;
-}
-.borderPaddingStack {
-  align-self: stretch;
-  overflow: hidden;
-  display: flex;
-  flex-direction: row;
-  align-items: flex-start;
-  justify-content: flex-start;
-}
-.base {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  justify-content: flex-start;
-  padding: 3px 0px 0px;
-  gap: 17px;
-}
-.tab {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  justify-content: flex-start;
-  cursor: pointer;
-}
-.base1 {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  justify-content: flex-start;
-  padding: 3px 0px 0px;
-}
-.tab1 {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  justify-content: flex-start;
-  cursor: pointer;
-}
-.tabs {
-  align-self: stretch;
-  border-bottom: 1px solid #1f1f1f;
-  display: flex;
-  flex-direction: row;
-  align-items: flex-start;
-  justify-content: flex-start;
-  gap: 16px;
-  z-index: 0;
-  font-size: 14px;
-  color: #d8d8d8;
-}
-.jan12020 {
-  position: absolute;
-  width: 24.95%;
-  top: calc(50% - 8px);
-  left: 75.04%;
-  display: inline-block;
-}
-.dateRange {
-  position: absolute;
-  width: 10.59%;
-  top: calc(50% - 8px);
-  left: 63.93%;
-  display: inline-block;
-}
-.div {
-  position: absolute;
-  width: 0.51%;
-  top: calc(50% - 8px);
-  left: 60.68%;
-  display: inline-block;
-}
-.all {
-  position: absolute;
-  width: 2.74%;
-  top: calc(50% - 8px);
-  left: 55.21%;
-  display: inline-block;
-}
-.groups {
-  position: absolute;
-  width: 7.18%;
-  top: calc(50% - 8px);
-  left: 47.86%;
-  display: inline-block;
-}
-.div1 {
-  position: absolute;
-  width: 0.51%;
-  top: calc(50% - 8px);
-  left: 44.62%;
-  display: inline-block;
-}
-.all1 {
-  position: absolute;
-  width: 2.74%;
-  top: calc(50% - 8px);
-  left: 39.15%;
-  display: inline-block;
-}
-.location {
-  position: absolute;
-  width: 8.21%;
-  top: calc(50% - 8px);
-  left: 30.43%;
-  display: inline-block;
-}
-.div2 {
-  position: absolute;
-  width: 0.51%;
-  top: calc(50% - 8px);
-  left: 27.18%;
-  display: inline-block;
-}
-.amPt {
-  position: absolute;
-  width: 12.31%;
-  top: calc(50% - 8px);
-  left: 12.14%;
-  display: inline-block;
-}
-.dec312019Container {
-  position: absolute;
-  width: 12.48%;
-  top: calc(50% - 8px);
-  left: 0%;
-  color: #686868;
-  display: none;
-}
-.dateContainer {
-  position: absolute;
-  width: 12%;
-  top: calc(50% - 8px);
-  left: 0%;
-  display: inline-block;
-}
-.infoStrip {
-  width: 642px;
-  position: relative;
-  height: 16px;
-  overflow: hidden;
-  flex-shrink: 0;
-  z-index: 1;
-  font-family: 'Segoe UI';
-}
-.daysCopy {
-  position: absolute;
-  top: calc(50% - 5px);
-  right: 2px;
-  line-height: 10px;
-}
-.daysCopy3 {
-  position: absolute;
-  top: calc(50% - 5px);
-  left: 40.52%;
-  line-height: 10px;
-  color: #5b5fc7;
-  text-align: center;
-}
-.daysCopy1 {
-  position: absolute;
-  top: calc(50% - 5px);
-  left: 0px;
-  line-height: 10px;
-  text-align: left;
-}
-.pivotPointsdoubleFull60 {
-  width: 232px;
-  position: relative;
-  height: 10px;
-  z-index: 2;
-  text-align: right;
-  font-size: 10px;
-  font-family: 'Segoe UI';
-}
-.string {
-  width: 38px;
-  position: relative;
-  line-height: 16px;
-  display: flex;
-  align-items: center;
-  flex-shrink: 0;
-}
-.string1 {
-  flex: 1;
-  position: relative;
-  line-height: 16px;
-}
-.string2 {
-  position: relative;
-  line-height: 16px;
-}
-.stringWrapper {
-  width: 85px;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: flex-end;
-}
-.iconContent {
-  width: 20px;
-  position: relative;
-  height: 20px;
-}
-.base3 {
-  border-radius: 100px;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: flex-start;
-  padding: 2px;
-}
-.iconbutton {
-  border-radius: 4px;
-  overflow: hidden;
-  display: flex;
-  flex-direction: row;
-  align-items: flex-start;
-  justify-content: flex-start;
-}
-.buttonsStack {
-  display: flex;
-  flex-direction: row;
-  align-items: flex-start;
-  justify-content: flex-start;
-}
-.headerContents {
-  flex: 1;
-  height: 32px;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: flex-start;
-  padding: 0px 10px;
-  box-sizing: border-box;
-  gap: 8px;
-}
-.headercell {
-  align-self: stretch;
-  background-color: #1f1f1f;
-  display: flex;
-  flex-direction: row;
-  align-items: flex-start;
-  justify-content: flex-start;
-  color: #d8d8d8;
-  font-family: 'Segoe UI';
-}
-.rankChild {
-  position: absolute;
-  height: 100%;
-  width: 100%;
-  top: 0%;
-  right: 0%;
-  bottom: 0%;
-  left: 0%;
-  border-radius: 50%;
-  background: linear-gradient(-41.31deg, #6ba513, #84cc16);
-}
-.b {
-  position: absolute;
-  height: 65.42%;
-  width: 26.17%;
-  top: 16.67%;
-  left: 37.49%;
-  display: inline-block;
-}
-.rank {
-  width: 25.6px;
-  position: relative;
-  height: 24px;
-}
-.avatarIcon {
-  width: 24px;
-  position: relative;
-  height: 24px;
-  object-fit: cover;
-}
-.userName {
-  flex: 1;
-  position: relative;
-}
-.personDetails {
-  flex: 1;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: flex-start;
-  gap: 10px;
-  text-align: left;
-  color: #fff;
-}
-.mainContentStack {
-  flex: 1;
-  height: 32px;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: flex-start;
-  gap: 20px;
-}
-.b1 {
-  position: relative;
-}
-.icon {
-  width: 16px;
-  position: relative;
-  height: 16px;
-  overflow: hidden;
-  flex-shrink: 0;
-}
-.transactionDetails {
-  align-self: stretch;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: flex-end;
-  padding: 0px 28px 0px 0px;
-  gap: 10px;
-  text-align: end !important;
-  color: #84cc16;
-}
-.bodyContents {
-  flex: 1;
-  background-color: #1f1f1f;
-  height: 44px;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0px 10px;
-  box-sizing: border-box;
-}
-.bodycell {
-  align-self: stretch;
-  border-bottom: 1px solid #2d2b2c;
-  display: flex;
-  flex-direction: row;
-  align-items: flex-start;
-  justify-content: flex-start;
-  text-align: center;
-  color: #2d2b2c;
-}
-.rankItem {
-  position: absolute;
-  height: 100%;
-  width: 100%;
-  top: 0%;
-  right: 0%;
-  bottom: 0%;
-  left: 0%;
-  border-radius: 50%;
-  background: linear-gradient(-41.31deg, #818080, #e5e5e5);
-}
-.rankInner {
-  position: absolute;
-  height: 100%;
-  width: 100%;
-  top: 0%;
-  right: 0%;
-  bottom: 0%;
-  left: 0%;
-  border-radius: 50%;
-  background: linear-gradient(-41.31deg, #5a9311, #6ba513);
-}
-.rank3 {
-  width: 24.7px;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: flex-start;
-  padding: 4px 9px;
-  box-sizing: border-box;
-}
-.personDetails3 {
-  flex: 1;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: flex-start;
-  gap: 10px;
-}
-.transactionDetails3 {
-  align-self: stretch;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: flex-end;
-  padding: 0px 28px 0px 0px;
-  gap: 10px;
-  text-align: right;
-}
-.bodycell3 {
-  align-self: stretch;
-  border-bottom: 1px solid #2d2b2c;
-  display: flex;
-  flex-direction: row;
-  align-items: flex-start;
-  justify-content: flex-start;
-}
-.ranking {
-  align-self: stretch;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  justify-content: flex-start;
-  gap: 1px;
-  z-index: 3;
-  color: #fff;
-}
-.div3 {
-  position: absolute;
-  top: calc(50% - 9.7px);
-  left: 0%;
-  font-weight: 300;
-}
-.icon21 {
-  position: absolute;
-  top: 0px;
-  right: 4px;
-  width: 16px;
-  height: 20px;
-  overflow: hidden;
-}
-.moreIcon {
-  position: absolute;
-  height: 100%;
-  width: 100%;
-  top: 0%;
-  right: 0%;
-  bottom: 0%;
-  left: 0%;
-  overflow: hidden;
-}
-.actionBarReportFull1 {
-  position: absolute;
-  height: 75%;
-  width: 15.79%;
-  top: 12.5%;
-  right: 1.32%;
-  bottom: 12.5%;
-  left: 82.89%;
-}
-.actionBarReportFull {
-  width: 152px;
-  position: absolute;
-  margin: 0 !important;
-  top: 6px;
-  left: 851px;
-  height: 32px;
-  z-index: 4;
-  font-size: 16px;
-  color: #fff;
-  font-family: 'Teams Assets';
-}
 .feedcomponent {
   width: 100%;
   position: relative;
+  margin-top: var(--space-4);
   box-shadow:
-    0px 1px 2px rgba(0, 0, 0, 0.14),
-    0px 0px 1px rgba(0, 0, 0, 0.12);
-  border-radius: 4px;
-  background-color: #2d2b2c;
+    0 1px 2px rgba(0, 0, 0, 0.14),
+    0 0 1px rgba(0, 0, 0, 0.12);
+  border-radius: var(--radius-md);
+  background-color: var(--surface-raised);
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
-  justify-content: flex-start;
-  padding: 20px;
+  align-items: stretch;
+  padding: var(--space-4);
   box-sizing: border-box;
-  gap: 20px;
+  gap: var(--space-4);
   text-align: left;
-  font-size: 12px;
-  color: #d6d6d6;
-  font-family: Inter;
+  font-size: var(--font-size-sm);
+  color: var(--text-body);
+  font-family: var(--font-family-base);
+}
+
+.tabs {
+  align-self: stretch;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-start;
+  gap: var(--space-6);
+  flex-wrap: wrap;
+  font-size: var(--font-size-md);
+  color: var(--text-body);
+}
+
+.stringTabTitle {
+  appearance: none;
+  background: none;
+  border: none;
+  margin: 0;
+  padding: var(--space-2) 0 var(--space-3);
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  line-height: 20px;
+  border-bottom: 3px solid transparent;
+  white-space: nowrap;
+}
+
+.stringTabTitle:hover {
+  color: var(--text-primary);
+}
+
+.stringTabTitle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+.stringTabTitle.active {
+  color: var(--text-primary);
+  font-weight: 700;
+  border-bottom-color: var(--accent);
+}
+
+@media (max-width: 480px) {
+  .feedcomponent {
+    padding: var(--space-3);
+  }
+
+  .tabs {
+    gap: var(--space-4);
+  }
 }

--- a/tabs/src/components/WalletTransactionHistory.tsx
+++ b/tabs/src/components/WalletTransactionHistory.tsx
@@ -1,87 +1,53 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import styles from './WalletTransactionHistory.module.css';
 import WalletTransactionLog from './WalletTransactionLog';
+
+type HistoryFilter = 'all' | 'sent' | 'received';
 
 interface WalletTransactionHistoryProps {
   activeMainTab?: string;
 }
 
+const FILTERS: Array<{ id: HistoryFilter; label: string }> = [
+  { id: 'all', label: 'All' },
+  { id: 'sent', label: 'Sent' },
+  { id: 'received', label: 'Received' },
+];
+
 const WalletTransactionHistory: React.FC<WalletTransactionHistoryProps> = ({
   activeMainTab,
 }) => {
-  const [activeTab, setActiveTab] = useState<string>('all');
-  const [activeWalletTabName, setActiveWalletTabName] =
-    useState<string>('Private');
+  const [activeTab, setActiveTab] = useState<HistoryFilter>('all');
 
-  const onHistoryTabClick = (tabName: string) => {
-    setActiveTab(tabName);
-  };
-
-  useEffect(() => {
-    const filterZaps = (currentActiveTab: string, currentMainTab: string) => {
-      // Define filterZaps function here or import it from WalletTransactionLog
-      setActiveWalletTabName(currentMainTab);
-    };
-
-    if (activeMainTab) {
-      filterZaps('all', activeMainTab);
-    }
-  }, [activeMainTab]);
+  if (activeMainTab !== 'Private' && activeMainTab !== 'Allowance') {
+    return (
+      <div className={styles.feedcomponent} role="alert">
+        Choose a wallet to view its transaction history.
+      </div>
+    );
+  }
 
   return (
     <div className={styles.feedcomponent}>
-      <div className={styles.tabs}>
-        <div className={styles.tab} onClick={() => onHistoryTabClick('all')}>
-          <div className={styles.base}>
-            <div className={styles.stringBadgeIconStack}>
-              <div className={styles.stringTabTitle}>All</div>
-            </div>
-            <div className={styles.borderPaddingStack}>
-              {activeTab === 'all' && <div className={styles.borderBottom} />}
-            </div>
-          </div>
-        </div>
-        <div className={styles.tab1} onClick={() => onHistoryTabClick('sent')}>
-          <div className={styles.base}>
-            <div className={styles.stringBadgeIconStack}>
-              <div className={styles.stringTabTitle}>Sent</div>
-            </div>
-            <div className={styles.borderPaddingStack}>
-              {activeTab === 'sent' && <div className={styles.borderBottom} />}
-            </div>
-          </div>
-        </div>
-
-        <div
-          className={styles.tab1}
-          onClick={() => onHistoryTabClick('received')}
-        >
-          <div className={styles.base}>
-            <div className={styles.stringBadgeIconStack}>
-              <div className={styles.stringTabTitle}>Received</div>
-            </div>
-            <div className={styles.borderPaddingStack}>
-              {activeTab === 'received' && (
-                <div className={styles.borderBottom} />
-              )}
-            </div>
-          </div>
-        </div>
+      <div className={styles.tabs} aria-label="Filter transactions">
+        {FILTERS.map(filter => (
+          <button
+            key={filter.id}
+            type="button"
+            className={`${styles.stringTabTitle} ${
+              activeTab === filter.id ? styles.active : ''
+            }`}
+            onClick={() => setActiveTab(filter.id)}
+            aria-pressed={activeTab === filter.id}
+          >
+            {filter.label}
+          </button>
+        ))}
       </div>
-
-      {activeWalletTabName === 'Private' ? (
-        <WalletTransactionLog
-          filterZaps={onHistoryTabClick}
-          activeTab={activeTab}
-          activeWallet={activeWalletTabName}
-        />
-      ) : (
-        <WalletTransactionLog
-          filterZaps={onHistoryTabClick}
-          activeTab={activeTab}
-          activeWallet={activeWalletTabName}
-        />
-      )}
+      <WalletTransactionLog
+        activeTab={activeTab}
+        activeWallet={activeMainTab}
+      />
     </div>
   );
 };

--- a/tabs/src/components/WalletTransactionLog.module.css
+++ b/tabs/src/components/WalletTransactionLog.module.css
@@ -1,167 +1,252 @@
-.string {
-  width: 160px;
-  position: relative;
-  line-height: 16px;
-  display: flex;
-  align-items: center;
-  flex-shrink: 0;
-}
-.string2 {
-  flex: 1;
-  position: relative;
-  line-height: 16px;
-}
-.string3 {
-  position: relative;
-  line-height: 16px;
-}
-.stringWrapper {
-  width: 85px;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: flex-end;
-  font-family: 'Segoe UI';
-}
-.iconContent {
-  width: 20px;
-  position: relative;
-  height: 20px;
-}
-.base {
-  border-radius: 100px;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: flex-start;
-  padding: 2px;
-}
-.iconbutton {
-  border-radius: 4px;
-  overflow: hidden;
-  display: flex;
-  flex-direction: row;
-  align-items: flex-start;
-  justify-content: flex-start;
-}
-.buttonsStack {
-  display: flex;
-  flex-direction: row;
-  align-items: flex-start;
-  justify-content: flex-start;
-}
-.headerContents {
-  flex: 1;
-  height: 32px;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: flex-start;
-  padding: 0px 10px;
-  box-sizing: border-box;
-  gap: 20px;
-}
-.headercell {
-  align-self: stretch;
-  background-color: #1f1f1f;
-  display: flex;
-  flex-direction: row;
-  align-items: flex-start;
-  justify-content: flex-start;
-  color: #d8d8d8;
-}
-.avatarIcon {
-  width: 24px;
-  position: relative;
-  height: 24px;
-  object-fit: cover;
-}
-.userName {
-  flex: 1;
-  position: relative;
-}
-.personDetails {
-  width: 160px;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: flex-start;
-  gap: 10px;
-}
-.mainContentStack {
-  flex: 1;
-  /* height: 32px; */
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: flex-start;
-  gap: 20px;
-}
-.b {
-  position: relative;
-}
-.icon {
-  width: 16px;
-  position: relative;
-  height: 16px;
-  overflow: hidden;
-  flex-shrink: 0;
-}
-.transactionDetailsAllowance {
-  align-self: stretch;
-  /* display: flex; */
-  flex-direction: row;
-  align-items: center;
-  justify-content: flex-end;
-  padding: 0px 28px 0px 0px;
-  gap: 10px;
-  text-align: end !important;
-  color: #00a14b;
-}
-
-.transactionDetails {
-  align-self: stretch;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: flex-end;
-  padding: 0px 28px 0px 20px;
-  gap: 10px;
-  text-align: right;
-}
-.bodyContents {
-  flex: 1;
-  background-color: #1f1f1f;
-  /* height: 44px; */
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0px 10px;
-  box-sizing: border-box;
-}
-.bodycell {
-  align-self: stretch;
-  /* height: 44px; */
-  display: flex;
-  flex-direction: row;
-  align-items: flex-start;
-  justify-content: flex-start;
-}
 .feedlist {
   width: 100%;
   position: relative;
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
-  justify-content: flex-start;
+  align-items: stretch;
   gap: 1px;
   text-align: left;
-  font-size: 12px;
-  color: #fff;
-  font-family: Inter;
+  font-size: var(--font-size-sm);
+  color: var(--text-primary);
+  font-family: var(--font-family-base);
 }
 
-.lightHelightInItems {
-  margin-top: 8px;
+.bodycell {
+  align-self: stretch;
+  display: flex;
+  align-items: flex-start;
+}
+
+.bodyContents {
+  flex: 1;
+  min-width: 0;
+  background-color: var(--surface-page);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  box-sizing: border-box;
+}
+
+.mainContentStack {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3);
+}
+
+.avatarIcon {
+  width: 24px;
+  height: 24px;
+  object-fit: cover;
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.userName {
+  flex: 1;
+  min-width: 0;
+}
+
+.txTitle {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: var(--font-size-md);
+  line-height: 20px;
+}
+
+.pending {
+  display: inline-block;
+  margin-left: var(--space-2);
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  font-weight: 400;
+}
+
+.txMeta {
+  margin: var(--space-1) 0 0;
+  color: var(--text-muted);
+  font-size: var(--font-size-sm);
+  line-height: 16px;
+}
+
+.txMeta b {
+  color: var(--text-body);
+}
+
+.txMemo {
+  margin: var(--space-1) 0 0;
+  color: var(--text-body);
+  font-size: var(--font-size-sm);
+  line-height: 16px;
+  overflow-wrap: anywhere;
+}
+
+.transactionDetailsAllowance {
+  align-self: center;
+  flex-shrink: 0;
+  text-align: right;
+  padding-right: var(--space-2);
+  white-space: nowrap;
+}
+
+.amountPositive {
+  color: var(--accent);
+}
+
+.amountNegative {
+  color: var(--danger);
+}
+
+.b {
+  font-size: var(--font-size-md);
+}
+
+.emptyState {
+  width: 100%;
+  box-sizing: border-box;
+  padding: var(--space-6);
+  background-color: var(--surface-page);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  font-size: var(--font-size-md);
+  text-align: center;
+}
+
+.statusState {
+  width: 100%;
+  box-sizing: border-box;
+  padding: var(--space-4);
+  background-color: var(--surface-page);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  font-size: var(--font-size-md);
+  font-family: var(--font-family-base);
+}
+
+.errorState {
+  width: 100%;
+  box-sizing: border-box;
+  padding: var(--space-4);
+  background-color: var(--surface-page);
+  border-left: 3px solid var(--danger);
+  border-radius: var(--radius-sm);
+  color: var(--danger);
+  font-size: var(--font-size-md);
+  font-family: var(--font-family-base);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.errorState button {
+  flex-shrink: 0;
+  border: 1px solid var(--danger);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-primary);
+  padding: var(--space-2) var(--space-3);
+  cursor: pointer;
+}
+
+.errorState button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.skeletonRow {
+  width: 100%;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  background-color: var(--surface-page);
+}
+
+.skeletonAvatar {
+  width: 24px;
+  height: 24px;
+  border-radius: var(--radius-full);
+  background-color: var(--border);
+  flex-shrink: 0;
+}
+
+.skeletonLines {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.skeletonLine {
+  height: 10px;
+  border-radius: var(--radius-full);
+  background-color: var(--border);
+}
+
+.skeletonLineWide {
+  width: 60%;
+}
+
+.skeletonLineNarrow {
+  width: 35%;
+}
+
+.skeletonAmount {
+  width: 64px;
+  height: 12px;
+  border-radius: var(--radius-full);
+  background-color: var(--border);
+  flex-shrink: 0;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .skeletonAvatar,
+  .skeletonLine,
+  .skeletonAmount {
+    animation: skeletonPulse 1.5s ease-in-out infinite;
+  }
+
+  @keyframes skeletonPulse {
+    0%,
+    100% {
+      opacity: 1;
+    }
+    50% {
+      opacity: 0.45;
+    }
+  }
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 480px) {
+  .bodyContents {
+    flex-wrap: wrap;
+    padding: var(--space-3);
+  }
+
+  .transactionDetailsAllowance {
+    padding-right: 0;
+    margin-left: auto;
+  }
+
+  .errorState {
+    align-items: stretch;
+    flex-direction: column;
+  }
 }

--- a/tabs/src/components/WalletTransactionLog.test.tsx
+++ b/tabs/src/components/WalletTransactionLog.test.tsx
@@ -1,0 +1,297 @@
+import React, { act } from 'react';
+import { createRoot, Root } from 'react-dom/client';
+import {
+  getUsers,
+  getUserWallets,
+  getWalletTransactionsSince,
+} from '../services/lnbitsServiceLocal';
+import { fetchZapActivity } from '../utils/walletUtilities';
+import { RewardNameContext } from './RewardNameContext';
+import WalletTransactionLog from './WalletTransactionLog';
+
+const mockUseMsal = jest.fn();
+
+jest.mock('@azure/msal-react', () => ({
+  useMsal: () => mockUseMsal(),
+}));
+
+jest.mock('../services/lnbitsServiceLocal', () => ({
+  getUsers: jest.fn(),
+  getUserWallets: jest.fn(),
+  getWalletTransactionsSince: jest.fn(),
+}));
+
+jest.mock('../utils/walletUtilities', () => ({
+  ...jest.requireActual('../utils/walletUtilities'),
+  fetchZapActivity: jest.fn(),
+}));
+
+const user = (id: string, displayName: string): User => ({
+  id,
+  displayName,
+  profileImg: '',
+  aadObjectId: `aad-${id}`,
+  email: `${id}@example.test`,
+  type: 'Teammate',
+  privateWallet: null,
+  allowanceWallet: null,
+});
+
+const wallet = (id: string, name: string, owner: string): Wallet => ({
+  id,
+  name,
+  user: owner,
+  balance_msat: 0,
+  deleted: false,
+});
+
+const payment = (
+  checkingId: string,
+  walletId: string,
+  amount: number,
+  memo: string,
+  time = 1_700_000_000,
+): Transaction => ({
+  checking_id: checkingId,
+  pending: false,
+  amount,
+  fee: 0,
+  memo,
+  time,
+  extra: { tag: 'zap' },
+  wallet_id: walletId,
+});
+
+const alex = user('alex', 'Alex Rivera');
+const sam = user('sam', 'Sam Chen');
+const privateWallet = wallet('alex-private', 'Private', alex.id);
+const privateArchive = wallet(
+  'alex-private-archive',
+  'Private archive',
+  alex.id,
+);
+const knownIncoming = payment(
+  'known-transfer',
+  privateWallet.id,
+  20_000,
+  'Thanks for the review',
+);
+const knownOutgoingPair = payment(
+  'internal_known-transfer',
+  'sam-allowance',
+  -20_000,
+  'Thanks for the review',
+);
+
+let container: HTMLDivElement;
+let root: Root;
+
+const mount = async (
+  activeTab: 'all' | 'sent' | 'received' = 'all',
+  rewardContext: React.ContextType<typeof RewardNameContext> = {
+    rewardName: 'Sats',
+    setRewardName: jest.fn(),
+    isLoading: false,
+    error: null,
+  },
+) => {
+  // eslint-disable-next-line testing-library/no-unnecessary-act
+  await act(async () => {
+    root.render(
+      <RewardNameContext.Provider value={rewardContext}>
+        <WalletTransactionLog activeTab={activeTab} activeWallet="Private" />
+      </RewardNameContext.Provider>,
+    );
+  });
+};
+
+const settle = async () => {
+  await act(async () => {
+    await new Promise(resolve => setTimeout(resolve, 0));
+  });
+};
+
+const eventually = async (assertion: () => void) => {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await settle();
+    }
+  }
+  throw lastError;
+};
+
+const configureSuccess = (transactions: Transaction[] = [knownIncoming]) => {
+  (getUsers as jest.Mock).mockResolvedValue([alex]);
+  (getUserWallets as jest.Mock).mockResolvedValue([
+    privateArchive,
+    privateWallet,
+  ]);
+  (getWalletTransactionsSince as jest.Mock).mockResolvedValue(transactions);
+  (fetchZapActivity as jest.Mock).mockResolvedValue({
+    users: [alex, sam],
+    transfers: [{ transaction: knownOutgoingPair, from: sam, to: alex }],
+  });
+};
+
+describe('WalletTransactionLog', () => {
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    jest.clearAllMocks();
+    jest.spyOn(Date, 'now').mockReturnValue(1_700_000_100_000);
+    mockUseMsal.mockReturnValue({ accounts: [{ localAccountId: 'aad-alex' }] });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    jest.restoreAllMocks();
+  });
+
+  test('uses the exact selected wallet and verified transfer pairing', async () => {
+    configureSuccess();
+
+    await mount();
+    await eventually(() => {
+      expect(container.textContent).toContain('from Sam Chen');
+    });
+
+    expect(getUsers).toHaveBeenCalledWith({ aadObjectId: 'aad-alex' });
+    expect(getWalletTransactionsSince).toHaveBeenCalledWith(
+      privateWallet.id,
+      expect.any(Number),
+      null,
+    );
+    expect(container.textContent).toContain('+20 Sats');
+    expect(container.textContent).not.toContain('$0.11');
+  });
+
+  test('rejects ambiguous selected wallets', async () => {
+    configureSuccess();
+    (getUserWallets as jest.Mock).mockResolvedValue([
+      privateWallet,
+      wallet('alex-private-copy', ' private ', alex.id),
+    ]);
+
+    await mount();
+    await eventually(() => {
+      expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+        'Your Private wallet could not be identified uniquely.',
+      );
+    });
+
+    expect(getWalletTransactionsSince).not.toHaveBeenCalled();
+    expect(fetchZapActivity).not.toHaveBeenCalled();
+  });
+
+  test('does not infer a counterparty from memo text or mutate API data', async () => {
+    const unpaired = payment(
+      'external-payment',
+      privateWallet.id,
+      4_000,
+      'Payment from Sam Chen',
+    );
+    const originalExtra = unpaired.extra;
+    configureSuccess([unpaired]);
+    (fetchZapActivity as jest.Mock).mockResolvedValue({
+      users: [alex, sam],
+      transfers: [],
+    });
+
+    await mount();
+    await eventually(() => {
+      expect(container.textContent).toContain('Counterparty unavailable');
+    });
+
+    expect(container.textContent).toContain('from Counterparty unavailable');
+    expect(unpaired.extra).toBe(originalExtra);
+    expect(unpaired.extra).toEqual({ tag: 'zap' });
+  });
+
+  test('fails closed on incomplete activity data and retries the full request', async () => {
+    configureSuccess();
+    (fetchZapActivity as jest.Mock)
+      .mockRejectedValueOnce(new Error('Transaction history is unavailable.'))
+      .mockResolvedValueOnce({
+        users: [alex, sam],
+        transfers: [{ transaction: knownOutgoingPair, from: sam, to: alex }],
+      });
+
+    await mount();
+    await eventually(() => {
+      expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+        'Transaction history is unavailable.',
+      );
+    });
+    expect(container.textContent).not.toContain('+20 Sats');
+
+    const retry = Array.from(container.querySelectorAll('button')).find(
+      button => button.textContent === 'Try again',
+    );
+    if (!retry) throw new Error('Retry button was not rendered.');
+    await act(async () => {
+      retry.click();
+    });
+    await eventually(() => {
+      expect(container.textContent).toContain('from Sam Chen');
+    });
+    expect(fetchZapActivity).toHaveBeenCalledTimes(2);
+  });
+
+  test('does not query wallet data without an authenticated account', async () => {
+    mockUseMsal.mockReturnValue({ accounts: [] });
+
+    await mount();
+
+    expect(container.querySelector('[role="alert"]')?.textContent).toBe(
+      'Sign in to load your transaction history.',
+    );
+    expect(getUsers).not.toHaveBeenCalled();
+    expect(getUserWallets).not.toHaveBeenCalled();
+    expect(fetchZapActivity).not.toHaveBeenCalled();
+  });
+
+  test('does not select an arbitrary MSAL account', async () => {
+    mockUseMsal.mockReturnValue({
+      accounts: [{ localAccountId: 'aad-alex' }, { localAccountId: 'aad-sam' }],
+    });
+
+    await mount();
+
+    expect(container.querySelector('[role="alert"]')?.textContent).toBe(
+      'Your Zaplie account could not be identified.',
+    );
+    expect(getUsers).not.toHaveBeenCalled();
+    expect(getUserWallets).not.toHaveBeenCalled();
+  });
+
+  test('does not invent a reward name when configuration is unavailable', async () => {
+    configureSuccess();
+
+    await mount('all', {
+      rewardName: null,
+      setRewardName: jest.fn(),
+      isLoading: false,
+      error: new Error('Reward configuration is unavailable.'),
+      retry: jest.fn(),
+    });
+    await eventually(() => {
+      expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+        'Reward configuration is unavailable.',
+      );
+    });
+
+    expect(container.textContent).not.toContain('sats');
+  });
+});

--- a/tabs/src/components/WalletTransactionLog.tsx
+++ b/tabs/src/components/WalletTransactionLog.tsx
@@ -1,296 +1,269 @@
-import React, { useEffect, useState, useContext } from 'react';
-import styles from './WalletTransactionLog.module.css';
-import {
-  getUsers,
-  getWalletTransactionsSince,
-  getUserWallets,
-} from '../services/lnbitsServiceLocal';
+import React, { useContext, useEffect, useMemo, useState } from 'react';
+import { useMsal } from '@azure/msal-react';
 import ArrowIncoming from '../images/ArrowIncoming.svg';
 import ArrowOutgoing from '../images/ArrowOutcoming.svg';
-import moment from 'moment';
-import { useMsal } from '@azure/msal-react';
+import {
+  getUsers,
+  getUserWallets,
+  getWalletTransactionsSince,
+} from '../services/lnbitsServiceLocal';
+import {
+  fetchZapActivity,
+  pairId,
+  transactionTime,
+  ZapTransfer,
+} from '../utils/walletUtilities';
 import { RewardNameContext } from './RewardNameContext';
+import styles from './WalletTransactionLog.module.css';
+
+type HistoryFilter = 'all' | 'sent' | 'received';
 
 interface WalletTransactionLogProps {
-  activeTab?: string;
-  activeWallet?: string;
-  filterZaps?: (activeTab: string) => void;
+  activeTab: HistoryFilter;
+  activeWallet: WalletType;
 }
 
-// Time constants
-const SECONDS_PER_DAY = 86400;
-const MS_PER_SECOND = 1000;
+interface TransactionHistory {
+  currentUser: User;
+  transactions: Transaction[];
+  transfersById: Map<string, ZapTransfer>;
+}
+
+const SECONDS_PER_DAY = 86_400;
 const TRANSACTION_HISTORY_DAYS = 30;
+
+const relativeTime = (transaction: Transaction): string => {
+  const seconds = transactionTime(transaction);
+  if (!Number.isFinite(seconds)) return 'Time unavailable';
+
+  const elapsedSeconds = Math.max(0, Math.floor(Date.now() / 1000 - seconds));
+  if (elapsedSeconds < 60) return `${elapsedSeconds} seconds ago`;
+  if (elapsedSeconds < 3_600) {
+    return `${Math.floor(elapsedSeconds / 60)} minutes ago`;
+  }
+  if (elapsedSeconds < SECONDS_PER_DAY) {
+    return `${Math.floor(elapsedSeconds / 3_600)} hours ago`;
+  }
+  return `${Math.floor(elapsedSeconds / SECONDS_PER_DAY)} days ago`;
+};
+
+const counterpartyName = (
+  transaction: Transaction,
+  currentUser: User,
+  transfer: ZapTransfer | undefined,
+): string => {
+  if (!transfer) return 'Counterparty unavailable';
+
+  if (transaction.amount > 0) {
+    if (transfer.to.id !== currentUser.id) return 'Counterparty unavailable';
+    if (transaction.memo?.startsWith('[Anonymous]')) return 'Anonymous';
+    return (
+      transfer.from.displayName ||
+      transfer.from.email ||
+      'Counterparty unavailable'
+    );
+  }
+
+  if (transaction.amount < 0) {
+    if (transfer.from.id !== currentUser.id) {
+      return 'Counterparty unavailable';
+    }
+    return (
+      transfer.to.displayName || transfer.to.email || 'Counterparty unavailable'
+    );
+  }
+
+  return 'Counterparty unavailable';
+};
 
 const WalletTransactionLog: React.FC<WalletTransactionLogProps> = ({
   activeTab,
   activeWallet,
 }) => {
-  const [allTransactions, setAllTransactions] = useState<Transaction[]>([]); // Cache all transactions
-  const [displayedTransactions, setDisplayedTransactions] = useState<
-    Transaction[]
-  >([]); // Filtered transactions to display
+  const { accounts } = useMsal();
+  const accountCount = accounts.length;
+  const accountId =
+    accountCount === 1 ? accounts[0]?.localAccountId : undefined;
+  const {
+    rewardName,
+    isLoading: isRewardNameLoading,
+    error: rewardNameError,
+    retry: retryRewardName,
+  } = useContext(RewardNameContext);
+  const [history, setHistory] = useState<TransactionHistory | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [currentWallet, setCurrentWallet] = useState<string | undefined>(
-    undefined,
-  ); // Track which wallet data is cached for
+  const [retryToken, setRetryToken] = useState(0);
 
-  const { accounts } = useMsal();
-
-  // Effect to fetch data when wallet changes
   useEffect(() => {
-    // Calculate the timestamp for transaction history period
-    const transactionHistoryStart =
-      Date.now() / MS_PER_SECOND - TRANSACTION_HISTORY_DAYS * SECONDS_PER_DAY;
+    let cancelled = false;
 
-    const paymentsSinceTimestamp = transactionHistoryStart;
-
-    const account = accounts[0];
-
-    const fetchTransactions = async () => {
-      setLoading(true);
+    const loadTransactions = async () => {
+      setHistory(null);
       setError(null);
 
-      let fetchedTransactions: Transaction[] = [];
-
-      try {
-        // First, fetch all users
-        const allUsers = await getUsers({});
-
-        const currentUserLNbitDetails = await getUsers({
-          aadObjectId: account.localAccountId,
-        });
-
-        if (currentUserLNbitDetails && currentUserLNbitDetails.length > 0) {
-          const user = currentUserLNbitDetails[0];
-
-          // Fetch user's wallets
-          const userWallets = await getUserWallets(user.id);
-
-          // Create a wallet ID to user mapping for ALL users - parallelized
-          const walletToUserMap = new Map<string, User>();
-          let allPayments: Transaction[] = [];
-
-          if (allUsers) {
-            // Parallelize wallet fetches for all users
-            const walletResults = await Promise.all(
-              allUsers.map(async u => {
-                try {
-                  const wallets = await getUserWallets(u.id);
-                  return { user: u, wallets: wallets || [] };
-                } catch (err) {
-                  // Log error but continue - don't fail for one user
-                  return { user: u, wallets: [] };
-                }
-              }),
-            );
-
-            // Build wallet to user mapping
-            walletResults.forEach(({ user, wallets }) => {
-              wallets.forEach(wallet => {
-                walletToUserMap.set(wallet.id, user);
-              });
-            });
-
-            // Collect all wallets and parallelize payment fetches
-            const allWallets = walletResults.flatMap(r => r.wallets);
-            const paymentResults = await Promise.all(
-              allWallets.map(async wallet => {
-                try {
-                  return await getWalletTransactionsSince(
-                    wallet.id,
-                    paymentsSinceTimestamp,
-                    null,
-                  );
-                } catch (err) {
-                  // Log error but continue - don't fail for one wallet
-                  return [];
-                }
-              }),
-            );
-            allPayments = paymentResults.flat();
-          }
-
-          // Create a map of all payments by checking_id for internal transfer matching
-          const paymentsByCheckingId = new Map<string, Transaction[]>();
-          allPayments.forEach(payment => {
-            const cleanId = payment.checking_id?.replace('internal_', '') || '';
-            if (cleanId) {
-              const existing = paymentsByCheckingId.get(cleanId) || [];
-              existing.push(payment);
-              paymentsByCheckingId.set(cleanId, existing);
-            }
-          });
-
-          let walletId: string | undefined;
-
-          if (userWallets && userWallets.length > 0) {
-            if (activeWallet === 'Private') {
-              const privateWallet = userWallets.find(w =>
-                w.name.toLowerCase().includes('private'),
-              );
-              walletId = privateWallet?.id;
-            } else {
-              const allowanceWallet = userWallets.find(w =>
-                w.name.toLowerCase().includes('allowance'),
-              );
-              walletId = allowanceWallet?.id;
-            }
-          } else {
-            console.error('No wallets found for user');
-          }
-
-          if (!walletId) {
-            throw new Error('Selected wallet was not found');
-          }
-
-          const transactions = await getWalletTransactionsSince(
-            walletId,
-            paymentsSinceTimestamp,
-            null,
-          );
-
-          // Don't filter by tab here - we'll cache ALL transactions and filter later
-          for (const transaction of transactions) {
-            const walletOwner = walletToUserMap.get(transaction.wallet_id);
-            const isIncoming = transaction.amount > 0;
-
-            // Initialize extra.from and extra.to
-            if (!transaction.extra) {
-              transaction.extra = {};
-            }
-
-            // Try to find matching internal payment (the other side of the transfer)
-            const cleanCheckingId =
-              transaction.checking_id?.replace('internal_', '') || '';
-            const matchingPayments =
-              paymentsByCheckingId.get(cleanCheckingId) || [];
-            const matchingPayment = matchingPayments.find(
-              p => p.wallet_id !== transaction.wallet_id,
-            );
-
-            let otherUser: User | null = null;
-
-            // First try to find the other party via matching payment
-            if (matchingPayment) {
-              otherUser =
-                walletToUserMap.get(matchingPayment.wallet_id) || null;
-            }
-
-            // If no matching payment found, try to extract from memo
-            if (!otherUser && transaction.memo) {
-              // Try to find user by matching displayName or email in memo
-              const memo = transaction.memo.toLowerCase();
-              const foundUser = allUsers?.find(u => {
-                const displayName = u.displayName?.toLowerCase();
-                const email = u.email?.toLowerCase();
-                const username = u.email?.split('@')[0]?.toLowerCase();
-
-                return (
-                  (displayName && memo.includes(displayName)) ||
-                  (email && memo.includes(email)) ||
-                  (username && memo.includes(username))
-                );
-              });
-
-              if (foundUser) {
-                otherUser = foundUser;
-              }
-            }
-
-            if (isIncoming) {
-              // For incoming: TO = current wallet owner, FROM = other party
-              transaction.extra.to = walletOwner || null;
-              transaction.extra.from = otherUser;
-            } else {
-              // For outgoing: FROM = current wallet owner, TO = other party
-              transaction.extra.from = walletOwner || null;
-              transaction.extra.to = otherUser;
-            }
-          }
-
-          fetchedTransactions = fetchedTransactions.concat(transactions);
-        }
-
-        // Cache all transactions
-        setAllTransactions(fetchedTransactions);
-        setCurrentWallet(activeWallet);
-      } catch (error) {
-        if (error instanceof Error) {
-          setError(`Failed to fetch transactions: ${error.message}`);
-        } else {
-          setError('An unknown error occurred while fetching transactions');
-        }
-        console.error(error);
-      } finally {
+      if (!accountId) {
         setLoading(false);
+        setError(
+          accountCount === 0
+            ? 'Sign in to load your transaction history.'
+            : 'Your Zaplie account could not be identified.',
+        );
+        return;
+      }
+
+      setLoading(true);
+      try {
+        const matchingUsers = await getUsers({ aadObjectId: accountId });
+        if (matchingUsers.length !== 1) {
+          throw new Error('Your Zaplie account could not be identified.');
+        }
+
+        const currentUser = matchingUsers[0];
+        const wallets = await getUserWallets(currentUser.id);
+        const matchingWallets = wallets.filter(
+          candidate =>
+            candidate.name.trim().toLowerCase() === activeWallet.toLowerCase(),
+        );
+        if (matchingWallets.length === 0) {
+          throw new Error(`Your ${activeWallet} wallet could not be found.`);
+        }
+        if (matchingWallets.length > 1) {
+          throw new Error(
+            `Your ${activeWallet} wallet could not be identified uniquely.`,
+          );
+        }
+        const wallet = matchingWallets[0];
+
+        const since =
+          Date.now() / 1000 - TRANSACTION_HISTORY_DAYS * SECONDS_PER_DAY;
+        const [transactions, activity] = await Promise.all([
+          getWalletTransactionsSince(wallet.id, since, null),
+          fetchZapActivity(),
+        ]);
+        const transfersById = new Map(
+          activity.transfers
+            .map(transfer => [pairId(transfer.transaction), transfer] as const)
+            .filter(([id]) => Boolean(id)),
+        );
+
+        if (!cancelled) {
+          setHistory({ currentUser, transactions, transfersById });
+        }
+      } catch (loadError) {
+        if (!cancelled) {
+          setError(
+            loadError instanceof Error
+              ? loadError.message
+              : 'Transaction history could not be loaded.',
+          );
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
       }
     };
 
-    // Early return if no accounts available yet
-    if (!accounts || accounts.length === 0) {
-      setLoading(false);
-      return;
-    }
+    void loadTransactions();
+    return () => {
+      cancelled = true;
+    };
+  }, [accountCount, accountId, activeWallet, retryToken]);
 
-    // Only fetch if wallet changed or no data cached
-    if (currentWallet !== activeWallet) {
-      setAllTransactions([]);
-      setDisplayedTransactions([]);
-      fetchTransactions();
-    }
-  }, [activeWallet, accounts, currentWallet]);
+  const displayedTransactions = useMemo(() => {
+    if (!history) return [];
 
-  // Separate effect to filter cached transactions when activeTab changes
-  useEffect(() => {
-    if (allTransactions.length === 0) {
-      setDisplayedTransactions([]);
-      return;
-    }
-
-    let filtered: Transaction[];
-    if (activeTab === 'sent') {
-      filtered = allTransactions.filter(f => f.amount < 0);
-    } else if (activeTab === 'received') {
-      filtered = allTransactions.filter(f => f.amount > 0);
-    } else {
-      filtered = allTransactions;
-    }
-
-    setDisplayedTransactions(filtered);
-  }, [activeTab, allTransactions]);
-
-  const rewardNameContext = useContext(RewardNameContext);
-  if (!rewardNameContext) {
-    return null; // or handle the case where the context is not available
-  }
-  const rewardsName = rewardNameContext.rewardName;
+    return history.transactions
+      .filter(transaction => {
+        if (activeTab === 'sent') return transaction.amount < 0;
+        if (activeTab === 'received') return transaction.amount > 0;
+        return true;
+      })
+      .slice()
+      .sort((left, right) => transactionTime(right) - transactionTime(left));
+  }, [activeTab, history]);
 
   if (loading) {
-    return <div>Loading...</div>;
+    return (
+      <div className={styles.feedlist} aria-busy="true" role="status">
+        <span className={styles.srOnly}>Loading transactions</span>
+        {[0, 1, 2].map(placeholder => (
+          <div
+            key={placeholder}
+            className={styles.skeletonRow}
+            aria-hidden="true"
+          >
+            <div className={styles.skeletonAvatar} />
+            <div className={styles.skeletonLines}>
+              <div
+                className={`${styles.skeletonLine} ${styles.skeletonLineNarrow}`}
+              />
+              <div
+                className={`${styles.skeletonLine} ${styles.skeletonLineWide}`}
+              />
+            </div>
+            <div className={styles.skeletonAmount} />
+          </div>
+        ))}
+      </div>
+    );
   }
 
   if (error) {
-    return <div>{error}</div>;
+    return (
+      <div className={styles.errorState} role="alert">
+        <span>{error}</span>
+        {accountId && (
+          <button
+            type="button"
+            onClick={() => setRetryToken(token => token + 1)}
+          >
+            Try again
+          </button>
+        )}
+      </div>
+    );
   }
+
+  if (isRewardNameLoading) {
+    return (
+      <div className={styles.statusState} aria-busy="true" role="status">
+        Loading reward name…
+      </div>
+    );
+  }
+
+  if (rewardNameError || !rewardName) {
+    return (
+      <div className={styles.errorState} role="alert">
+        <span>
+          {rewardNameError?.message || 'The reward name is unavailable.'}
+        </span>
+        {retryRewardName && (
+          <button type="button" onClick={retryRewardName}>
+            Try again
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  if (!history) return null;
 
   return (
     <div className={styles.feedlist}>
-      {displayedTransactions
-        ?.sort((a, b) => {
-          // Convert both times to numbers for sorting
-          const timeA =
-            typeof a.time === 'number'
-              ? a.time
-              : new Date(a.time).getTime() / 1000;
-          const timeB =
-            typeof b.time === 'number'
-              ? b.time
-              : new Date(b.time).getTime() / 1000;
-          return timeB - timeA;
-        })
-        .map((transaction, index) => (
+      {displayedTransactions.map((transaction, index) => {
+        const outgoing = transaction.amount < 0;
+        const transfer = history.transfersById.get(pairId(transaction));
+        const counterparty = counterpartyName(
+          transaction,
+          history.currentUser,
+          transfer,
+        );
+        const time = transactionTime(transaction);
+        const memo = transaction.memo?.replace(/^\[Anonymous\]\s*/, '').trim();
+        const amount = transaction.amount / 1000;
+
+        return (
           <div
             key={transaction.checking_id || index}
             className={styles.bodycell}
@@ -300,105 +273,55 @@ const WalletTransactionLog: React.FC<WalletTransactionLogProps> = ({
                 <img
                   className={styles.avatarIcon}
                   alt=""
-                  src={
-                    (transaction.amount as number) < 0
-                      ? ArrowOutgoing
-                      : ArrowIncoming
-                  }
+                  src={outgoing ? ArrowOutgoing : ArrowIncoming}
                 />
-
                 <div className={styles.userName}>
-                  <p className={styles.lightHelightInItems}>
-                    {' '}
+                  <p className={styles.txTitle}>
                     <b>
-                      {transaction.extra?.tag === 'zap'
-                        ? 'Zap!'
-                        : (transaction.extra?.tag ?? 'Regular transaction')}
+                      {transaction.extra?.tag === 'zap' ? 'Zap' : 'Payment'}
                     </b>
+                    {transaction.pending && (
+                      <span className={styles.pending}>Pending</span>
+                    )}
                   </p>
-                  {/* 
-                    Dynamically calculate and display the time difference between the transaction and the current time.
-                    The output format adapts based on the time elapsed:
-                    - Less than 60 seconds: show in seconds.
-                    - Less than 1 hour: show in minutes.
-                    - Less than 1 day: show in hours.
-                    - More than 1 day: show in days.
-                  */}
-                  <div className={styles.lightHelightInItems}>
-                    {(() => {
-                      const now = moment();
-                      // Convert time to milliseconds for moment
-                      const timeInMs =
-                        typeof transaction.time === 'number'
-                          ? transaction.time * 1000
-                          : new Date(transaction.time).getTime();
-                      const transactionTime = moment(timeInMs);
-                      const diffInSeconds = now.diff(
-                        transactionTime,
-                        'seconds',
-                      );
-
-                      if (diffInSeconds < 60) {
-                        return `${diffInSeconds} seconds ago `;
-                      } else if (diffInSeconds < 3600) {
-                        const diffInMinutes = now.diff(
-                          transactionTime,
-                          'minutes',
-                        );
-                        return `${diffInMinutes} minutes ago `;
-                      } else if (diffInSeconds < 86400) {
-                        const diffInHours = now.diff(transactionTime, 'hours');
-                        return `${diffInHours} hours ago `;
-                      } else {
-                        const diffInDays = now.diff(transactionTime, 'days');
-                        return `${diffInDays} days ago `;
+                  <p className={styles.txMeta}>
+                    <time
+                      dateTime={
+                        Number.isFinite(time)
+                          ? new Date(time * 1000).toISOString()
+                          : undefined
                       }
-                    })()}
-                    {(transaction.amount as number) < 0 ? 'to' : 'from'}{' '}
-                    <b>
-                      {(transaction.amount as number) < 0
-                        ? transaction.extra?.to?.displayName ||
-                          transaction.extra?.to?.email ||
-                          'Unknown'
-                        : transaction.extra?.from?.displayName ||
-                          transaction.extra?.from?.email ||
-                          'Unknown'}{' '}
-                    </b>
-                  </div>
-                  <p className={styles.lightHelightInItems}>
-                    {transaction.memo}
+                    >
+                      {relativeTime(transaction)}
+                    </time>
+                    <span aria-hidden="true"> · </span>
+                    {outgoing
+                      ? 'to'
+                      : transaction.amount > 0
+                        ? 'from'
+                        : 'with'}{' '}
+                    <b>{counterparty}</b>
                   </p>
+                  {memo && <p className={styles.txMemo}>{memo}</p>}
                 </div>
               </div>
               <div
-                className={styles.transactionDetailsAllowance}
-                style={{
-                  color:
-                    (transaction.amount as number) < 0 ? '#E75858' : '#00A14B',
-                }}
+                className={`${styles.transactionDetailsAllowance} ${
+                  outgoing ? styles.amountNegative : styles.amountPositive
+                }`}
               >
-                <div className={styles.lightHelightInItems}>
-                  {' '}
-                  <b className={styles.b}>
-                    {transaction.amount < 0
-                      ? transaction.amount / 1000
-                      : '+' + transaction.amount / 1000}
-                  </b>{' '}
-                  {rewardsName}{' '}
-                </div>
-                <div
-                  style={{ display: 'none' }}
-                  className={styles.lightHelightInItems}
-                >
-                  {' '}
-                  about $0.11{' '}
-                </div>
+                <b className={styles.b}>
+                  {transaction.amount > 0 ? '+' : ''}
+                  {amount.toLocaleString()}
+                </b>{' '}
+                {rewardName}
               </div>
             </div>
           </div>
-        ))}
+        );
+      })}
       {displayedTransactions.length === 0 && (
-        <div>No transactions to show.</div>
+        <div className={styles.emptyState}>No transactions to show.</div>
       )}
     </div>
   );

--- a/tabs/src/utils/walletUtilities.test.ts
+++ b/tabs/src/utils/walletUtilities.test.ts
@@ -1,0 +1,125 @@
+import {
+  getAllPayments,
+  getUsers,
+  getUserWallets,
+} from '../services/lnbitsServiceLocal';
+import { fetchZapActivity } from './walletUtilities';
+
+jest.mock('../services/lnbitsServiceLocal', () => ({
+  getAllPayments: jest.fn(),
+  getUsers: jest.fn(),
+  getUserWallets: jest.fn(),
+}));
+
+const user = (id: string): User => ({
+  id,
+  displayName: id,
+  profileImg: '',
+  aadObjectId: `aad-${id}`,
+  email: `${id}@example.test`,
+  type: 'Teammate',
+  privateWallet: null,
+  allowanceWallet: null,
+});
+
+const wallet = (id: string, name: string, owner: string): Wallet => ({
+  id,
+  name,
+  user: owner,
+  balance_msat: 0,
+  deleted: false,
+});
+
+const payment = (
+  checkingId: string,
+  walletId: string,
+  amount: number,
+  time: number,
+): Transaction => ({
+  checking_id: checkingId,
+  pending: false,
+  amount,
+  fee: 0,
+  memo: 'Thanks',
+  time,
+  extra: {},
+  wallet_id: walletId,
+});
+
+describe('fetchZapActivity', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('returns only paired Allowance-to-Private transfers between users', async () => {
+    const alex = user('alex');
+    const sam = user('sam');
+    (getUsers as jest.Mock).mockResolvedValue([alex, sam]);
+    (getUserWallets as jest.Mock).mockImplementation(async (id: string) =>
+      id === 'alex'
+        ? [wallet('alex-a', ' allowance ', id), wallet('alex-p', 'private', id)]
+        : [wallet('sam-a', 'ALLOWANCE', id), wallet('sam-p', 'Private', id)],
+    );
+    (getAllPayments as jest.Mock).mockResolvedValue([
+      payment('internal_valid', 'alex-a', -20_000, 10),
+      payment('valid', 'sam-p', 20_000, 10),
+      payment('external', 'alex-a', -10_000, 20),
+      payment('internal_self', 'sam-a', -5_000, 30),
+      payment('self', 'sam-p', 5_000, 30),
+    ]);
+
+    const result = await fetchZapActivity();
+
+    expect(result.users).toEqual([alex, sam]);
+    expect(result.transfers).toEqual([
+      expect.objectContaining({
+        from: alex,
+        to: sam,
+        transaction: expect.objectContaining({ checking_id: 'internal_valid' }),
+      }),
+    ]);
+  });
+
+  test('rejects instead of presenting partial wallet data', async () => {
+    (getUsers as jest.Mock).mockResolvedValue([user('alex')]);
+    (getUserWallets as jest.Mock).mockRejectedValue(new Error('LNbits down'));
+
+    await expect(fetchZapActivity()).rejects.toThrow('LNbits down');
+    expect(getAllPayments).not.toHaveBeenCalled();
+  });
+
+  test('skips ambiguous and mismatched payment pairs', async () => {
+    const alex = user('alex');
+    const sam = user('sam');
+    (getUsers as jest.Mock).mockResolvedValue([alex, sam]);
+    (getUserWallets as jest.Mock).mockImplementation(async (id: string) =>
+      id === 'alex'
+        ? [wallet('alex-a', 'Allowance', id)]
+        : [wallet('sam-p', 'Private', id)],
+    );
+    (getAllPayments as jest.Mock).mockResolvedValue([
+      payment('internal_ambiguous', 'alex-a', -20_000, 10),
+      payment('ambiguous', 'sam-p', 20_000, 10),
+      payment('ambiguous', 'sam-p', 20_000, 10),
+      payment('internal_mismatch', 'alex-a', -10_000, 20),
+      payment('mismatch', 'sam-p', 9_000, 20),
+    ]);
+
+    await expect(fetchZapActivity()).resolves.toEqual({
+      users: [alex, sam],
+      transfers: [],
+    });
+  });
+
+  test('rejects conflicting wallet ownership', async () => {
+    const alex = user('alex');
+    const sam = user('sam');
+    (getUsers as jest.Mock).mockResolvedValue([alex, sam]);
+    (getUserWallets as jest.Mock).mockImplementation(async (id: string) => [
+      wallet('shared-wallet', 'Allowance', id),
+    ]);
+
+    await expect(fetchZapActivity()).rejects.toThrow(
+      'Wallet shared-wallet has conflicting owners.',
+    );
+    expect(getAllPayments).not.toHaveBeenCalled();
+  });
+});

--- a/tabs/src/utils/walletUtilities.ts
+++ b/tabs/src/utils/walletUtilities.ts
@@ -1,65 +1,100 @@
-import { getAllPayments } from '../services/lnbitsServiceLocal';
+import {
+  getAllPayments,
+  getUsers,
+  getUserWallets,
+} from '../services/lnbitsServiceLocal';
 
-//import { Wallet, ZapTransaction } from 'path-to-types';
+export interface ZapTransfer {
+  transaction: Transaction;
+  from: User;
+  to: User;
+}
 
-export const fetchAllowanceWalletTransactions = async (): Promise<
-  Transaction[]
-> => {
-  console.log('=== fetchAllowanceWalletTransactions DEBUG ===');
-  console.log(
-    'Using getAllPayments endpoint to fetch ALL payments from ALL users',
-  );
+export interface ZapActivity {
+  users: User[];
+  transfers: ZapTransfer[];
+}
 
-  try {
-    // Fetch ALL payments from ALL users using the new endpoint
-    const allPayments = await getAllPayments(10000); // Get up to 10000 payments
+export const pairId = (payment: Transaction) =>
+  payment.checking_id?.replace(/^internal_/, '') || '';
 
-    console.log('Total Payments Retrieved: ', allPayments.length);
-
-    // Filter to only exclude system transactions like "Weekly Allowance cleared"
-    // Don't filter by extra.tag since that field doesn't exist in the payment data
-    const zapTransactions = allPayments.filter(
-      payment => !payment.memo?.includes('Weekly Allowance cleared'),
-    );
-
-    console.log('Zap Transactions (filtered): ', zapTransactions.length);
-    console.log('Sample transaction:', zapTransactions[0]);
-    console.log('==============================================');
-
-    return zapTransactions;
-  } catch (error) {
-    console.error('Error fetching all payments:', error);
-    console.log('==============================================');
-    throw error;
-  }
+const walletType = (wallet: Wallet): 'allowance' | 'private' | null => {
+  const name = wallet.name.trim().toLowerCase();
+  if (name === 'allowance') return 'allowance';
+  if (name === 'private') return 'private';
+  return null;
 };
 
-export function getUserName(wallet: Wallet | null): string {
-  let userName = null;
-  try {
-    if (!wallet) {
-      return 'Unknown';
-    }
+export const transactionTime = (transaction: Transaction): number => {
+  const seconds =
+    typeof transaction.time === 'number'
+      ? transaction.time
+      : Date.parse(transaction.time) / 1000;
+  return Number.isFinite(seconds) ? seconds : Number.NEGATIVE_INFINITY;
+};
 
-    if (!wallet.name) {
-      return 'Unknown';
-    }
+export const fetchZapActivity = async (): Promise<ZapActivity> => {
+  const users = await getUsers();
+  const walletsByUser = await Promise.all(
+    users.map(async user => ({ user, wallets: await getUserWallets(user.id) })),
+  );
+  const walletOwners = new Map<string, User>();
+  const allowanceWalletIds = new Set<string>();
+  const privateWalletIds = new Set<string>();
 
-    if (wallet.name.includes(' - ')) {
-      userName = wallet.name.split(' - ')[0];
-      return userName;
-    } else {
-      return 'Unknown';
-    }
-  } catch (e) {
-    return 'Unknown';
-  }
-}
+  walletsByUser.forEach(({ user, wallets }) => {
+    wallets.forEach(wallet => {
+      const existingOwner = walletOwners.get(wallet.id);
+      if (existingOwner && existingOwner.id !== user.id) {
+        throw new Error(`Wallet ${wallet.id} has conflicting owners.`);
+      }
 
-export function getAadObjectId(wallet: Wallet): string {
-  throw new Error('Not yet implemented.');
-}
+      walletOwners.set(wallet.id, user);
+      const type = walletType(wallet);
+      if (type === 'allowance') allowanceWalletIds.add(wallet.id);
+      if (type === 'private') privateWalletIds.add(wallet.id);
+    });
+  });
 
-export function getWalletType(wallet: Wallet): string {
-  throw new Error('Not yet implemented.');
-}
+  const payments = await getAllPayments(10_000);
+  const paymentsByPair = new Map<string, Transaction[]>();
+  payments.forEach(payment => {
+    const id = pairId(payment);
+    if (!id) return;
+    const matches = paymentsByPair.get(id) ?? [];
+    matches.push(payment);
+    paymentsByPair.set(id, matches);
+  });
+
+  const transfers = Array.from(paymentsByPair.values()).flatMap<ZapTransfer>(
+    pairedPayments => {
+      if (pairedPayments.length !== 2) return [];
+
+      const outgoing = pairedPayments.filter(
+        payment =>
+          payment.amount < 0 && allowanceWalletIds.has(payment.wallet_id),
+      );
+      const incoming = pairedPayments.filter(
+        payment =>
+          payment.amount > 0 && privateWalletIds.has(payment.wallet_id),
+      );
+      if (outgoing.length !== 1 || incoming.length !== 1) return [];
+      if (Math.abs(outgoing[0].amount) !== incoming[0].amount) return [];
+
+      const from = walletOwners.get(outgoing[0].wallet_id);
+      const to = walletOwners.get(incoming[0].wallet_id);
+      if (!from || !to || from.id === to.id) return [];
+
+      return [{ transaction: outgoing[0], from, to }];
+    },
+  );
+
+  transfers.sort(
+    (left, right) =>
+      transactionTime(right.transaction) - transactionTime(left.transaction),
+  );
+  return { users, transfers };
+};
+
+export const fetchAllowanceWalletTransactions = async () =>
+  (await fetchZapActivity()).transfers.map(transfer => transfer.transaction);


### PR DESCRIPTION
Fixes #331

Part of splitting #287 into reviewable layers. Stacked on the wallet payments PR.

## What changed
- Transaction history verifies zap pairs instead of guessing: `walletUtilities` requires exact two-sided payment pairs (matching amounts, distinct owners) keyed by `checking_id`, and flags wallets with conflicting owners rather than picking the first.
- `WalletTransactionLog` renders explicit loading/error/retry states (no more `rewardName ?? 'sats'` fallback), handles multiple signed-in MSAL accounts, and reuses the shared `pairId`/`transactionTime` helpers from `walletUtilities` instead of local copies.

## Test plan for QA
- `npm test` (tabs): new `walletUtilities.test.ts` covers pair matching, conflicting-owner detection, and unpaired-payment exclusion.