### PR TITLE
fix: run the weekly allowance and make it safe to trigger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,10 @@ tabs/backend/pending-rewards.json
 tabs/backend/connections.json
 tabs/backend/webhook-keys.json
 
+# Local bot data directory (weekly allowance run guard); deployed instances
+# point ZAPLIE_DATA_DIR outside the app.
+.zaplie-data/
+
 # Generated documentation PDF
 docs/TECHNICAL_SOLUTION_DOCUMENT.pdf
 docs/.asciidoctor/

--- a/docs/DEPLOYMENT.adoc
+++ b/docs/DEPLOYMENT.adoc
@@ -154,10 +154,31 @@ Deploy `dist/` with Azure Functions Core Tools or your preferred pipeline
 | `WEBSITE_API_URL`
 | Reward-name API base URL used by the bot
 | Bot
+
+| `BOT_API_RATE_LIMIT`
+| Requests per minute allowed on the bot's `/api/v1/*` routes (positive
+  integer, default 30). Distinct from the tabs backend's `API_RATE_LIMIT`
+| Bot
 |===
 
 Secrets belong in `env/.env.*.user` files (gitignored) or Azure app settings —
 never in tracked files.
+
+== Weekly Allowance Schedule
+
+An external scheduler (Azure Logic App) must POST
+`/api/v1/allowance/topup` once a week with the same `x-api-key` header as
+`/api/v1/rewards`. The run sweeps every Allowance wallet back to the treasury
+and refills it to `LNBITS_INITIAL_ALLOWANCE`; nothing inside the bot fires it.
+
+Weeks are ISO-8601 weeks computed in *UTC*, so schedule the trigger in UTC too
+— a local-time Monday schedule near midnight can land in the previous UTC week.
+A trigger that repeats inside the same UTC ISO week is answered with
+`{"skipped": true}` and moves no funds; concurrent triggers join the single run
+in flight. The guard is a JSON record in `ZAPLIE_DATA_DIR`, written *before*
+the sweep starts, so a crash mid-run leaves the week blocked until an operator
+reconciles the wallets against LNbits. An unreadable or corrupt guard answers
+`503` and sweeps nothing.
 
 == Manifest and App Package
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "dotenv": "^16.4.5",
         "dotenv-flow": "^4.1.0",
         "express": "^5.2.1",
+        "express-rate-limit": "^8.6.2",
         "isomorphic-fetch": "^3.0.0",
         "node-cron": "^3.0.3",
         "react-qr-reader": "^3.0.0-beta-1",
@@ -5013,6 +5014,25 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/express/node_modules/mime-db": {
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
@@ -5887,6 +5907,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/ipaddr.js": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "dotenv": "^16.4.5",
     "dotenv-flow": "^4.1.0",
     "express": "^5.2.1",
+    "express-rate-limit": "^8.6.2",
     "isomorphic-fetch": "^3.0.0",
     "node-cron": "^3.0.3",
     "react-qr-reader": "^3.0.0-beta-1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 // Import required packages
 import express from 'express';
+import { rateLimit } from 'express-rate-limit';
 import * as fs from 'fs';
 import * as path from 'path';
 import { createHash, timingSafeEqual } from 'crypto';
@@ -28,6 +29,7 @@ import {
   payReward,
   RewardError,
 } from './services/rewardsService';
+import { createAllowanceTopupHandler } from './services/allowanceTopup';
 
 // Create adapter.
 // See https://aka.ms/about-bot-adapter to learn more about adapters.
@@ -111,6 +113,42 @@ const bot = new TeamsBot();
 // Create HTTP server. Express instead of restify: restify still requires
 // spdy, whose native http_parser binding no longer exists on Node >= 21.
 const server = express();
