### PR TITLE
fix: keep internal errors out of the chat

### DIFF
--- a/src/commands/sendZapCommand.test.ts
+++ b/src/commands/sendZapCommand.test.ts
@@ -1,0 +1,57 @@
+// sendZapCommand.test.ts
+//
+// Covers the command's error hygiene: LNbits failures carry wallet ids and
+// configuration names, so they belong in the logs and never in the chat.
+
+import { afterEach, describe, expect, jest, test } from '@jest/globals';
+import type { TurnContext } from 'botbuilder';
+import { SendZapCommand } from './sendZapCommand';
+import { getUsers } from '../services/lnbitsService';
+import { GENERIC_ERROR_MESSAGE } from '../messages';
+
+jest.mock('../services/lnbitsService');
+
+const makeContext = () => {
+  const sendActivity = jest
+    .fn<() => Promise<void>>()
+    .mockResolvedValue(undefined);
+  return {
+    sendActivity,
+    context: {
+      turnState: new Map<unknown, unknown>(),
+      sendActivity,
+    } as unknown as TurnContext,
+  };
+};
+
+describe('SendZapCommand error hygiene', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('logs the failure and sends a generic message instead of error.message', async () => {
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    jest.spyOn(console, 'log').mockImplementation(() => undefined);
+    jest
+      .mocked(getUsers)
+      .mockRejectedValue(
+        new Error('LNbits admin key for wallet 0d1f rejected'),
+      );
+    const { context, sendActivity } = makeContext();
+
+    await new SendZapCommand().execute(context);
+
+    expect(sendActivity).toHaveBeenCalledWith(GENERIC_ERROR_MESSAGE);
+    for (const [message] of sendActivity.mock.calls as unknown as [string][]) {
+      expect(message).not.toContain('admin key');
+    }
+    expect(consoleError).toHaveBeenCalledWith(
+      'SendZapCommand failed:',
+      expect.objectContaining({
+        message: expect.stringContaining('admin key'),
+      }),
+    );
+  });
+});

--- a/src/commands/sendZapCommand.ts
+++ b/src/commands/sendZapCommand.ts
@@ -7,6 +7,7 @@ import {
   getWalletBalance,
 } from '../services/lnbitsService';
 import { UserService } from '../services/userService';
+import { GENERIC_ERROR_MESSAGE } from '../messages';
 
 const adminKey = process.env.LNBITS_ADMINKEY as string;
 const lnbitsLabel = process.env.LNBITS_POINTS_LABEL as string;
@@ -31,9 +32,10 @@ export class SendZapCommand extends SSOCommand {
       await context.sendActivity(message);
       console.log('sendActivity completed.');
     } catch (error) {
-      await context.sendActivity(
-        'Oops! Something went wrong (' + error.message + ')',
-      );
+      // The details belong in the logs: an LNbits error message can carry
+      // wallet ids or configuration names into the chat.
+      console.error('SendZapCommand failed:', error);
+      await context.sendActivity(GENERIC_ERROR_MESSAGE);
     }
   }
 }

--- a/src/commands/zapBudget.ts
+++ b/src/commands/zapBudget.ts
@@ -1,3 +1,5 @@
+import { UserFacingError } from '../messages';
+
 // Card inputs arrive as strings and the amount regex is client-only and
 // forgeable, so the amount and the cumulative budget must be enforced
 // server-side before any payment. liveBalance must be a fresh read: the
