### PR TITLE
fix: declare the Zaplie.Admin app role

### DIFF
--- a/aad.manifest.json
+++ b/aad.manifest.json
@@ -4,6 +4,18 @@
     "name": "Zaplie v2",
     "accessTokenAcceptedVersion": 2,
     "signInAudience": "AzureADMyOrg",
+    "appRoles": [
+        {
+            "allowedMemberTypes": [
+                "User"
+            ],
+            "description": "Can configure reward policy, bot persona and integrations",
+            "displayName": "Zaplie Administrator",
+            "id": "a753735c-1fd6-4e7e-bd5a-66e975060a45",
+            "isEnabled": true,
+            "value": "Zaplie.Admin"
+        }
+    ],
     "optionalClaims": {
         "idToken": [],
         "accessToken": [


### PR DESCRIPTION
Fixes #184

Stacked on the persistent-state PR.

## What changed
`tabs/backend/adminAuth.js` gates every admin route on the Entra app role `Zaplie.Admin` — but no such role was declared anywhere, so on day one every admin route returns 403 to everyone, including the admin. This adds the `appRoles` block to `aad.manifest.json` ("Zaplie Administrator", value `Zaplie.Admin`, users only, stable GUID).

## Operational follow-up
After provisioning, assign the role in Entra → Enterprise applications → Users and groups. The day-one runbook PR documents it.

## Test plan for QA
- JSON validated; role `value` matches `adminAuth.js` exactly. After provisioning + assignment, `POST /api/reward-name` succeeds for the assigned admin and stays 403 for others.

