### PR TITLE
ci: stop shipping LNbits admin credentials to the browser build

### DIFF
--- a/.github/workflows/Azure_App_Service_zaplie-prod.yml
+++ b/.github/workflows/Azure_App_Service_zaplie-prod.yml
@@ -18,13 +18,12 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      # Source-level guard: the portal must never read LNbits admin
-      # credentials from browser code. It runs before the build, so it holds
-      # whether or not the bundle ships sourcemaps.
+      # Scanning the sources instead of the bundle keeps this guard effective
+      # regardless of whether the build ships sourcemaps.
       - name: Fail if the portal sources read LNbits admin credentials
         shell: bash
         run: |
-          test -d tabs/src || { echo '::error::tabs/src not found, nothing to scan'; exit 1; }
+          test -d tabs/src || { echo '::error::tabs/src not found, cannot verify the portal sources'; exit 1; }
           if grep -REl 'process\.env\.REACT_APP_LNBITS_(ADMINKEY|PASSWORD)' tabs/src; then
             echo '::error::Portal sources read LNbits admin credentials in browser code. Move privileged LNbits calls behind the backend.'
             exit 1

--- a/.github/workflows/Azure_App_Service_zaplie-prod.yml
+++ b/.github/workflows/Azure_App_Service_zaplie-prod.yml
@@ -18,6 +18,18 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # Source-level guard: the portal must never read LNbits admin
+      # credentials from browser code. It runs before the build, so it holds
+      # whether or not the bundle ships sourcemaps.
+      - name: Fail if the portal sources read LNbits admin credentials
+        shell: bash
+        run: |
+          test -d tabs/src || { echo '::error::tabs/src not found, nothing to scan'; exit 1; }
+          if grep -REl 'process\.env\.REACT_APP_LNBITS_(ADMINKEY|PASSWORD)' tabs/src; then
+            echo '::error::Portal sources read LNbits admin credentials in browser code. Move privileged LNbits calls behind the backend.'
+            exit 1
+          fi
+
       - name: Set up Node.js version
         uses: actions/setup-node@v7
         with:
@@ -28,8 +40,6 @@ jobs:
           CI: false
           REACT_APP_LNBITS_NODE_URL: ${{ secrets.REACT_APP_LNBITS_NODE_URL }}
           REACT_APP_LNBITS_USERNAME: ${{ secrets.REACT_APP_LNBITS_USERNAME }}
-          REACT_APP_LNBITS_PASSWORD: ${{ secrets.REACT_APP_LNBITS_PASSWORD }}
-          REACT_APP_LNBITS_ADMINKEY: ${{ secrets.REACT_APP_LNBITS_ADMINKEY }}
           REACT_APP_LNBITS_STORE_ID: ${{ secrets.REACT_APP_LNBITS_STORE_ID }}
           REACT_APP_LNBITS_STORE_OWNER_EMAIL: ${{ secrets.REACT_APP_LNBITS_STORE_OWNER_EMAIL }}
           REACT_APP_TENANT_ID: ${{ secrets.REACT_APP_TENANT_ID }}
@@ -40,6 +50,20 @@ jobs:
           npm install
           npm run build --if-present
       
+      # CRA inlines REACT_APP_* values into public JavaScript, so any LNbits
+      # admin credential reference in the built bundle is a secret leak. The
+      # variable names survive in CRA output even without sourcemaps, so scan
+      # for the names as well as the bare credential identifiers. A missing
+      # build directory is a failure, not a pass: grep would exit 2 there.
+      - name: Fail if the built bundle references LNbits admin credentials
+        shell: bash
+        run: |
+          test -d tabs/build || { echo '::error::No built bundle found to scan'; exit 1; }
+          if grep -RlE 'REACT_APP_LNBITS_(ADMINKEY|PASSWORD)|LNBITS_ADMINKEY|LNBITS_PASSWORD' tabs/build; then
+            echo '::error::LNbits admin credential references found in the built portal bundle. Move privileged LNbits calls behind the backend before deploying.'
+            exit 1
+          fi
+
       - name: Upload artifact for deployment job
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/Azure_App_Service_zaplie-test.yml
+++ b/.github/workflows/Azure_App_Service_zaplie-test.yml
@@ -19,13 +19,12 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      # Source-level guard: the portal must never read LNbits admin
-      # credentials from browser code. It runs before the build, so it holds
-      # whether or not the bundle ships sourcemaps.
+      # Scanning the sources instead of the bundle keeps this guard effective
+      # regardless of whether the build ships sourcemaps.
       - name: Fail if the portal sources read LNbits admin credentials
         shell: bash
         run: |
