### PR TITLE
fix: render the key-value zap receipt card

### DIFF
--- a/src/commands/sendZapCommand.test.ts
+++ b/src/commands/sendZapCommand.test.ts
@@ -2,10 +2,13 @@
 //
 // Covers the command's error hygiene: LNbits failures carry wallet ids and
 // configuration names, so they belong in the logs and never in the chat.
+// Also covers the receipt card builder: shape, key/value fields and the
+// regression where a ColumnSet was nested inside another ColumnSet's columns
+// array (invalid Adaptive Card JSON).
 
 import { afterEach, describe, expect, jest, test } from '@jest/globals';
 import type { TurnContext } from 'botbuilder';
-import { SendZapCommand } from './sendZapCommand';
+import { SendZapCommand, buildZapReceiptCard } from './sendZapCommand';
 import { getUsers } from '../services/lnbitsService';
 import { GENERIC_ERROR_MESSAGE } from '../messages';
 
@@ -22,6 +25,44 @@ const makeContext = () => {
       sendActivity,
     } as unknown as TurnContext,
   };
+};
+
+type CardElement = {
+  type?: string;
+  text?: string;
+  columns?: CardElement[];
+  items?: CardElement[];
+  body?: CardElement[];
+};
+
+// Depth-first walk over every element of the card body.
+const walk = (element: CardElement, visit: (el: CardElement) => void): void => {
+  visit(element);
+  for (const child of [
+    ...(element.body ?? []),
+    ...(element.columns ?? []),
+    ...(element.items ?? []),
+  ]) {
+    walk(child, visit);
+  }
+};
+
+const allText = (card: CardElement): string => {
+  const texts: string[] = [];
+  walk(card, el => {
+    if (typeof el.text === 'string') {
+      texts.push(el.text);
+    }
+  });
+  return texts.join('\n');
+};
+
+const baseReceipt = {
+  recipients: ['Bob'],
+  message: 'Thanks for the review!',
+  amount: 21,
+  remainingBalance: 979,
+  rewardName: 'Sats',
 };
 
 describe('SendZapCommand error hygiene', () => {
@@ -53,5 +94,121 @@ describe('SendZapCommand error hygiene', () => {
         message: expect.stringContaining('admin key'),
       }),
     );
+  });
+});
+
+describe('buildZapReceiptCard', () => {
+  test('produces a valid Adaptive Card 1.5 envelope', () => {
+    const card = buildZapReceiptCard(baseReceipt);
+
+    expect(card.type).toBe('AdaptiveCard');
+    expect(card.version).toBe('1.5');
+    expect(card.$schema).toBe(
+      'http://adaptivecards.io/schemas/adaptive-card.json',
+    );
+    // Serializable, plain JSON.
+    expect(() => JSON.stringify(card)).not.toThrow();
+  });
+
+  test('never nests a ColumnSet inside a columns array', () => {
+    const card = buildZapReceiptCard({
+      ...baseReceipt,
+      recipients: ['Bob', 'Carol'],
+      failedRecipients: ['Dave'],
+    });
+
+    walk(card as CardElement, element => {
+      if (element.type === 'ColumnSet') {
+        for (const column of element.columns ?? []) {
+          expect(column.type).toBe('Column');
+        }
+      }
+    });
+  });
+
+  test('shows the Receiver/Message/Amount/Remaining fields', () => {
+    const text = allText(buildZapReceiptCard(baseReceipt) as CardElement);
+
+    expect(text).toContain('Zap sent!');
+    expect(text).toContain('Receiver:');
+    expect(text).toContain('Bob');
+    expect(text).toContain('Message:');
+    expect(text).toContain('Thanks for the review!');
+    expect(text).toContain('Amount (Sats):');
+    expect(text).toContain('21');
+    expect(text).toContain('Remaining Amount (Sats):');
+    expect(text).toContain('979');
+  });
+
+  test('lists every recipient and the total on a multi-recipient receipt', () => {
+    const card = buildZapReceiptCard({
+      ...baseReceipt,
+      recipients: ['Bob', 'Carol', 'Dave'],
+    }) as CardElement;
+    const text = allText(card);
+
+    expect(text).toContain('Receivers:');
+    expect(text).toContain('Bob, Carol, Dave');
+    expect(text).toContain('Total Sent (Sats):');
+    expect(text).toContain('63');
+  });
+
+  test('shows failed recipients only when there are failures', () => {
+    const clean = allText(buildZapReceiptCard(baseReceipt) as CardElement);
+    expect(clean).not.toContain('Failed Receivers');
+
+    const withFailure = allText(
+      buildZapReceiptCard({
+        ...baseReceipt,
+        failedRecipients: ['Dave'],
+      }) as CardElement,
+    );
+    expect(withFailure).toContain('Failed Receivers');
+    expect(withFailure).toContain('- Dave');
+  });
+
+  test('reports an unconfirmed payment apart from the failures', () => {
+    const clean = allText(buildZapReceiptCard(baseReceipt) as CardElement);
+    expect(clean).not.toContain('Needs checking');
+
+    const blocks: string[] = [];
+    walk(
+      buildZapReceiptCard({
+        ...baseReceipt,
+        failedRecipients: ['Erin'],
+        uncertainRecipients: ['Dave'],
+      }) as CardElement,
+      element => {
+        if (typeof element.text === 'string') {
+          blocks.push(element.text);
+        }
+      },
+    );
+
+    const needsChecking = blocks.find(text => text.includes('Needs checking'));
+    expect(needsChecking).toContain('- Dave');
+    expect(needsChecking).toContain(
+      'Payment outcome uncertain — an admin should verify before retrying.',
+    );
+    // Dave's payment may have settled: listing him as failed would invite a
+    // retry that pays him twice.
+    const failed = blocks.find(text => text.includes('Failed Receivers'));
+    expect(failed).toContain('- Erin');
+    expect(failed).not.toContain('Dave');
+  });
+
+  test('groups large amounts for readability', () => {
+    const text = allText(
+      buildZapReceiptCard({
+        ...baseReceipt,
+        recipients: ['Bob', 'Carol'],
+        amount: 2500,
+        remainingBalance: 12000,
+      }) as CardElement,
+    );
+
+    expect(text).toContain((2500).toLocaleString());
+    expect(text).toContain((5000).toLocaleString());
+    expect(text).toContain((12000).toLocaleString());
   });
 });

