### PR TITLE
chore: stop advertising the unimplemented withdraw command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,9 @@ deployable components in one repository:
   handled by `CloudAdapter`. `src/teamsBot.ts` extends `TeamsActivityHandler`
   and routes text commands via the `SSOCommandMap` registry
   (`src/commands/SSOCommandMap.ts`). Commands: `send zap`, `show my balance`,
-  `show leaderboard`, `withdraw my zaps` (stub). Adaptive card submits arrive
+  `show leaderboard`. (`withdraw my zaps` exists as a stub in
+  `src/commands/withdrawFundsCommand.ts` but is not registered or listed in the
+  manifests until withdrawals work — issue #293.) Adaptive card submits arrive
   with `activity.value.action === 'submitZaps'`.
 - **Assistant instructions** (`src/services/foundryAgentService.ts`): the
   Foundry agent's instructions are `FIXED_GUARDRAILS` (tool honesty, withdrawals

--- a/docs/SOLUTION_DESIGN.adoc
+++ b/docs/SOLUTION_DESIGN.adoc
@@ -109,10 +109,12 @@ in a static `SSOCommandMap` keyed by lower-case message text:
 | `src/commands/showLeaderboardCommand.ts`
 | Ranks users by Private wallet balance in an Adaptive Card
 
-| `withdraw my zaps`
-| `src/commands/withdrawFundsCommand.ts`
-| Stub — "coming soon"
 |===
+
+`withdraw my zaps` is implemented as a stub in
+`src/commands/withdrawFundsCommand.ts` but is deliberately *not* registered in
+`SSOCommandMap` and not listed in the Teams manifests, so the bot never
+advertises a command that cannot complete. See issue #293.
 
 The bot also implements Teams SSO handlers (`handleTeamsSigninVerifyState`,
 `handleTeamsSigninTokenExchange`). Conversation and user state use in-memory

--- a/manifest.template.json
+++ b/manifest.template.json
@@ -53,10 +53,6 @@
                         {
                             "title": "Show Leaderboard",
                             "description": "Show the leaderboard of users private wallets"
-                        },
-                        {
-                            "title": "Withdraw my Zaps",
-                            "description": "Withdraw funds from your private wallet to your own personal wallet"
                         }
                     ]
                 }

--- a/src/teamsBot.test.ts
+++ b/src/teamsBot.test.ts
@@ -154,3 +154,26 @@ describe('TeamsBot onMessage error hygiene', () => {
     );
   });
 });
+
+describe('TeamsBot withdraw command', () => {
+  test('neither runs nor advertises the unlisted withdraw command', async () => {
+    const bot = new TeamsBot();
+    const { context, sendActivity } = makeContext({
+      text: 'withdraw my zaps',
+      conversation: {
+        id: 'conv-2',
+        conversationType: 'channel',
+        tenantId: 'tenant-1',
+      },
+    });
+
+    await bot.run(context);
+
+    // The stub would have replied "coming soon", so a lone unrecognized
+    // command reply proves it was not invoked.
+    expect(sendActivity).toHaveBeenCalledTimes(1);
+    const [reply] = sendActivity.mock.calls[0] as unknown as [string];
+    expect(reply).toContain("D'oh!");
+    expect(reply).not.toContain('withdraw');
+  });
+});

--- a/src/teamsBot.ts
+++ b/src/teamsBot.ts
@@ -21,7 +21,6 @@ import {
 } from './commands/zapRecipient';
 import { validateZapSubmit } from './commands/zapBudget';
 import { ShowMyBalanceCommand } from './commands/showMyBalanceCommand';
-import { WithdrawFundsCommand } from './commands/withdrawFundsCommand';
 import { ShowLeaderboardCommand } from './commands/showLeaderboardCommand';
 import {
   CONNECT_CALENDAR_COMMAND,
@@ -70,7 +69,9 @@ export class TeamsBot extends TeamsActivityHandler {
     // Register commands
     SSOCommandMap.register('send zap', new SendZapCommand());
     SSOCommandMap.register('show my balance', new ShowMyBalanceCommand());
-    SSOCommandMap.register('withdraw my zaps', new WithdrawFundsCommand());
+    // "withdraw my zaps" is deliberately not registered (or listed in the
+    // app manifests) until withdrawals actually work — see issue #293. The
+    // command implementation is kept in commands/withdrawFundsCommand.ts.
     SSOCommandMap.register('show leaderboard', new ShowLeaderboardCommand());
     if (process.env.GRAPH_CONNECTION_NAME) {
       SSOCommandMap.register(


### PR DESCRIPTION
Part of #293.

## What changed

"Withdraw my Zaps" promised to move real Bitcoin but is a stub ("coming soon"). Until withdrawals work, it is no longer advertised: removed from `commandLists` in `manifest.template.json` (the generated `appPackage/manifest.json` is no longer tracked, see #313) and unregistered from the command map. `withdrawFundsCommand.ts` stays for the real implementation (issue #293 remains open).

## Test plan for QA

- The built manifest contains no Withdraw entry; typing "withdraw my zaps" now gets the unrecognized command reply instead of a false promise.
- `src/teamsBot.test.ts` guards the regression: a channel message of "withdraw my zaps" must not reach the stub.