+
+// Azure App Service fronts the bot with a single proxy; without this the
+// limiter would key every client on the proxy's IP.
+server.set('trust proxy', 1);
+
+const DEFAULT_API_RATE_LIMIT = 30;
+
+// Named for the bot specifically: the tabs backend reads API_RATE_LIMIT with a
+// browser-sized default, and one shared name would silently apply the wrong
+// budget to whichever process is configured second. A malformed value falls
+// back to the default rather than to `Number()`'s NaN, which would disable the
+// limit entirely.
+const botApiRateLimit = (): number => {
+  const configured = process.env.BOT_API_RATE_LIMIT?.trim();
+  if (!configured) {
+    return DEFAULT_API_RATE_LIMIT;
+  }
+  const parsed = Number(configured);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    console.warn(
+      `BOT_API_RATE_LIMIT must be a positive integer; using ${DEFAULT_API_RATE_LIMIT}`,
+    );
+    return DEFAULT_API_RATE_LIMIT;
+  }
+  return parsed;
+};
+
+// The API routes are called by schedulers and automations, never by browsers,
+// so a tight window is plenty and CodeQL's js/missing-rate-limiting is
+// satisfied by a recognised middleware.
+const apiRateLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  limit: botApiRateLimit(),
+  standardHeaders: true,
+  legacyHeaders: false,
+});
 server.disable('x-powered-by');
 server.use(express.json());
 server.get('/healthz', (_req, res) => {
@@ -162,7 +200,7 @@ const isAuthorizedRewardKey = async (providedKey: string): Promise<boolean> => {
 };
 
 // Deterministic automation path — no LLM can trigger a payment here.
-server.post('/api/v1/rewards', async (req, res) => {
+server.post('/api/v1/rewards', apiRateLimiter, async (req, res) => {
   try {
     if (!(await isAuthorizedRewardKey(req.header('x-api-key') ?? ''))) {
       res.status(401).json({ error: 'invalid API key' });
@@ -209,6 +247,16 @@ server.post('/api/v1/rewards', async (req, res) => {
     res.status(500).json({ error: 'internal error' });
   }
 });
+
+// Weekly allowance sweep-and-refill, fired by an external scheduler (e.g. an
+// Azure Logic App). Same key contract as /api/v1/rewards; a re-fired trigger
+// inside the same ISO week is answered with {skipped: true} instead of
+// sweeping wallets twice.
+server.post(
+  '/api/v1/allowance/topup',
+  apiRateLimiter,
+  createAllowanceTopupHandler({ isAuthorized: isAuthorizedRewardKey }),
+);
 
 const authStartPage = fs.readFileSync(
   path.join(__dirname, '../public/auth-start.html'),

--- a/src/services/allowanceTopup.test.ts
+++ b/src/services/allowanceTopup.test.ts
@@ -118,6 +118,16 @@ describe('allowance run store', () => {
     );
     expect(() => readLastRun()).toThrow(AllowanceGuardError);
 
+    // A week label nothing could have written must not be read back as "some
+    // other week", which would let this week be swept again.
+    for (const isoWeek of ['junk', '2026-34', '2026-W00', '2026-W54']) {
+      fs.writeFileSync(
+        file,
+        JSON.stringify({ isoWeek, startedAt: '2026-08-18T05:59:00.000Z' }),
+      );
+      expect(() => readLastRun()).toThrow(AllowanceGuardError);
+    }
+
     fs.rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/src/services/allowanceTopup.test.ts
+++ b/src/services/allowanceTopup.test.ts
@@ -1,0 +1,441 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import type { Request, Response } from 'express';
+import {
+  AllowanceGuardError,
+  AllowanceRunRecord,
+  clearRun,
+  createAllowanceTopupHandler,
+  isoWeekOf,
+  readLastRun,
+  recordRun,
+} from './allowanceTopup';
+import { RewardError } from './rewardsService';
+
+const originalEnv = { ...process.env };
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+  jest.restoreAllMocks();
+});
+
+const request = (apiKey?: string): Request =>
+  ({
+    header: (name: string) =>
+      name.toLowerCase() === 'x-api-key' ? apiKey : undefined,
+  }) as unknown as Request;
+
+interface CapturedResponse {
+  statusCode: number;
+  body: unknown;
+}
+
+const response = (): Response & CapturedResponse => {
+  const res = {
+    statusCode: 0,
+    body: undefined as unknown,
+    status(code: number) {
+      res.statusCode = code;
+      return res;
+    },
+    json(payload: unknown) {
+      res.body = payload;
+      return res;
+    },
+  };
+  return res as unknown as Response & CapturedResponse;
+};
+
+const summary = (
+  overrides: Partial<{
+    wallets: number;
+    swept: number;
+    toppedUp: number;
+    failures: { walletId: string; error: string }[];
+    warnings: { walletId: string; warning: string }[];
+  }> = {},
+) => ({
+  wallets: 2,
+  swept: 1,
+  toppedUp: 2,
+  failures: [],
+  warnings: [],
+  ...overrides,
+});
+
+const passingConfig = () => undefined;
+
+describe('isoWeekOf', () => {
+  test('labels dates with their ISO week', () => {
+    expect(isoWeekOf(new Date(Date.UTC(2026, 7, 18)))).toBe('2026-W34');
+    // January 1st 2027 is a Friday and still belongs to 2026's last week.
+    expect(isoWeekOf(new Date(Date.UTC(2027, 0, 1)))).toBe('2026-W53');
+    expect(isoWeekOf(new Date(Date.UTC(2027, 0, 4)))).toBe('2027-W01');
+  });
+});
+
+describe('allowance run store', () => {
+  test('round-trips the run record and clears it', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'allowance-store-'));
+    process.env.ZAPLIE_DATA_DIR = dir;
+
+    expect(readLastRun()).toBeNull();
+
+    const record: AllowanceRunRecord = {
+      isoWeek: '2026-W34',
+      startedAt: '2026-08-18T05:59:00.000Z',
+      lastSuccessAt: '2026-08-18T06:00:00.000Z',
+      summary: { wallets: 2, swept: 1, toppedUp: 2, failed: 0, warned: 0 },
+    };
+    recordRun(record);
+    expect(readLastRun()).toEqual(record);
+
+    clearRun();
+    expect(readLastRun()).toBeNull();
+    // Clearing an already-absent guard is not an error.
+    expect(() => clearRun()).not.toThrow();
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('fails closed on a corrupt or unrecognised guard file', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'allowance-store-'));
+    process.env.ZAPLIE_DATA_DIR = dir;
+    const file = path.join(dir, 'allowance-runs.json');
+
+    // A guard we cannot read must never be mistaken for "never ran": that
+    // would authorise a second sweep of the same week.
+    fs.writeFileSync(file, 'not json');
+    expect(() => readLastRun()).toThrow(AllowanceGuardError);
+
+    fs.writeFileSync(file, JSON.stringify({ isoWeek: '2026-W34' }));
+    expect(() => readLastRun()).toThrow(AllowanceGuardError);
+
+    fs.writeFileSync(
+      file,
+      JSON.stringify({ isoWeek: '2026-W34', startedAt: 'not-a-date' }),
+    );
+    expect(() => readLastRun()).toThrow(AllowanceGuardError);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe('createAllowanceTopupHandler', () => {
+  test('rejects a missing or wrong API key with 401', async () => {
+    const runTopup = jest.fn();
+    const handler = createAllowanceTopupHandler({
+      isAuthorized: async () => false,
+      runTopup,
+    });
+    const res = response();
+
+    await handler(request(), res);
+
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toEqual({ error: 'invalid API key' });
+    expect(runTopup).not.toHaveBeenCalled();
+  });
+
+  test('surfaces a RewardError from key validation with its status', async () => {
+    const handler = createAllowanceTopupHandler({
+      isAuthorized: async () => {
+        throw new RewardError('rewards endpoint disabled', 503);
+      },
+    });
+    const res = response();
+
+    await handler(request('any'), res);
+
+    expect(res.statusCode).toBe(503);
+    expect(res.body).toEqual({ error: 'rewards endpoint disabled' });
+  });
+
+  test('returns 503 when the LNbits configuration is incomplete', async () => {
+    delete process.env.LNBITS_INKEY;
+    const runTopup = jest.fn();
+    const handler = createAllowanceTopupHandler({
+      isAuthorized: async () => true,
+      runTopup,
+    });
+    const res = response();
+
+    await handler(request('valid-key'), res);
+
+    expect(res.statusCode).toBe(503);
+    expect(res.body).toEqual({
+      error: expect.stringContaining('allowance topup not configured'),
+    });
+    expect(runTopup).not.toHaveBeenCalled();
+  });
+
+  test('refuses to sweep when the run guard cannot be read', async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const runTopup = jest.fn();
+    const handler = createAllowanceTopupHandler({
+      isAuthorized: async () => true,
+      runTopup,
+      assertConfig: passingConfig,
+      getLastRun: () => {
+        throw new AllowanceGuardError('allowance run guard is invalid');
+      },
+    });
+    const res = response();
+
+    await handler(request('valid-key'), res);
+
+    expect(res.statusCode).toBe(503);
+    expect(res.body).toEqual({ error: 'allowance guard unavailable' });
+    expect(runTopup).not.toHaveBeenCalled();
+  });
+
+  test('runs the topup and records the week on success', async () => {
+    const saveRun = jest.fn();
+    const now = new Date('2026-08-18T06:00:00.000Z');
+    const handler = createAllowanceTopupHandler({
+      isAuthorized: async () => true,
+      runTopup: async () => summary(),
+      assertConfig: passingConfig,
+      getLastRun: () => null,
+      saveRun,
+      now: () => now,
+    });
+    const res = response();
+
+    await handler(request('valid-key'), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      skipped: false,
+      wallets: 2,
+      swept: 1,
+      toppedUp: 2,
+      failed: 0,
+      failures: [],
+      lastSuccessAt: '2026-08-18T06:00:00.000Z',
+    });
+    // The week is claimed before the sweep begins, then completed.
+    expect(saveRun).toHaveBeenNthCalledWith(1, {
+      isoWeek: '2026-W34',
+      startedAt: '2026-08-18T06:00:00.000Z',
+    });
+    expect(saveRun).toHaveBeenNthCalledWith(2, {
+      isoWeek: '2026-W34',
+      startedAt: '2026-08-18T06:00:00.000Z',
+      lastSuccessAt: '2026-08-18T06:00:00.000Z',
+      summary: { wallets: 2, swept: 1, toppedUp: 2, failed: 0, warned: 0 },
+    });
+  });
+
+  test('reports per-wallet failures and warnings and keeps the week guard', async () => {
+    const saveRun = jest.fn();
+    const handler = createAllowanceTopupHandler({
+      isAuthorized: async () => true,
+      runTopup: async () =>
+        summary({
+          swept: 1,
+          toppedUp: 1,
+          failures: [{ walletId: 'wallet-2', error: 'payment failed' }],
+          warnings: [{ walletId: 'wallet-1', warning: 'left 500 msat' }],
+        }),
+      assertConfig: passingConfig,
+      getLastRun: () => null,
+      saveRun,
+      now: () => new Date('2026-08-18T06:00:00.000Z'),
+    });
+    const res = response();
+
+    await handler(request('valid-key'), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({
+      skipped: false,
+      failed: 1,
+      failures: [{ walletId: 'wallet-2', error: 'payment failed' }],
+      warnings: [{ walletId: 'wallet-1', warning: 'left 500 msat' }],
+      lastError: 'payment failed',
+    });
+    expect(saveRun).toHaveBeenCalledTimes(2);
+    expect(saveRun).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        summary: { wallets: 2, swept: 1, toppedUp: 1, failed: 1, warned: 1 },
+      }),
+    );
+  });
+
+  test('drops the week guard when the run proved no funds moved', async () => {
+    const saveRun = jest.fn();
+    const clearLastRun = jest.fn();
+    const handler = createAllowanceTopupHandler({
+      isAuthorized: async () => true,
+      runTopup: async () =>
+        summary({
+          swept: 0,
+          toppedUp: 0,
+          failures: [
+            { walletId: 'wallet-1', error: 'LNbits unavailable' },
+            { walletId: 'wallet-2', error: 'LNbits unavailable' },
+          ],
+        }),
+      assertConfig: passingConfig,
+      getLastRun: () => null,
+      saveRun,
+      clearLastRun,
+    });
+    const res = response();
+
+    await handler(request('valid-key'), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({ skipped: false, failed: 2 });
+    // Only the pre-run claim was written, and it is withdrawn again so the
+    // scheduler's retry can try the week once more.
+    expect(saveRun).toHaveBeenCalledTimes(1);
+    expect(clearLastRun).toHaveBeenCalledTimes(1);
+  });
+
+  test('skips a duplicate trigger inside the same ISO week', async () => {
+    const runTopup = jest.fn();
+    const lastRun: AllowanceRunRecord = {
+      isoWeek: '2026-W34',
+      startedAt: '2026-08-17T05:59:00.000Z',
+      lastSuccessAt: '2026-08-17T06:00:00.000Z',
+      summary: { wallets: 2, swept: 2, toppedUp: 2, failed: 0, warned: 0 },
+    };
+    const handler = createAllowanceTopupHandler({
+      isAuthorized: async () => true,
+      runTopup,
+      assertConfig: passingConfig,
+      getLastRun: () => lastRun,
+      now: () => new Date('2026-08-18T06:00:00.000Z'),
+    });
+    const res = response();
+
+    await handler(request('valid-key'), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ skipped: true, lastRun });
+    expect(runTopup).not.toHaveBeenCalled();
+  });
+
+  test('skips a week whose run started and never reported back', async () => {
+    const runTopup = jest.fn();
+    const lastRun: AllowanceRunRecord = {
+      isoWeek: '2026-W34',
+      startedAt: '2026-08-18T05:59:00.000Z',
+      lastErrorAt: '2026-08-18T05:59:30.000Z',
+      lastError: 'LNbits unreachable',
+    };
+    const handler = createAllowanceTopupHandler({
+      isAuthorized: async () => true,
+      runTopup,
+      assertConfig: passingConfig,
+      getLastRun: () => lastRun,
+      now: () => new Date('2026-08-18T06:00:00.000Z'),
+    });
+    const res = response();
+
+    await handler(request('valid-key'), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ skipped: true, lastRun });
+    expect(runTopup).not.toHaveBeenCalled();
+  });
+
+  test('two concurrent triggers share a single sweep', async () => {
+    let release: () => void = () => undefined;
+    const started = new Promise<void>(resolve => {
+      release = resolve;
+    });
+    const runTopup = jest.fn(async () => {
+      await started;
+      return summary();
+    });
+    const saveRun = jest.fn();
+    // Both requests observe an empty guard: the persisted record cannot help
+    // here because neither has written anything yet.
+    const handler = createAllowanceTopupHandler({
+      isAuthorized: async () => true,
+      runTopup,
+      assertConfig: passingConfig,
+      getLastRun: () => null,
+      saveRun,
+      now: () => new Date('2026-08-18T06:00:00.000Z'),
+    });
+    const first = response();
+    const second = response();
+
+    const requests = Promise.all([
+      handler(request('valid-key'), first),
+      handler(request('valid-key'), second),
+    ]);
+    release();
+    await requests;
+
+    expect(runTopup).toHaveBeenCalledTimes(1);
+    expect(first.statusCode).toBe(200);
+    expect(first.body).toMatchObject({ skipped: false, swept: 1 });
+    expect(second.statusCode).toBe(200);
+    expect(second.body).toMatchObject({
+      skipped: true,
+      lastRun: expect.objectContaining({ isoWeek: '2026-W34' }),
+    });
+  });
+
+  test('runs again in a new ISO week', async () => {
+    const saveRun = jest.fn();
+    const runTopup = jest.fn(async () => summary());
+    const handler = createAllowanceTopupHandler({
+      isAuthorized: async () => true,
+      runTopup,
+      assertConfig: passingConfig,
+      getLastRun: () => ({
+        isoWeek: '2026-W33',
+        startedAt: '2026-08-11T05:59:00.000Z',
+        lastSuccessAt: '2026-08-11T06:00:00.000Z',
+        summary: { wallets: 2, swept: 2, toppedUp: 2, failed: 0, warned: 0 },
+      }),
+      saveRun,
+      now: () => new Date('2026-08-18T06:00:00.000Z'),
+    });
+    const res = response();
+
+    await handler(request('valid-key'), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({ skipped: false });
+    expect(runTopup).toHaveBeenCalledTimes(1);
+  });
+
+  test('answers 500 without internals and keeps the week when the run throws', async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const saveRun = jest.fn();
+    const clearLastRun = jest.fn();
+    const handler = createAllowanceTopupHandler({
+      isAuthorized: async () => true,
+      runTopup: async () => {
+        throw new Error('Unable to load allowance wallets');
+      },
+      assertConfig: passingConfig,
+      getLastRun: () => null,
+      saveRun,
+      clearLastRun,
+      now: () => new Date('2026-08-18T06:00:00.000Z'),
+    });
+    const res = response();
+
+    await handler(request('valid-key'), res);
+
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toEqual({ error: 'internal error' });
+    // The run's effect is unknown, so the week stays claimed for an operator.
+    expect(clearLastRun).not.toHaveBeenCalled();
+    expect(saveRun).toHaveBeenLastCalledWith({
+      isoWeek: '2026-W34',
+      startedAt: '2026-08-18T06:00:00.000Z',
+      lastErrorAt: '2026-08-18T06:00:00.000Z',
+      lastError: 'Unable to load allowance wallets',
+    });
+  });
+});

--- a/src/services/allowanceTopup.ts
+++ b/src/services/allowanceTopup.ts
@@ -77,6 +77,11 @@ export const isoWeekOf = (date: Date): string => {
 const isIsoTimestamp = (value: unknown): value is string =>
   typeof value === 'string' && !Number.isNaN(Date.parse(value));
 
+// A week label we could not have written would read as "a different week" and
+// authorise a second sweep, so anything off-format is corruption.
+const isIsoWeek = (value: unknown): value is string =>
+  typeof value === 'string' && /^\d{4}-W(0[1-9]|[1-4]\d|5[0-3])$/.test(value);
+
 // A missing file means the guard has never been written and the run may
 // proceed. Anything else — unreadable file, invalid JSON, a record we cannot
 // interpret — must fail closed: treating a corrupt guard as "never ran" is how
@@ -107,10 +112,9 @@ export const readLastRun = (): AllowanceRunRecord | null => {
 
   const record = parsed as Partial<AllowanceRunRecord> | null;
   if (
-    typeof record?.isoWeek !== 'string' ||
-    record.isoWeek.length === 0 ||
-    !isIsoTimestamp(record.startedAt) ||
-    (record.lastSuccessAt !== undefined &&
+    !isIsoWeek(record?.isoWeek) ||
+    !isIsoTimestamp(record?.startedAt) ||
+    (record?.lastSuccessAt !== undefined &&
       !isIsoTimestamp(record.lastSuccessAt))
   ) {
     throw new AllowanceGuardError('allowance run guard is invalid');

--- a/src/services/allowanceTopup.ts
+++ b/src/services/allowanceTopup.ts
@@ -1,0 +1,316 @@
+// Trigger contract for the weekly allowance run (POST /api/v1/allowance/topup).
+//
+// Operator contract: an external scheduler (Azure Logic App) POSTs this route
+// once a week with the `x-api-key` header used by /api/v1/rewards. Weeks are
+// ISO-8601 weeks computed in UTC, so a Monday-morning schedule in any local
+// timezone lands inside the intended week. The response is JSON: `skipped`
+// says whether this trigger started a run, and per-wallet counters report what
+// moved.
+//
+// Schedulers retry, and a retry that re-runs the sweep would send the freshly
+// granted allowances straight back to the treasury. Two guards prevent that:
+// a persisted week record (written before the run starts, so a crash mid-run
+// still blocks the week) and an in-process promise shared by concurrent
+// triggers, so two simultaneous POSTs join one run instead of both sweeping.
+
+import * as fs from 'fs';
+import * as path from 'path';
+import type { Request, Response } from 'express';
+import {
+  assertWeeklyAllowanceConfig,
+  scheduledTopup,
+  WeeklyAllowanceSummary,
+} from './lnbitsService';
+import { resolveDataDir } from './dataDir';
+import { RewardError } from './rewardsService';
+
+export interface AllowanceRunSummary {
+  wallets: number;
+  swept: number;
+  toppedUp: number;
+  failed: number;
+  warned: number;
+}
+
+export interface AllowanceRunRecord {
+  isoWeek: string;
+  // Written before the sweep begins. A record with no `lastSuccessAt` is a run
+  // that started and never reported back — the week stays blocked until an
+  // operator reconciles it.
+  startedAt: string;
+  lastSuccessAt?: string;
+  summary?: AllowanceRunSummary;
+  lastErrorAt?: string;
+  lastError?: string;
+}
+
+export class AllowanceGuardError extends Error {
+  constructor(
+    message: string,
+    readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = 'AllowanceGuardError';
+  }
+}
+
+const isErrnoException = (error: unknown): error is NodeJS.ErrnoException =>
+  typeof error === 'object' && error !== null && 'code' in error;
+
+const runFilePath = (): string =>
+  path.join(resolveDataDir(), 'allowance-runs.json');
+
+// ISO-8601 week label (e.g. 2026-W34), always in UTC. The week's year can
+// differ from the calendar year around January 1st, so it is derived from the
+// week's Thursday.
+export const isoWeekOf = (date: Date): string => {
+  const day = new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
+  );
+  const weekday = day.getUTCDay() || 7;
+  day.setUTCDate(day.getUTCDate() + 4 - weekday);
+  const yearStart = Date.UTC(day.getUTCFullYear(), 0, 1);
+  const week = Math.ceil(((day.getTime() - yearStart) / 86400000 + 1) / 7);
+  return `${day.getUTCFullYear()}-W${String(week).padStart(2, '0')}`;
+};
+
+const isIsoTimestamp = (value: unknown): value is string =>
+  typeof value === 'string' && !Number.isNaN(Date.parse(value));
+
+// A missing file means the guard has never been written and the run may
+// proceed. Anything else — unreadable file, invalid JSON, a record we cannot
+// interpret — must fail closed: treating a corrupt guard as "never ran" is how
+// a second sweep gets authorised.
+export const readLastRun = (): AllowanceRunRecord | null => {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(runFilePath(), 'utf8');
+  } catch (error) {
+    if (isErrnoException(error) && error.code === 'ENOENT') {
+      return null;
+    }
+    throw new AllowanceGuardError(
+      'allowance run guard could not be read',
+      error,
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new AllowanceGuardError(
+      'allowance run guard is not valid JSON',
+      error,
+    );
+  }
+
+  const record = parsed as Partial<AllowanceRunRecord> | null;
+  if (
+    typeof record?.isoWeek !== 'string' ||
+    record.isoWeek.length === 0 ||
+    !isIsoTimestamp(record.startedAt) ||
+    (record.lastSuccessAt !== undefined &&
+      !isIsoTimestamp(record.lastSuccessAt))
+  ) {
+    throw new AllowanceGuardError('allowance run guard is invalid');
+  }
+  return record as AllowanceRunRecord;
+};
+
+export const recordRun = (record: AllowanceRunRecord): void => {
+  const file = runFilePath();
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  const tmp = `${file}.${process.pid}.tmp`;
+  fs.writeFileSync(tmp, JSON.stringify(record, null, 2));
+  fs.renameSync(tmp, file);
+};
+
+// Only used when the run finished and proved that nothing moved, so the
+// scheduler's retry is free to try the week again.
+export const clearRun = (): void => {
+  try {
+    fs.unlinkSync(runFilePath());
+  } catch (error) {
+    if (isErrnoException(error) && error.code === 'ENOENT') {
+      return;
+    }
+    throw new AllowanceGuardError(
+      'allowance run guard could not be cleared',
+      error,
+    );
+  }
+};
+
+export interface AllowanceTopupHandlerDependencies {
+  isAuthorized: (providedKey: string) => Promise<boolean>;
+  runTopup?: () => Promise<WeeklyAllowanceSummary>;
+  assertConfig?: () => void;
+  getLastRun?: () => AllowanceRunRecord | null;
+  saveRun?: (record: AllowanceRunRecord) => void;
+  clearLastRun?: () => void;
+  now?: () => Date;
+}
+
+interface AllowanceRunOutcome {
+  record: AllowanceRunRecord;
+  summary: WeeklyAllowanceSummary;
+}
+
+const responseBody = (outcome: AllowanceRunOutcome) => ({
+  skipped: false,
+  wallets: outcome.summary.wallets,
+  swept: outcome.summary.swept,
+  toppedUp: outcome.summary.toppedUp,
+  failed: outcome.summary.failures.length,
+  failures: outcome.summary.failures,
+  ...(outcome.summary.warnings.length > 0
+    ? { warnings: outcome.summary.warnings }
+    : {}),
+  lastSuccessAt: outcome.record.lastSuccessAt,
+  ...(outcome.record.lastError ? { lastError: outcome.record.lastError } : {}),
+});
+
+export const createAllowanceTopupHandler = ({
+  isAuthorized,
+  runTopup = () => scheduledTopup(),
+  assertConfig = assertWeeklyAllowanceConfig,
+  getLastRun = readLastRun,
+  saveRun = recordRun,
+  clearLastRun = clearRun,
+  now = () => new Date(),
+}: AllowanceTopupHandlerDependencies) => {
+  // Shared by every concurrent trigger for as long as a run is in flight. The
+  // persisted week record only stops sequential retries; this stops two POSTs
+  // that arrive before the first one has written anything.
+  let inFlight: Promise<AllowanceRunOutcome> | null = null;
+
+  const startRun = (currentWeek: string): Promise<AllowanceRunOutcome> => {
+    const run = (async (): Promise<AllowanceRunOutcome> => {
+      const startedAt = now().toISOString();
+      // Claim the week before touching a single wallet: if the process dies
+      // mid-sweep the guard is already on disk and the week stays blocked.
+      saveRun({ isoWeek: currentWeek, startedAt });
+
+      let summary: WeeklyAllowanceSummary;
+      try {
+        summary = await runTopup();
+      } catch (error) {
+        // The run's effect is unknown, so the week guard stays: a blind retry
+        // could double-sweep. Record why for the operator who reconciles it.
+        saveRun({
+          isoWeek: currentWeek,
+          startedAt,
+          lastErrorAt: now().toISOString(),
+          lastError: error instanceof Error ? error.message : String(error),
+        });
+        throw error;
+      }
+
+      const record: AllowanceRunRecord = {
+        isoWeek: currentWeek,
+        startedAt,
+        lastSuccessAt: now().toISOString(),
+        summary: {
+          wallets: summary.wallets,
+          swept: summary.swept,
+          toppedUp: summary.toppedUp,
+          failed: summary.failures.length,
+          warned: summary.warnings.length,
+        },
+        ...(summary.failures.length > 0
+          ? {
+              lastErrorAt: now().toISOString(),
+              lastError: summary.failures[summary.failures.length - 1].error,
+            }
+          : {}),
+      };
+
+      // Once any wallet was swept or topped up the week is spent: a retry
+      // would double-sweep the wallets that succeeded. If the run completed
+      // and proved nothing moved at all, drop the guard so the scheduler's
+      // retry can try again.
+      if (summary.swept > 0 || summary.toppedUp > 0 || summary.wallets === 0) {
+        saveRun(record);
+      } else {
+        clearLastRun();
+      }
+
+      return { record, summary };
+    })();
+
+    inFlight = run;
+    run
+      .finally(() => {
+        if (inFlight === run) {
+          inFlight = null;
+        }
+      })
+      .catch(() => undefined);
+    return run;
+  };
+
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      if (!(await isAuthorized(req.header('x-api-key') ?? ''))) {
+        res.status(401).json({ error: 'invalid API key' });
+        return;
+      }
+    } catch (error) {
+      if (error instanceof RewardError) {
+        res.status(error.statusCode).json({ error: error.message });
+        return;
+      }
+      console.error('allowance key validation failed:', error);
+      res.status(503).json({ error: 'allowance endpoint unavailable' });
+      return;
+    }
+
+    try {
+      assertConfig();
+    } catch (error) {
+      res.status(503).json({
+        error: `allowance topup not configured: ${
+          error instanceof Error ? error.message : 'invalid configuration'
+        }`,
+      });
+      return;
+    }
+
+    const currentWeek = isoWeekOf(now());
+
+    let lastRun: AllowanceRunRecord | null;
+    try {
+      lastRun = getLastRun();
+    } catch (error) {
+      console.error('allowance run guard unreadable:', error);
+      res.status(503).json({ error: 'allowance guard unavailable' });
+      return;
+    }
+
+    // Covers both a completed run and one that started and never reported: in
+    // either case this week's wallets must not be swept again.
+    if (lastRun && lastRun.isoWeek === currentWeek) {
+      res.status(200).json({ skipped: true, lastRun });
+      return;
+    }
+
+    // A trigger that arrives while a run is in flight joins it rather than
+    // starting a second sweep, and reports the shared run's outcome.
+    const joined = inFlight !== null;
+    const run = inFlight ?? startRun(currentWeek);
+
+    try {
+      const outcome = await run;
+      if (joined) {
+        res.status(200).json({ skipped: true, lastRun: outcome.record });
+        return;
+      }
+      res.status(200).json(responseBody(outcome));
+    } catch (error) {
+      // Internals (env names, LNbits ids) must not leak to the scheduler.
+      console.error('weekly allowance run failed:', error);
+      res.status(500).json({ error: 'internal error' });
+    }
+  };
+};

--- a/src/services/dataDir.test.ts
+++ b/src/services/dataDir.test.ts
@@ -1,0 +1,45 @@
+import * as path from 'path';
+import { DataDirError, resolveDataDir } from './dataDir';
+
+const workingDirectory = path.resolve('working-directory');
+const durableDirectory = path.resolve(path.sep, 'srv', 'zaplie-data');
+
+describe('resolveDataDir', () => {
+  test('requires an absolute directory in every deployed runtime', () => {
+    expect(() =>
+      resolveDataDir({ NODE_ENV: 'production' }, workingDirectory),
+    ).toThrow(DataDirError);
+    expect(() =>
+      resolveDataDir(
+        { WEBSITE_INSTANCE_ID: 'azure-instance' },
+        workingDirectory,
+      ),
+    ).toThrow('ZAPLIE_DATA_DIR is required');
+    expect(() =>
+      resolveDataDir(
+        { NODE_ENV: 'production', ZAPLIE_DATA_DIR: 'relative-data' },
+        workingDirectory,
+      ),
+    ).toThrow('ZAPLIE_DATA_DIR must be an absolute durable path');
+    // Explicit development mode still counts as deployed when it runs on Azure.
+    expect(() =>
+      resolveDataDir(
+        { NODE_ENV: 'development', WEBSITE_SITE_NAME: 'azure-site' },
+        workingDirectory,
+      ),
+    ).toThrow('ZAPLIE_DATA_DIR is required');
+    expect(
+      resolveDataDir(
+        { NODE_ENV: 'production', ZAPLIE_DATA_DIR: durableDirectory },
+        workingDirectory,
+      ),
+    ).toBe(durableDirectory);
+  });
+
+  test('only explicit development mode receives the ignored local fallback', () => {
+    expect(resolveDataDir({ NODE_ENV: 'development' }, workingDirectory)).toBe(
+      path.join(workingDirectory, '.zaplie-data'),
+    );
+    expect(() => resolveDataDir({}, workingDirectory)).toThrow(DataDirError);
+  });
+});

--- a/src/services/dataDir.ts
+++ b/src/services/dataDir.ts
@@ -1,0 +1,55 @@
+// Single resolution rule for ZAPLIE_DATA_DIR, the directory holding the bot's
+// mutable on-disk state.
+//
+// Every deployed runtime must point it at an absolute, persistent path outside
+// the deployment artifact: state written into `wwwroot` is destroyed by the
+// next clean deploy. Only an explicit `NODE_ENV=development` run that is not on
+// Azure may fall back to the git-ignored `.zaplie-data` directory, so a
+// forgotten setting fails at startup instead of silently losing money records.
+
+import * as path from 'path';
+
+export class DataDirError extends Error {
+  constructor(
+    message: string,
+    readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = 'DataDirError';
+  }
+}
+
+export const DEVELOPMENT_DATA_DIR = '.zaplie-data';
+
+const isAzureRuntime = (environment: NodeJS.ProcessEnv): boolean =>
+  Boolean(
+    environment.RUNNING_ON_AZURE ||
+    environment.WEBSITE_INSTANCE_ID ||
+    environment.WEBSITE_SITE_NAME,
+  );
+
+export const resolveDataDir = (
+  environment: NodeJS.ProcessEnv = process.env,
+  workingDirectory = process.cwd(),
+): string => {
+  const configured = environment.ZAPLIE_DATA_DIR?.trim();
+  const durableRuntime =
+    environment.NODE_ENV !== 'development' || isAzureRuntime(environment);
+
+  if (configured) {
+    if (durableRuntime && !path.isAbsolute(configured)) {
+      throw new DataDirError(
+        'ZAPLIE_DATA_DIR must be an absolute durable path in production',
+      );
+    }
+    return path.resolve(workingDirectory, configured);
+  }
+
+  if (durableRuntime) {
+    throw new DataDirError(
+      'ZAPLIE_DATA_DIR is required outside explicit development mode',
+    );
+  }
+
+  return path.resolve(workingDirectory, DEVELOPMENT_DATA_DIR);
+};

--- a/src/services/lnbitsService.ts
+++ b/src/services/lnbitsService.ts
@@ -815,44 +815,129 @@ async function topUpWallet(walletId: string, amount: number): Promise<void> {
     amount,
   };
 
-  try {
-    const response = await fetch(url, {
-      method: 'PUT',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${accessToken}`,
-      },
-      body: JSON.stringify(body),
-    });
+  const response = await fetch(url, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify(body),
+  });
 
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
-    }
-
-    const responseData = await response.json();
-    console.log('Wallet topped up successfully:', responseData);
-  } catch (error) {
-    console.error('Error topping up wallet:', error);
+  if (!response.ok) {
+    throw new Error(`Error topping up wallet (status: ${response.status})`);
   }
 }
 
-async function scheduledTopup() {
-  const allowancewallets = await getWallets(
-    process.env.LNBITS_ADMINKEY as string,
-    'Allowance',
-  );
-  const allowanceValue = process.env.LNBITS_INITIAL_ALLOWANCE as string;
-  const hostWalletId = process.env.LNBITS_HOST_WALLET_ID as string;
-  const hostUserId = process.env.LNBITS_HOST_USER_ID as string;
+interface WeeklyAllowanceDependencies {
+  getWallets: typeof getWallets;
+  getUser: typeof getUser;
+  getWalletById: typeof getWalletById;
+  createInvoice: typeof createInvoice;
+  payInvoice: typeof payInvoice;
+  topUpWallet: typeof topUpWallet;
+}
 
-  const host = await getWalletById(hostUserId, hostWalletId);
+interface WeeklyAllowanceFailure {
+  walletId: string;
+  error: string;
+}
 
-  if (allowancewallets) {
-    allowancewallets.forEach(async wallet => {
-      const User = await getUser(
-        process.env.LNBITS_ADMINKEY as string,
-        wallet.user,
-      );
+interface WeeklyAllowanceWarning {
+  walletId: string;
+  warning: string;
+}
+
+interface WeeklyAllowanceSummary {
+  wallets: number;
+  swept: number;
+  toppedUp: number;
+  failures: WeeklyAllowanceFailure[];
+  warnings: WeeklyAllowanceWarning[];
+}
+
+const requirePositiveIntegerEnv = (name: string): number => {
+  const value = Number(requireEnv(name));
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return value;
+};
+
+// Validates everything the weekly run needs before any request is made, so a
+// misconfigured scheduler call fails closed instead of half-running.
+function assertWeeklyAllowanceConfig(): void {
+  requireEnv('LNBITS_NODE_URL');
+  requireEnv('LNBITS_ADMINKEY');
+  requireEnv('LNBITS_INKEY');
+  requireEnv('LNBITS_HOST_WALLET_ID');
+  requireEnv('LNBITS_HOST_USER_ID');
+  requirePositiveIntegerEnv('LNBITS_INITIAL_ALLOWANCE');
+}
+
+async function scheduledTopup(
+  dependencies: WeeklyAllowanceDependencies = {
+    getWallets,
+    getUser,
+    getWalletById,
+    createInvoice,
+    payInvoice,
+    topUpWallet,
+  },
+): Promise<WeeklyAllowanceSummary> {
+  assertWeeklyAllowanceConfig();
+  const adminKey = requireEnv('LNBITS_ADMINKEY');
+  const invoiceKey = requireEnv('LNBITS_INKEY');
+  const hostWalletId = requireEnv('LNBITS_HOST_WALLET_ID');
+  const hostUserId = requireEnv('LNBITS_HOST_USER_ID');
+  const allowanceValue = requirePositiveIntegerEnv('LNBITS_INITIAL_ALLOWANCE');
+
+  const allowanceWallets = await dependencies.getWallets(adminKey, 'Allowance');
+  if (!Array.isArray(allowanceWallets)) {
+    throw new Error('Unable to load allowance wallets');
+  }
+
+  const host = await dependencies.getWalletById(hostUserId, hostWalletId);
+  if (!host) {
+    throw new Error('Unable to load treasury wallet');
+  }
+
+  const summary: WeeklyAllowanceSummary = {
+    wallets: allowanceWallets.length,
+    swept: 0,
+    toppedUp: 0,
+    failures: [],
+    warnings: [],
+  };
+
+  // Per-wallet failures are recorded and skipped so one broken wallet cannot
+  // block everyone else's allowance; a failed sweep never reaches the top-up.
+  for (const wallet of allowanceWallets) {
+    try {
+      const user = await dependencies.getUser(adminKey, wallet.user);
+      if (!user) {
+        throw new Error(`Allowance owner not found for wallet ${wallet.id}`);
+      }
+      if (
+        !Number.isSafeInteger(wallet.balance_msat) ||
+        wallet.balance_msat < 0
+      ) {
+        throw new Error(`Invalid balance for allowance wallet ${wallet.id}`);
+      }
+
+      // LNbits invoices are denominated in whole sats. A balance carrying a
+      // sub-sat remainder is swept down to the last whole sat rather than
+      // excluded from the week: skipping it would leave the wallet
+      // permanently above its allowance. The remainder is reported so an
+      // operator can see why the wallet did not end up empty.
+      const sweepSats = Math.floor(wallet.balance_msat / 1000);
+      const remainderMsat = wallet.balance_msat - sweepSats * 1000;
+      if (remainderMsat > 0) {
+        summary.warnings.push({
+          walletId: wallet.id,
+          warning: `Balance is not a whole number of sats; swept ${sweepSats} sats and left ${remainderMsat} msat`,
+        });
+      }
 
       const extra = {
         from: wallet,
@@ -860,19 +945,29 @@ async function scheduledTopup() {
         tag: 'zap',
       };
 
-      if (wallet.balance_msat > 0) {
-        const paymentRequest = await createInvoice(
-          process.env.LNBITS_INKEY as string,
+      if (sweepSats > 0) {
+        const paymentRequest = await dependencies.createInvoice(
+          invoiceKey,
           hostWalletId,
-          wallet.balance_msat / 1000,
-          `${User.displayName} Weekly Allowance cleared`,
+          sweepSats,
+          `${user.displayName} Weekly Allowance cleared`,
           extra,
         );
-        await payInvoice(wallet.adminkey, paymentRequest, extra);
+        await dependencies.payInvoice(wallet.adminkey, paymentRequest, extra);
+        summary.swept += 1;
       }
-      topUpWallet(wallet.id, parseInt(allowanceValue));
-    });
+
+      await dependencies.topUpWallet(wallet.id, allowanceValue);
+      summary.toppedUp += 1;
+    } catch (error) {
+      summary.failures.push({
+        walletId: wallet.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
+
+  return summary;
 }
 
 export {
@@ -895,5 +990,13 @@ export {
   payInvoice,
   getWalletIdByUserId,
   topUpWallet,
+  assertWeeklyAllowanceConfig,
   scheduledTopup,
+};
+
+export type {
+  WeeklyAllowanceDependencies,
+  WeeklyAllowanceFailure,
+  WeeklyAllowanceWarning,
+  WeeklyAllowanceSummary,
 };

--- a/src/services/scheduledTopup.test.ts
+++ b/src/services/scheduledTopup.test.ts
@@ -1,0 +1,260 @@
+import { scheduledTopup, WeeklyAllowanceDependencies } from './lnbitsService';
+
+const wallet = (id: string, user: string, balanceMsat: number): Wallet => ({
+  id,
+  user,
+  admin: `admin-${id}`,
+  name: 'Allowance',
+  adminkey: `admin-key-${id}`,
+  inkey: `invoice-key-${id}`,
+  balance_msat: balanceMsat,
+  deleted: false,
+});
+
+const member = (id: string, displayName: string): User => ({
+  id,
+  displayName,
+  profileImg: '',
+  aadObjectId: `aad-${id}`,
+  email: `${id}@example.test`,
+  allowanceWallet: null,
+  privateWallet: null,
+});
+
+const hostWallet = wallet('treasury-wallet', 'treasury-user', 0);
+
+const originalEnv = { ...process.env };
+
+const createDependencies = (): jest.Mocked<WeeklyAllowanceDependencies> => {
+  const dependencies: jest.Mocked<WeeklyAllowanceDependencies> = {
+    getWallets: jest.fn(),
+    getUser: jest.fn(),
+    getWalletById: jest.fn(),
+    createInvoice: jest.fn(),
+    payInvoice: jest.fn(),
+    topUpWallet: jest.fn(),
+  };
+  dependencies.getWalletById.mockResolvedValue(hostWallet);
+  return dependencies;
+};
+
+beforeEach(() => {
+  process.env.LNBITS_NODE_URL = 'https://lnbits.example.test';
+  process.env.LNBITS_ADMINKEY = 'server-admin-key';
+  process.env.LNBITS_INKEY = 'treasury-invoice-key';
+  process.env.LNBITS_HOST_WALLET_ID = 'treasury-wallet';
+  process.env.LNBITS_HOST_USER_ID = 'treasury-user';
+  process.env.LNBITS_INITIAL_ALLOWANCE = '25000';
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+  jest.restoreAllMocks();
+});
+
+describe('scheduledTopup', () => {
+  test('clears and refills each allowance wallet in order', async () => {
+    const first = wallet('wallet-1', 'user-1', 20000);
+    const second = wallet('wallet-2', 'user-2', 0);
+    const dependencies = createDependencies();
+    const calls: string[] = [];
+
+    dependencies.getWallets.mockResolvedValue([first, second]);
+    dependencies.getUser.mockImplementation(async (_adminKey, userId) =>
+      userId === 'user-1'
+        ? member('user-1', 'Alex Rivera')
+        : member('user-2', 'Dana Kowalski'),
+    );
+    dependencies.createInvoice.mockImplementation(async () => {
+      calls.push('invoice:wallet-1');
+      return 'lnbc-invoice';
+    });
+    dependencies.payInvoice.mockImplementation(async () => {
+      calls.push('payment:wallet-1');
+      return { checking_id: 'payment-1' };
+    });
+    dependencies.topUpWallet.mockImplementation(async walletId => {
+      calls.push(`topup:${walletId}`);
+    });
+
+    const summary = await scheduledTopup(dependencies);
+
+    expect(calls).toEqual([
+      'invoice:wallet-1',
+      'payment:wallet-1',
+      'topup:wallet-1',
+      'topup:wallet-2',
+    ]);
+    expect(summary).toEqual({
+      wallets: 2,
+      swept: 1,
+      toppedUp: 2,
+      failures: [],
+      warnings: [],
+    });
+    expect(dependencies.getWallets).toHaveBeenCalledWith(
+      'server-admin-key',
+      'Allowance',
+    );
+    expect(dependencies.getWalletById).toHaveBeenCalledWith(
+      'treasury-user',
+      'treasury-wallet',
+    );
+    expect(dependencies.createInvoice).toHaveBeenCalledWith(
+      'treasury-invoice-key',
+      'treasury-wallet',
+      20,
+      'Alex Rivera Weekly Allowance cleared',
+      { from: first, to: hostWallet, tag: 'zap' },
+    );
+    expect(dependencies.topUpWallet).toHaveBeenNthCalledWith(
+      1,
+      'wallet-1',
+      25000,
+    );
+    expect(dependencies.topUpWallet).toHaveBeenNthCalledWith(
+      2,
+      'wallet-2',
+      25000,
+    );
+  });
+
+  test('validates all configuration before loading wallets', async () => {
+    const dependencies = createDependencies();
+    delete process.env.LNBITS_HOST_WALLET_ID;
+
+    await expect(scheduledTopup(dependencies)).rejects.toThrow(
+      'LNBITS_HOST_WALLET_ID is not set',
+    );
+    expect(dependencies.getWallets).not.toHaveBeenCalled();
+  });
+
+  test('rejects an invalid allowance before loading wallets', async () => {
+    const dependencies = createDependencies();
+    process.env.LNBITS_INITIAL_ALLOWANCE = '25.5';
+
+    await expect(scheduledTopup(dependencies)).rejects.toThrow(
+      'LNBITS_INITIAL_ALLOWANCE must be a positive integer',
+    );
+    expect(dependencies.getWallets).not.toHaveBeenCalled();
+  });
+
+  test('fails closed when the wallet directory is unavailable', async () => {
+    const dependencies = createDependencies();
+    dependencies.getWallets.mockResolvedValue(null);
+
+    await expect(scheduledTopup(dependencies)).rejects.toThrow(
+      'Unable to load allowance wallets',
+    );
+    expect(dependencies.topUpWallet).not.toHaveBeenCalled();
+  });
+
+  test('fails closed when the treasury wallet cannot be resolved', async () => {
+    const dependencies = createDependencies();
+    dependencies.getWallets.mockResolvedValue([]);
+    dependencies.getWalletById.mockResolvedValue(null);
+
+    await expect(scheduledTopup(dependencies)).rejects.toThrow(
+      'Unable to load treasury wallet',
+    );
+    expect(dependencies.topUpWallet).not.toHaveBeenCalled();
+  });
+
+  test('does not move or add funds when the owner cannot be resolved', async () => {
+    const dependencies = createDependencies();
+    dependencies.getWallets.mockResolvedValue([
+      wallet('missing-owner-wallet', 'missing-user', 20000),
+    ]);
+    dependencies.getUser.mockResolvedValue(null);
+
+    const summary = await scheduledTopup(dependencies);
+
+    expect(summary.failures).toEqual([
+      {
+        walletId: 'missing-owner-wallet',
+        error: 'Allowance owner not found for wallet missing-owner-wallet',
+      },
+    ]);
+    expect(dependencies.createInvoice).not.toHaveBeenCalled();
+    expect(dependencies.payInvoice).not.toHaveBeenCalled();
+    expect(dependencies.topUpWallet).not.toHaveBeenCalled();
+  });
+
+  test('does not top up a wallet whose outgoing payment failed, but continues', async () => {
+    const dependencies = createDependencies();
+    dependencies.getWallets.mockResolvedValue([
+      wallet('wallet-1', 'user-1', 20000),
+      wallet('wallet-2', 'user-2', 0),
+    ]);
+    dependencies.getUser.mockImplementation(async (_adminKey, userId) =>
+      userId === 'user-1'
+        ? member('user-1', 'Alex Rivera')
+        : member('user-2', 'Dana Kowalski'),
+    );
+    dependencies.createInvoice.mockResolvedValue('lnbc-invoice');
+    dependencies.payInvoice.mockRejectedValue(new Error('payment failed'));
+
+    const summary = await scheduledTopup(dependencies);
+
+    expect(summary).toEqual({
+      wallets: 2,
+      swept: 0,
+      toppedUp: 1,
+      failures: [{ walletId: 'wallet-1', error: 'payment failed' }],
+      warnings: [],
+    });
+    expect(dependencies.topUpWallet).toHaveBeenCalledTimes(1);
+    expect(dependencies.topUpWallet).toHaveBeenCalledWith('wallet-2', 25000);
+  });
+
+  test('sweeps a sub-sat balance down to whole sats and warns', async () => {
+    const dependencies = createDependencies();
+    dependencies.getWallets.mockResolvedValue([
+      wallet('wallet-1', 'user-1', 20500),
+    ]);
+    dependencies.getUser.mockResolvedValue(member('user-1', 'Alex Rivera'));
+    dependencies.createInvoice.mockResolvedValue('lnbc-invoice');
+    dependencies.payInvoice.mockResolvedValue({ checking_id: 'payment-1' });
+
+    const summary = await scheduledTopup(dependencies);
+
+    // Excluding the wallet would leave it permanently above its allowance.
+    expect(summary.failures).toEqual([]);
+    expect(summary.swept).toBe(1);
+    expect(summary.toppedUp).toBe(1);
+    expect(summary.warnings).toEqual([
+      {
+        walletId: 'wallet-1',
+        warning:
+          'Balance is not a whole number of sats; swept 20 sats and left 500 msat',
+      },
+    ]);
+    expect(dependencies.createInvoice).toHaveBeenCalledWith(
+      'treasury-invoice-key',
+      'treasury-wallet',
+      20,
+      'Alex Rivera Weekly Allowance cleared',
+      expect.anything(),
+    );
+    expect(dependencies.topUpWallet).toHaveBeenCalledWith('wallet-1', 25000);
+  });
+
+  test('rejects a balance that is not a usable number', async () => {
+    const dependencies = createDependencies();
+    dependencies.getWallets.mockResolvedValue([
+      wallet('wallet-1', 'user-1', -1),
+    ]);
+    dependencies.getUser.mockResolvedValue(member('user-1', 'Alex Rivera'));
+
+    const summary = await scheduledTopup(dependencies);
+
+    expect(summary.failures).toEqual([
+      {
+        walletId: 'wallet-1',
+        error: 'Invalid balance for allowance wallet wallet-1',
+      },
+    ]);
+    expect(dependencies.createInvoice).not.toHaveBeenCalled();
+    expect(dependencies.topUpWallet).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes #206

## What changed
- `scheduledTopup` was dead code with async bugs: nothing called it, `forEach(async ...)` never awaited, the final top-up wasn't awaited, and `LNBITS_INITIAL_ALLOWANCE` wasn't validated. It now runs a sequential `for...of` with real awaits, validates config up front, records per-wallet failures (a broken wallet is skipped and reported instead of aborting everyone's allowance), and returns a `{wallets, swept, toppedUp, failures}` summary.
- New authenticated trigger: `POST /api/v1/allowance/topup` (same `x-api-key` scheme as `/api/v1/rewards`) so an Azure scheduler/Logic App can fire it weekly. 401 without a key, 503 with a clear message when LNbits config is missing.
- ISO-week idempotency guard (atomic JSON store under `ZAPLIE_DATA_DIR`): a re-fired scheduler in the same week gets `{skipped: true, lastRun}` instead of sweeping allowances twice. A run that moved no funds does not record the guard, so a failed week can be retried.
- Response includes `lastSuccessAt`/`lastError` for observability.

## Why not the LNbits Allowance extension
We evaluated [BenGWeeks/allowance](https://github.com/BenGWeeks/allowance): it only makes additive recurring payments to Lightning addresses/LNURL endpoints — no internal wallet-to-wallet payments (Zaplie allowance wallets have no Lightning address), no sweep-then-refill semantics, no guaranteed memo (reports filter on `Weekly Allowance cleared`), and its loop can double-pay across restarts. Adopting it would need a fork plus per-user paylink provisioning. Zaplie's own implementation already matches the product semantics and now has the trigger it was missing.

## Test plan for QA
- `npx jest`: 155 tests green — new `scheduledTopup.test.ts` (sweep-then-topup order, error propagation, env validation) and `allowanceTopup.test.ts` (401/503/200, same-week skip, new-week run, guard not recorded on total failure, corrupt store recovery).
- Manual: `curl -X POST -H "x-api-key: $REWARDS_API_KEY" https://<bot>/api/v1/allowance/topup` twice — first returns the summary, second returns `skipped: true`.

**Post-review hardening**: concurrent trigger calls share one run (in-flight memoization + startedAt marker) so a re-fired scheduler can never double-sweep; a corrupt guard store now fails closed with 503 instead of allowing a sweep; the bot's rate-limit env is `BOT_API_RATE_LIMIT` (no collision with the portal's `API_RATE_LIMIT`); wallets with sub-sat remainders are swept with floor() instead of being excluded forever.