@@ -13,24 +15,28 @@ export function validateZapSubmit(
 ): number {
   const amount = Number(rawAmount);
   if (!Number.isInteger(amount) || amount < 1 || amount > MAX_ZAP_SATS) {
-    throw new Error(
+    throw new UserFacingError(
       `You must specify a whole number between 1 and ${MAX_ZAP_SATS.toLocaleString()} ${rewardName}.`,
     );
   }
 
   if (!Number.isInteger(recipientCount) || recipientCount < 1) {
-    throw new Error('No valid recipients were selected, so no zaps were sent.');
+    throw new UserFacingError(
+      'No valid recipients were selected, so no zaps were sent.',
+    );
   }
 
   // NaN passes `typeof x === 'number'` and every comparison against it is
   // false, so an unreadable balance would skip the budget check entirely.
   if (!Number.isFinite(liveBalance) || liveBalance < 0) {
-    throw new Error('Could not read your live balance, so no zaps were sent.');
+    throw new UserFacingError(
+      'Could not read your live balance, so no zaps were sent.',
+    );
   }
 
   const totalRequired = amount * recipientCount;
   if (totalRequired > liveBalance) {
-    throw new Error(
+    throw new UserFacingError(
       `That would send ${totalRequired} ${rewardName} across ${recipientCount} ` +
         `recipient(s) but your balance is ${liveBalance}. No zaps were sent.`,
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,11 +13,11 @@ import {
   ConfigurationBotFrameworkAuthentication,
   MemoryStorage,
   TeamsSSOTokenExchangeMiddleware,
-  TurnContext,
 } from 'botbuilder';
 
 // This bot's main dialog.
 import { TeamsBot } from './teamsBot';
+import { onTurnErrorHandler } from './onTurnError';
 import config from './config';
 import { UserService } from './services/userService';
 import { FetchUserMiddleware } from './services/fetchUserMiddleware';
@@ -67,40 +67,6 @@ if (process.env.GRAPH_CONNECTION_NAME) {
 
 // Add FetchUserMiddleware and pass the userService instance
 adapter.use(new FetchUserMiddleware(userService));
-
-// Catch-all for errors.
-const onTurnErrorHandler = async (context: TurnContext, error: Error) => {
-  // Retrieve user information
-  const userId = context.activity.from.id;
-  const aadObjectId = context.activity.from.aadObjectId;
-  const userName = context.activity.from.name;
-
-  // Log user information
-  console.log(`User ID: ${userId}`);
-  console.log(`User AAD Object ID: ${aadObjectId}`);
-  console.log(`User Display Name: ${userName}`);
-
-  // This check writes out errors to console log .vs. app insights.
-  // NOTE: In production environment, you should consider logging this to Azure
-  //       application insights.
-  console.error(`\n [onTurnError] unhandled error: ${error}`);
-
-  // Send a trace activity, which will be displayed in Bot Framework Emulator
-  await context.sendTraceActivity(
-    'OnTurnError Trace',
-    `${error}`,
-    'https://www.botframework.com/schemas/error',
-    'TurnError',
-  );
-
-  // Send a message to the user
-  await context.sendActivity(
-    `The bot encountered unhandled error:\n ${error.message}`,
-  );
-  await context.sendActivity(
-    'To continue to run this bot, please fix the bot source code.',
-  );
-};
 
 // Set the onTurnError for the singleton CloudAdapter
 adapter.onTurnError = onTurnErrorHandler;

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -1,0 +1,12 @@
+// User-facing bot copy shared across handlers.
+
+// Sent whenever a turn fails unexpectedly. Raw error messages can leak
+// internals (wallet ids, env names, stack details) into the chat, so the
+// details go to the logs and the user gets this instead.
+export const GENERIC_ERROR_MESSAGE =
+  "D'oh! Something went wrong on my end, so that didn't complete. Please try again in a moment.";
+
+// Validation errors whose message is written for the user (balance, recipient
+// checks). The onMessage catch relays these verbatim; everything else gets
+// GENERIC_ERROR_MESSAGE.
+export class UserFacingError extends Error {}

--- a/src/onTurnError.test.ts
+++ b/src/onTurnError.test.ts
@@ -42,8 +42,10 @@ describe('onTurnErrorHandler', () => {
       expect(message).not.toContain('wallet inkey abc123 leaked');
       expect(message).not.toContain('fix the bot source code');
     }
+    // The error object, not its interpolation: the stack must reach the logs.
     expect(consoleError).toHaveBeenCalledWith(
-      expect.stringContaining('wallet inkey abc123 leaked'),
+      '\n [onTurnError] unhandled error:',
+      error,
     );
   });
 

--- a/src/onTurnError.test.ts
+++ b/src/onTurnError.test.ts
@@ -1,0 +1,63 @@
+// onTurnError.test.ts
+
+import { onTurnErrorHandler } from './onTurnError';
+import { GENERIC_ERROR_MESSAGE } from './messages';
+import { afterEach, describe, expect, jest, test } from '@jest/globals';
+import { TurnContext } from 'botbuilder';
+
+const makeContext = () => {
+  const sendActivity = jest
+    .fn<() => Promise<void>>()
+    .mockResolvedValue(undefined);
+  const sendTraceActivity = jest
+    .fn<() => Promise<void>>()
+    .mockResolvedValue(undefined);
+  const context = {
+    activity: {
+      from: { id: 'user-1', aadObjectId: 'aad-1', name: 'Alice' },
+    },
+    sendActivity,
+    sendTraceActivity,
+  } as unknown as TurnContext;
+  return { context, sendActivity, sendTraceActivity };
+};
+
+describe('onTurnErrorHandler', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('sends a single generic message instead of the raw error', async () => {
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    const { context, sendActivity } = makeContext();
+    const error = new Error('wallet inkey abc123 leaked');
+
+    await onTurnErrorHandler(context, error);
+
+    expect(sendActivity).toHaveBeenCalledTimes(1);
+    expect(sendActivity).toHaveBeenCalledWith(GENERIC_ERROR_MESSAGE);
+    for (const [message] of sendActivity.mock.calls as unknown as [string][]) {
+      expect(message).not.toContain('wallet inkey abc123 leaked');
+      expect(message).not.toContain('fix the bot source code');
+    }
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining('wallet inkey abc123 leaked'),
+    );
+  });
+
+  test('still emits the Bot Framework Emulator trace activity', async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const { context, sendTraceActivity } = makeContext();
+
+    await onTurnErrorHandler(context, new Error('boom'));
+
+    expect(sendTraceActivity).toHaveBeenCalledWith(
+      'OnTurnError Trace',
+      expect.stringContaining('boom'),
+      'https://www.botframework.com/schemas/error',
+      'TurnError',
+    );
+  });
+});

--- a/src/onTurnError.ts
+++ b/src/onTurnError.ts
@@ -11,7 +11,7 @@ export const onTurnErrorHandler = async (
   // (wallet ids, env names, stack details) into the chat.
   // NOTE: In production environment, you should consider logging this to
   // Azure application insights.
-  console.error(`\n [onTurnError] unhandled error: ${error}`);
+  console.error('\n [onTurnError] unhandled error:', error);
   console.error(
     `User ID: ${context.activity.from?.id}, AAD Object ID: ${context.activity.from?.aadObjectId}, Display Name: ${context.activity.from?.name}`,
   );

--- a/src/onTurnError.ts
+++ b/src/onTurnError.ts
@@ -1,0 +1,29 @@
+import { TurnContext } from 'botbuilder';
+import { GENERIC_ERROR_MESSAGE } from './messages';
+
+// Catch-all for errors. Lives outside index.ts so it can be unit tested
+// without starting the express server.
+export const onTurnErrorHandler = async (
+  context: TurnContext,
+  error: Error,
+) => {
+  // The full error goes to the logs only: raw messages can leak internals
+  // (wallet ids, env names, stack details) into the chat.
+  // NOTE: In production environment, you should consider logging this to
+  // Azure application insights.
+  console.error(`\n [onTurnError] unhandled error: ${error}`);
+  console.error(
+    `User ID: ${context.activity.from?.id}, AAD Object ID: ${context.activity.from?.aadObjectId}, Display Name: ${context.activity.from?.name}`,
+  );
+
+  // Send a trace activity, which will be displayed in Bot Framework Emulator
+  await context.sendTraceActivity(
+    'OnTurnError Trace',
+    `${error}`,
+    'https://www.botframework.com/schemas/error',
+    'TurnError',
+  );
+
+  // Send a single generic, friendly message to the user
+  await context.sendActivity(GENERIC_ERROR_MESSAGE);
+};

--- a/src/teamsBot.test.ts
+++ b/src/teamsBot.test.ts
@@ -1,0 +1,153 @@
+// teamsBot.test.ts
+//
+// Mocks the external services; exercises the bot through its public run()
+// entry point with plain mock TurnContexts.
+
+import {
+  afterEach,
+  describe,
+  expect,
+  jest,
+  test,
+  beforeEach,
+} from '@jest/globals';
+import * as os from 'os';
+import * as path from 'path';
+import { TurnContext } from 'botbuilder';
+import { GENERIC_ERROR_MESSAGE } from './messages';
+
+jest.mock('./services/lnbitsService');
+jest.mock('./services/foundryAgentService');
+jest.mock('./services/graphService');
+jest.mock('./services/zapHistoryService');
+
+// teamsBot.ts refuses to load without the reward label, so it must be set
+// before the module is required (which is why this is a require, not a
+// hoisted import).
+process.env.LNBITS_POINTS_LABEL = process.env.LNBITS_POINTS_LABEL || 'Sats';
+// The durable zap ledger refuses to construct without a data directory.
+process.env.ZAPLIE_DATA_DIR =
+  process.env.ZAPLIE_DATA_DIR || path.join(os.tmpdir(), 'zaplie-test-ledger');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { TeamsBot } = require('./teamsBot') as typeof import('./teamsBot');
+
+type MockContext = {
+  context: TurnContext;
+  sendActivity: jest.Mock;
+};
+
+const makeContext = (activity: Record<string, unknown>): MockContext => {
+  const sendActivity = jest
+    .fn<() => Promise<void>>()
+    .mockResolvedValue(undefined);
+  const context = {
+    activity: {
+      type: 'message',
+      channelId: 'msteams',
+      recipient: { id: 'bot-id' },
+      from: { id: 'user-1' },
+      conversation: {
+        id: 'conv-1',
+        conversationType: 'personal',
+        tenantId: 'tenant-1',
+      },
+      ...activity,
+    },
+    turnState: new Map<unknown, unknown>(),
+    sendActivity,
+    updateActivity: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
+  } as unknown as TurnContext;
+  return { context, sendActivity };
+};
+
+describe('TeamsBot onMessage error hygiene', () => {
+  let consoleError: jest.SpiedFunction<typeof console.error>;
+
+  beforeEach(() => {
+    consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('logs the error and sends a generic message instead of error.message', async () => {
+    const bot = new TeamsBot();
+    // A verified sender with no allowance wallet fails on an internal
+    // condition, which is exactly what the catch block must not leak.
+    const { context, sendActivity } = makeContext({
+      replyToId: 'card-1',
+      value: {
+        action: 'submitZaps',
+        zapReceiverId: 'recipient-1',
+        zapMessage: 'thanks!',
+        zapAmount: '10',
+      },
+    });
+    (context.turnState as Map<unknown, unknown>).set('user', {
+      id: 'user-1',
+      aadObjectId: 'aad-user-1',
+      allowanceWallet: null,
+    });
+
+    await bot.run(context);
+
+    expect(sendActivity).toHaveBeenCalledWith(GENERIC_ERROR_MESSAGE);
+    for (const [message] of sendActivity.mock.calls as unknown as [string][]) {
+      expect(message).not.toContain('sending wallet');
+    }
+    expect(consoleError).toHaveBeenCalledWith(
+      'Error in onMessage handler:',
+      expect.objectContaining({
+        message: expect.stringContaining('No sending wallet found.'),
+      }),
+    );
+  });
+
+  test('tells an unverified sender why nothing was sent', async () => {
+    const bot = new TeamsBot();
+    // The sender identity check is user-facing copy, not an internal detail:
+    // the person needs to know their zaps did not go out.
+    const { context, sendActivity } = makeContext({
+      replyToId: 'card-1',
+      value: {
+        action: 'submitZaps',
+        zapReceiverId: 'recipient-1',
+        zapMessage: 'thanks!',
+        zapAmount: '10',
+      },
+    });
+
+    await bot.run(context);
+
+    expect(sendActivity).toHaveBeenCalledWith(
+      "D'oh! Could not verify your sender identity, so no zaps were sent.",
+    );
+  });
+
+  test('relays user-facing validation messages verbatim', async () => {
+    const bot = new TeamsBot();
+    const { context, sendActivity } = makeContext({
+      replyToId: 'card-1',
+      value: {
+        action: 'submitZaps',
+        zapReceiverId: 'user-1',
+        zapMessage: 'thanks!',
+        zapAmount: '10',
+      },
+    });
+    (context.turnState as Map<unknown, unknown>).set('user', {
+      id: 'user-1',
+      aadObjectId: 'aad-user-1',
+      allowanceWallet: { id: 'wallet-1', inkey: 'inkey', adminkey: 'adminkey' },
+    });
+
+    await bot.run(context);
+
+    expect(sendActivity).toHaveBeenCalledWith(
+      "D'oh! You cannot zap yourself, so no zaps were sent.",
+    );
+  });
+});

--- a/src/teamsBot.test.ts
+++ b/src/teamsBot.test.ts
@@ -25,9 +25,12 @@ jest.mock('./services/zapHistoryService');
 // before the module is required (which is why this is a require, not a
 // hoisted import).
 process.env.LNBITS_POINTS_LABEL = process.env.LNBITS_POINTS_LABEL || 'Sats';
-// The durable zap ledger refuses to construct without a data directory.
-process.env.ZAPLIE_DATA_DIR =
-  process.env.ZAPLIE_DATA_DIR || path.join(os.tmpdir(), 'zaplie-test-ledger');
+// The durable zap ledger refuses to construct without a data directory. The
+// path is per worker because sibling suites set and then delete this one.
+process.env.ZAPLIE_DATA_DIR = path.join(
+  os.tmpdir(),
+  `zaplie-test-ledger-${process.pid}`,
+);
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { TeamsBot } = require('./teamsBot') as typeof import('./teamsBot');
 

--- a/src/teamsBot.ts
+++ b/src/teamsBot.ts
@@ -28,6 +28,7 @@ import {
   ConnectCalendarCommand,
   getStoredGraphToken,
 } from './commands/connectCalendarCommand';
+import { GENERIC_ERROR_MESSAGE, UserFacingError } from './messages';
 import { runConversationalTurn } from './services/foundryAgentService';
 import { createReadOnlyTools } from './commands/agentTools';
 import { getUser, getWalletBalance } from './services/lnbitsService';
@@ -141,7 +142,7 @@ export class TeamsBot extends TeamsActivityHandler {
 
           const sendingWallet = currentUser?.allowanceWallet;
           if (!currentUser || (!currentUser.id && !currentUser.aadObjectId)) {
-            throw new Error(
+            throw new UserFacingError(
               'Could not verify your sender identity, so no zaps were sent.',
             );
           }
@@ -154,13 +155,15 @@ export class TeamsBot extends TeamsActivityHandler {
           }
 
           if (receiverIds.length === 0) {
-            throw new Error(
+            throw new UserFacingError(
               'No valid recipients were selected, so no zaps were sent.',
             );
           }
 
           if (currentUser.id && receiverIds.includes(currentUser.id)) {
-            throw new Error('You cannot zap yourself, so no zaps were sent.');
+            throw new UserFacingError(
+              'You cannot zap yourself, so no zaps were sent.',
+            );
           }
 
           const pendingReceiverIds = getPendingRecipientIds(
@@ -332,8 +335,12 @@ export class TeamsBot extends TeamsActivityHandler {
           }
         }
       } catch (error) {
-        console.error('Error in onMessage handler:', error.message);
-        await context.sendActivity(`${error.message}`);
+        console.error('Error in onMessage handler:', error);
+        await context.sendActivity(
+          error instanceof UserFacingError
+            ? `D'oh! ${error.message}`
+            : GENERIC_ERROR_MESSAGE,
+        );
       }
 
       await next();
@@ -349,7 +356,7 @@ export class TeamsBot extends TeamsActivityHandler {
       await this.userState.saveChanges(context, false);
     } catch (error) {
       console.error('Error in run method:', error);
-      await context.sendActivity(error);
+      await context.sendActivity(GENERIC_ERROR_MESSAGE);
     }
   }
 


### PR DESCRIPTION
Fixes #323

Stacked on the portal-url PR.

## What changed
- The bot sent raw exception text to the chat (env var names, Foundry internals, and onTurnError's "please fix the bot source code"). Both catches now log the full error and send one friendly generic line.
- Validation messages that ARE written for users (balance, self-zap, recipient checks) still reach the user verbatim via a new `UserFacingError` class — hygiene without losing useful copy.
- `onTurnError` extracted to `src/onTurnError.ts` so it's testable; the Emulator trace activity is preserved.

## Test plan for QA
- `npx jest`: tests assert internal errors stay generic (and are logged), and "You cannot zap yourself…" is relayed verbatim.