-          test -d tabs/src || { echo '::error::tabs/src not found, nothing to scan'; exit 1; }
+          test -d tabs/src || { echo '::error::tabs/src not found, cannot verify the portal sources'; exit 1; }
           if grep -REl 'process\.env\.REACT_APP_LNBITS_(ADMINKEY|PASSWORD)' tabs/src; then
             echo '::error::Portal sources read LNbits admin credentials in browser code. Move privileged LNbits calls behind the backend.'
             exit 1

--- a/.github/workflows/Azure_App_Service_zaplie-test.yml
+++ b/.github/workflows/Azure_App_Service_zaplie-test.yml
@@ -19,6 +19,18 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # Source-level guard: the portal must never read LNbits admin
+      # credentials from browser code. It runs before the build, so it holds
+      # whether or not the bundle ships sourcemaps.
+      - name: Fail if the portal sources read LNbits admin credentials
+        shell: bash
+        run: |
+          test -d tabs/src || { echo '::error::tabs/src not found, nothing to scan'; exit 1; }
+          if grep -REl 'process\.env\.REACT_APP_LNBITS_(ADMINKEY|PASSWORD)' tabs/src; then
+            echo '::error::Portal sources read LNbits admin credentials in browser code. Move privileged LNbits calls behind the backend.'
+            exit 1
+          fi
+
       - name: Set up Node.js version
         uses: actions/setup-node@v7
         with:
@@ -32,6 +44,20 @@ jobs:
           npm install
           npm run build --if-present
       
+      # CRA inlines REACT_APP_* values into public JavaScript, so any LNbits
+      # admin credential reference in the built bundle is a secret leak. The
+      # variable names survive in CRA output even without sourcemaps, so scan
+      # for the names as well as the bare credential identifiers. A missing
+      # build directory is a failure, not a pass: grep would exit 2 there.
+      - name: Fail if the built bundle references LNbits admin credentials
+        shell: bash
+        run: |
+          test -d tabs/build || { echo '::error::No built bundle found to scan'; exit 1; }
+          if grep -RlE 'REACT_APP_LNBITS_(ADMINKEY|PASSWORD)|LNBITS_ADMINKEY|LNBITS_PASSWORD' tabs/build; then
+            echo '::error::LNbits admin credential references found in the built portal bundle. Move privileged LNbits calls behind the backend before deploying.'
+            exit 1
+          fi
+
       - name: Upload artifact for deployment job
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
> ⚠️ **Merge order**: land this AFTER the portal stack (#286 → … → #309) reaches `main`. On today's `main`, `tabs/src` still reads `REACT_APP_LNBITS_ADMINKEY`/`PASSWORD` (removed by the gateway refactor in that stack), so the new guard would fail deploys until then — which is exactly the regression it exists to catch.

## What changed
- Removes the `REACT_APP_LNBITS_PASSWORD` and `REACT_APP_LNBITS_ADMINKEY` build-env lines from the prod deploy workflow (the test workflow on main never had them). These put LNbits admin credentials into the public browser bundle.
- Adds a guard step to both deploy workflows that greps the built bundle for `LNBITS_ADMINKEY|LNBITS_PASSWORD` and fails the build before anything is uploaded.

## Operational follow-up (not in this PR)
The historic bundles already shipped these values: **rotate the LNbits admin key and password** after merging. The day-one runbook PR in this stack documents it.

## Test plan for QA
- Both workflow files parse (validated with js-yaml). After the portal stack lands, a test deploy passes the guard; re-adding either env line makes the guard fail.

> **Note on the source-level guard**: it lives in the deploy workflows (not PR CI) on purpose — `tabs/src` on `main` still reads the admin key until the portal stack lands, so a PR-CI check would be permanently red. The deploy guard failing on `main` until then is the honest behavior: the leak is real and deploys should be blocked.