--- a/src/commands/sendZapCommand.ts
+++ b/src/commands/sendZapCommand.ts
@@ -44,6 +44,125 @@ export interface SendZapResult {
   paymentHash: string;
 }
 
+export interface ZapReceipt {
+  recipients: string[];
+  failedRecipients?: string[];
+  // Recipients whose payment was sent but never confirmed. They are NOT
+  // failures: the money may already have moved, so they get their own section
+  // instead of an invitation to retry.
+  uncertainRecipients?: string[];
+  message: string;
+  amount: number;
+  remainingBalance: number;
+  rewardName: string;
+}
+
+// One key/value row of the receipt: bold label on the left, value on the
+// right. Kept flat — a ColumnSet must only ever contain Columns.
+const receiptRow = (label: string, value: string) => ({
+  type: 'ColumnSet',
+  columns: [
+    {
+      type: 'Column',
+      width: 'auto',
+      items: [
+        {
+          type: 'TextBlock',
+          text: label,
+          weight: 'Bolder',
+        },
+      ],
+    },
+    {
+      type: 'Column',
+      width: 'stretch',
+      items: [
+        {
+          type: 'TextBlock',
+          text: value,
+          wrap: true,
+        },
+      ],
+    },
+  ],
+});
+
+// The read-only receipt a zap card turns into once a submit finishes. It
+// reports the recipients this submit processed — recipients already settled by
+// an earlier submit of the same card are not repeated here.
+export function buildZapReceiptCard(receipt: ZapReceipt) {
+  const {
+    recipients,
+    failedRecipients = [],
+    uncertainRecipients = [],
+    message,
+    amount,
+    remainingBalance,
+    rewardName,
+  } = receipt;
+
+  const receiverLabel = recipients.length > 1 ? 'Receivers:' : 'Receiver:';
+  const totalAmountSent = recipients.length * amount;
+  const bulletList = (names: string[]): string =>
+    names.map(name => `- ${name}`).join('\n');
+
+  return {
+    type: 'AdaptiveCard',
+    body: [
+      {
+        type: 'TextBlock',
+        text: 'Zap sent!',
+        weight: 'Bolder',
+        size: 'Large',
+        color: 'Good',
+      },
+      receiptRow(receiverLabel, recipients.join(', ')),
+      ...(failedRecipients.length > 0
+        ? [
+            {
+              type: 'TextBlock',
+              text: `**Failed Receivers:**\n${bulletList(failedRecipients)}`,
+              wrap: true,
+              color: 'Attention',
+            },
+          ]
+        : []),
+      // Kept apart from the failures on purpose: these payments were sent and
+      // may well have settled, so listing them as failed would invite a retry
+      // that pays the same person twice.
+      ...(uncertainRecipients.length > 0
+        ? [
+            {
+              type: 'TextBlock',
+              text:
+                `**Needs checking:**\n${bulletList(uncertainRecipients)}\n` +
+                'Payment outcome uncertain — an admin should verify before ' +
+                'retrying.',
+              wrap: true,
+              color: 'Warning',
+            },
+          ]
+        : []),
+      receiptRow('Message:', message),
+      receiptRow(`Amount (${rewardName}):`, amount.toLocaleString()),
+      ...(recipients.length > 1
+        ? [
+            receiptRow(
+              `Total Sent (${rewardName}):`,
+              totalAmountSent.toLocaleString(),
+            ),
+          ]
+        : []),
+      receiptRow(
+        `Remaining Amount (${rewardName}):`,
+        remainingBalance.toLocaleString(),
+      ),
+    ],
+    $schema: 'http://adaptivecards.io/schemas/adaptive-card.json',
+    version: '1.5',
+  };
+}
+
 // Thrown only once payInvoice has been called: at that point the payment may
 // have settled even though we failed to confirm it, so a retry is unsafe.
 export class PaymentOutcomeUnknownError extends Error {
@@ -121,124 +240,13 @@ export async function SendZap(
       );
       console.log('Remaining Balance:', remainingBalance);
 
-      const updatedCard = {
-        type: 'AdaptiveCard',
-        body: [
-          {
-            type: 'TextBlock',
-            text: `Zap sent!`,
-            weight: 'Bolder',
-            size: 'Large',
-            color: 'Good',
-          },
-          {
-            type: 'ColumnSet',
-            columns: [
-              {
-                type: 'Column',
-                width: 'auto',
-                items: [
-                  {
-                    type: 'TextBlock',
-                    text: `Receiver:`,
-                    weight: 'Bolder',
-                  },
-                ],
-              },
-              {
-                type: 'Column',
-                width: 'stretch',
-                items: [
-                  {
-                    type: 'TextBlock',
-                    text: `${receiver.displayName}`,
-                  },
-                ],
-              },
-            ],
-          },
-          {
-            type: 'ColumnSet',
-            columns: [
-              {
-                type: 'Column',
-                width: 'auto',
-                items: [
-                  {
-                    type: 'TextBlock',
-                    text: `Message:`,
-                    weight: 'Bolder',
-                  },
-                ],
-              },
-              {
-                type: 'Column',
-                width: 'stretch',
-                items: [
-                  {
-                    type: 'TextBlock',
-                    text: `${zapMessage}`,
-                  },
-                ],
-              },
-            ],
-          },
-          {
-            type: 'ColumnSet',
-            columns: [
-              {
-                type: 'Column',
-                width: 'auto',
-                items: [
-                  {
-                    type: 'TextBlock',
-                    text: `Amount (${globalRewardName}):`,
-                    weight: 'Bolder',
-                  },
-                ],
-              },
-              {
-                type: 'Column',
-                width: 'stretch',
-                items: [
-                  {
-                    type: 'TextBlock',
-                    text: `${zapAmount}`,
-                  },
-                ],
-              },
-              {
-                type: 'ColumnSet',
-                columns: [
-                  {
-                    type: 'Column',
-                    width: 'auto',
-                    items: [
-                      {
-                        type: 'TextBlock',
-                        text: `Remaining Amount (${globalRewardName}):`,
-                        weight: 'Bolder',
-                      },
-                    ],
-                  },
-                  {
-                    type: 'Column',
-                    width: 'stretch',
-                    items: [
-                      {
-                        type: 'TextBlock',
-                        text: `${remainingBalance}`,
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-        $schema: 'http://adaptivecards.io/schemas/adaptive-card.json',
-        version: '1.2',
-      };
+      const updatedCard = buildZapReceiptCard({
+        recipients: [receiver.displayName],
+        message: zapMessage,
+        amount: zapAmount,
+        remainingBalance,
+        rewardName: globalRewardName,
+      });
 
       // Update responsive card in message
       const updatedMessage = MessageFactory.attachment(

--- a/src/teamsBot.test.ts
+++ b/src/teamsBot.test.ts
@@ -177,3 +177,35 @@ describe('TeamsBot withdraw command', () => {
     expect(reply).not.toContain('withdraw');
   });
 });
+
+describe('TeamsBot submitZaps message validation', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('rejects a submit with no message instead of building a receipt from it', async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    jest.spyOn(console, 'log').mockImplementation(() => undefined);
+    const bot = new TeamsBot();
+    const { context, sendActivity } = makeContext({
+      replyToId: 'card-1',
+      value: {
+        action: 'submitZaps',
+        zapReceiverId: 'recipient-1',
+        zapAmount: '10',
+      },
+    });
+    (context.turnState as Map<unknown, unknown>).set('user', {
+      id: 'user-1',
+      aadObjectId: 'aad-user-1',
+      allowanceWallet: { id: 'wallet-1', inkey: 'inkey', adminkey: 'adminkey' },
+    });
+
+    await bot.run(context);
+
+    expect(sendActivity).toHaveBeenCalledWith(
+      "D'oh! Your zap needs a message, so no zaps were sent.",
+    );
+    expect(context.updateActivity).not.toHaveBeenCalled();
+  });
+});

--- a/src/teamsBot.ts
+++ b/src/teamsBot.ts
@@ -10,7 +10,11 @@ import {
   MessageFactory,
 } from 'botbuilder';
 import { SSOCommandMap } from './commands/SSOCommandMap';
-import { SendZapCommand, SendZap } from './commands/sendZapCommand';
+import {
+  SendZapCommand,
+  SendZap,
+  buildZapReceiptCard,
+} from './commands/sendZapCommand';
 import { ZapLedger, zapKey } from './services/zapLedger';
 import {
   getPendingRecipientIds,
@@ -102,6 +106,9 @@ export class TeamsBot extends TeamsActivityHandler {
         );
 
         const failedRecipients: string[] = [];
+        // Kept separate from the failures: an unconfirmed payment may have
+        // settled, so it must never be presented as something to retry.
+        const uncertainRecipients: string[] = [];
 
         if (botMentioned) {
           // Remove the mention from the text
@@ -217,7 +224,7 @@ export class TeamsBot extends TeamsActivityHandler {
             } else if (outcome.status === 'paid') {
               successfulRecipients.push(outcome.label);
             } else if (outcome.status === 'needs-checking') {
-              failedRecipients.push(`${outcome.label} (needs checking)`);
+              uncertainRecipients.push(outcome.label);
             } else {
               failedRecipients.push(outcome.label);
             }
@@ -230,82 +237,43 @@ export class TeamsBot extends TeamsActivityHandler {
             return;
           }
 
-          // Nothing was paid this time: the card must not turn green.
+          // Nothing was confirmed this time: the card must not turn green.
           if (successfulRecipients.length === 0) {
             await context.sendActivity(
-              `No zaps were sent. Could not complete: ${failedRecipients.join(', ')}`,
+              [
+                uncertainRecipients.length > 0
+                  ? 'No zaps were confirmed.'
+                  : 'No zaps were sent.',
+                failedRecipients.length > 0
+                  ? `Could not complete: ${failedRecipients.join(', ')}.`
+                  : '',
+                uncertainRecipients.length > 0
+                  ? `Payment outcome uncertain for: ${uncertainRecipients.join(', ')} — an admin should verify before retrying.`
+                  : '',
+              ]
+                .filter(Boolean)
+                .join(' '),
             );
             return;
           }
-          const bulletReceivers = successfulRecipients
-            .map(name => `- ${name}`)
-            .join('\n');
-
-          const bulletFailed = failedRecipients.length
-            ? failedRecipients.map(name => `- ${name}`).join('\n')
-            : 'None';
-
           //fetch remainingBalance
           const remainingBalance = await getWalletBalance(
             currentUser.allowanceWallet.inkey,
           );
           console.log('Remaining Balance:', remainingBalance);
 
-          const totalAmountSent = successfulRecipients.length * amount;
-
-          // Update adaptive card to read-only with list of recipients
-          const updatedCard = {
-            type: 'AdaptiveCard',
-            body: [
-              {
-                type: 'TextBlock',
-                text: `Zap sent!`,
-                weight: 'Bolder',
-                size: 'Large',
-                color: 'Good',
-              },
-              {
-                type: 'TextBlock',
-                text: `**Successful Receivers:**\n${bulletReceivers}`,
-                wrap: true,
-              },
-              ...(failedRecipients.length > 0
-                ? [
-                    {
-                      type: 'TextBlock',
-                      text: `**Failed Receivers:**\n${bulletFailed}`,
-                      wrap: true,
-                      color: 'Attention',
-                    },
-                  ]
-                : []),
-              {
-                type: 'TextBlock',
-                text: `**Message:** ${zapMessage}`,
-                wrap: true,
-              },
-              {
-                type: 'TextBlock',
-                text: `**Amount (${globalRewardName}):** ${amount}`,
-                wrap: true,
-              },
-
-              {
-                type: 'TextBlock',
-                text: `Total Amount (Sats): ${totalAmountSent}`,
-                wrap: true,
-                color: 'Good',
-              },
-              {
-                type: 'TextBlock',
-                text: `**Remaining Amount (${globalRewardName}):** ${remainingBalance}`,
-                wrap: true,
-                color: 'Good',
-              },
-            ],
-            $schema: 'http://adaptivecards.io/schemas/adaptive-card.json',
-            version: '1.2',
-          };
+          // Update the adaptive card to a read-only receipt for the
+          // recipients this submit processed. Recipients already settled by an
+          // earlier submit of the same card were skipped and are not relisted.
+          const updatedCard = buildZapReceiptCard({
+            recipients: successfulRecipients,
+            failedRecipients,
+            uncertainRecipients,
+            message: zapMessage,
+            amount,
+            remainingBalance,
+            rewardName: globalRewardName,
+          });
 
           const updatedMessage = MessageFactory.attachment(
             CardFactory.adaptiveCard(updatedCard),

--- a/src/teamsBot.ts
+++ b/src/teamsBot.ts
@@ -168,6 +168,15 @@ export class TeamsBot extends TeamsActivityHandler {
             );
           }
 
+          // The card marks the message required, but that check is client-side
+          // and forgeable, and the message reaches both the invoice and the
+          // receipt card.
+          if (typeof zapMessage !== 'string' || zapMessage.trim() === '') {
+            throw new UserFacingError(
+              'Your zap needs a message, so no zaps were sent.',
+            );
+          }
+
           if (currentUser.id && receiverIds.includes(currentUser.id)) {
             throw new UserFacingError(
               'You cannot zap yourself, so no zaps were sent.',


### PR DESCRIPTION
Fixes #325

## What changed
The key-value zap receipt existed in `sendZapCommand.ts` but was dead code (its only caller passed `updateCard=false`) and malformed (a ColumnSet nested inside another ColumnSet's `columns` array, which is invalid Adaptive Card JSON). It's now a fixed, exported `buildZapReceiptCard()` (AC 1.5) with Receiver(s)/Message/Amount/Remaining rows, a Total row for multi-recipient zaps and an optional failed-recipients section, and the `submitZaps` flow actually renders it.

A follow-up commit rejects a zap submit that arrives with no message: the card marks that field required client-side only, and an undefined message would reach the LNbits invoice memo and then the receipt card, where a TextBlock with undefined text is dropped by `JSON.stringify` and leaves an invalid Adaptive Card.

## Test plan for QA
- `npx jest`: card envelope validity, anti-nesting regression, field rows, multi-recipient total, conditional failure section, and the missing-message rejection.

**Post-review**: recipients whose payment outcome is uncertain now render under a distinct **Needs checking** section (previously shown as failed, inviting unsafe retries); amounts are locale-formatted.
