### PR TITLE
fix: give the leaderboard card ranks, a title and a top-10 cap

### DIFF
--- a/src/commands/showLeaderboardCommand.test.ts
+++ b/src/commands/showLeaderboardCommand.test.ts
@@ -129,6 +129,8 @@ describe('buildLeaderboardCard', () => {
       type: 'TextBlock',
       text: LEADERBOARD_EMPTY_MESSAGE,
     });
+    // The card ranks balances, so the empty state must not promise zaps received.
+    expect(LEADERBOARD_EMPTY_MESSAGE).not.toMatch(/zaps? received/i);
   });
 });
 
@@ -207,6 +209,25 @@ describe('showLeaderboardCommand', () => {
     expect(rowText(rows[0])).toBe(`#1 Bob | ${(2000).toLocaleString()} Sats`);
     expect(rowText(rows[1])).toBe(`#2 Alice | ${(1000).toLocaleString()} Sats`);
     expect(mockGetUsers).toHaveBeenCalledTimes(1);
+  });
+
+  test('fetches wallets and users in parallel', async () => {
+    let releaseWallets: (wallets: Wallet[]) => void = () => undefined;
+    mockGetWallets.mockReturnValue(
+      new Promise<Wallet[] | null>(resolve => {
+        releaseWallets = resolve;
+      }),
+    );
+    const { context } = makeContext();
+
+    const executed = new ShowLeaderboardCommand().execute(context);
+    await Promise.resolve();
+    // Awaiting the two calls in sequence would leave getUsers uncalled while
+    // the wallet request is still pending.
+    expect(mockGetUsers).toHaveBeenCalledTimes(1);
+
+    releaseWallets([wallet({ id: 'w1', user: 'user-1' })]);
+    await executed;
   });
 
   test('orders equal balances by name so the card is stable', async () => {

--- a/src/commands/showLeaderboardCommand.test.ts
+++ b/src/commands/showLeaderboardCommand.test.ts
@@ -2,8 +2,15 @@
 //
 // Mocks lnbitsService (external dependency), not the command itself.
 
-import { ShowLeaderboardCommand } from './showLeaderboardCommand';
-import { getWallets, getUser } from '../services/lnbitsService';
+import {
+  LEADERBOARD_EMPTY_MESSAGE,
+  LEADERBOARD_LIMIT,
+  LEADERBOARD_TITLE,
+  LEADERBOARD_UNAVAILABLE_MESSAGE,
+  ShowLeaderboardCommand,
+  buildLeaderboardCard,
+} from './showLeaderboardCommand';
+import { getWallets, getUsers } from '../services/lnbitsService';
 import {
   afterEach,
   beforeEach,
@@ -17,7 +24,7 @@ import { TurnContext } from 'botbuilder';
 jest.mock('../services/lnbitsService');
 
 const mockGetWallets = getWallets as jest.MockedFunction<typeof getWallets>;
-const mockGetUser = getUser as jest.MockedFunction<typeof getUser>;
+const mockGetUsers = getUsers as jest.MockedFunction<typeof getUsers>;
 
 const wallet = (overrides: Partial<Wallet>): Wallet => ({
   id: 'w1',
@@ -55,18 +62,99 @@ const sentCard = (sendActivity: jest.Mock): any => {
   return activity.attachments[0].content;
 };
 
+const rowText = (row: any): string =>
+  row.columns
+    .map((column: any) => column.items.map((item: any) => item.text).join(' '))
+    .join(' | ');
+
+describe('buildLeaderboardCard', () => {
+  const entries = [
+    { displayName: 'Alice', amount: 300 },
+    { displayName: 'Bob', amount: 200 },
+    { displayName: 'Carol', amount: 100 },
+  ];
+
+  test('starts with the title and ranks each leader in a two-column row', () => {
+    const card = buildLeaderboardCard(entries, 'Sats');
+
+    expect(card.body[0]).toMatchObject({
+      type: 'TextBlock',
+      text: LEADERBOARD_TITLE,
+    });
+
+    const rows = card.body.slice(1) as any[];
+    expect(rows).toHaveLength(3);
+    expect(rowText(rows[0])).toBe('#1 Alice | 300 Sats');
+    expect(rowText(rows[1])).toBe('#2 Bob | 200 Sats');
+    expect(rowText(rows[2])).toBe('#3 Carol | 100 Sats');
+    // The title names the balance rather than promising "zaps received".
+    expect(LEADERBOARD_TITLE).toContain('balance');
+
+    // Name stretches on the left, bold amount sits on the right.
+    expect(rows[0].columns[0].width).toBe('stretch');
+    expect(rows[0].columns[1].width).toBe('auto');
+    expect(rows[0].columns[1].items[0].weight).toBe('Bolder');
+  });
+
+  test('caps the leaderboard at the top 10', () => {
+    const many = Array.from({ length: 15 }, (_, i) => ({
+      displayName: `User ${i + 1}`,
+      amount: 1500 - i * 100,
+    }));
+
+    const card = buildLeaderboardCard(many, 'Sats');
+
+    const rows = card.body.slice(1) as any[];
+    expect(rows).toHaveLength(LEADERBOARD_LIMIT);
+    expect(rowText(rows[9])).toContain('#10 User 10');
+  });
+
+  test('groups large amounts for readability', () => {
+    const card = buildLeaderboardCard(
+      [{ displayName: 'Alice', amount: 12345 }],
+      'Sats',
+    );
+
+    const rows = card.body.slice(1) as any[];
+    expect(rowText(rows[0])).toBe(
+      `#1 Alice | ${(12345).toLocaleString()} Sats`,
+    );
+  });
+
+  test('says the leaderboard is empty instead of showing a bare title', () => {
+    const card = buildLeaderboardCard([], 'Sats');
+
+    expect(card.body).toHaveLength(2);
+    expect(card.body[1]).toMatchObject({
+      type: 'TextBlock',
+      text: LEADERBOARD_EMPTY_MESSAGE,
+    });
+  });
+});
+
 describe('showLeaderboardCommand', () => {
+  const originalPointsLabel = process.env.LNBITS_POINTS_LABEL;
   const originalPortalUrl = process.env.PORTAL_URL;
 
   beforeEach(() => {
+    process.env.LNBITS_POINTS_LABEL = 'Sats';
     mockGetWallets.mockResolvedValue([
-      wallet({ id: 'w1', user: 'user-1', balance_msat: 2_000_000 }),
+      wallet({ id: 'w1', user: 'user-1', balance_msat: 1_000_000 }),
+      wallet({ id: 'w2', user: 'user-2', balance_msat: 2_000_000 }),
     ]);
-    mockGetUser.mockResolvedValue(user({ id: 'user-1' }));
+    mockGetUsers.mockResolvedValue([
+      user({ id: 'user-1', displayName: 'Alice' }),
+      user({ id: 'user-2', displayName: 'Bob' }),
+    ]);
   });
 
   afterEach(() => {
     jest.clearAllMocks();
+    if (originalPointsLabel === undefined) {
+      delete process.env.LNBITS_POINTS_LABEL;
+    } else {
+      process.env.LNBITS_POINTS_LABEL = originalPointsLabel;
+    }
     if (originalPortalUrl === undefined) {
       delete process.env.PORTAL_URL;
     } else {
@@ -80,8 +168,7 @@ describe('showLeaderboardCommand', () => {
 
     await new ShowLeaderboardCommand().execute(context);
 
-    const card = sentCard(sendActivity);
-    expect(card.actions).toEqual([
+    expect(sentCard(sendActivity).actions).toEqual([
       {
         type: 'Action.OpenUrl',
         title: 'View Wallets',
@@ -108,5 +195,94 @@ describe('showLeaderboardCommand', () => {
     await new ShowLeaderboardCommand().execute(context);
 
     expect(sentCard(sendActivity).actions).toBeUndefined();
+  });
+
+  test('sorts by balance and resolves names with a single getUsers call', async () => {
+    const { context, sendActivity } = makeContext();
+
+    await new ShowLeaderboardCommand().execute(context);
+
+    const card = sentCard(sendActivity);
+    const rows = card.body.slice(1) as any[];
+    expect(rowText(rows[0])).toBe(`#1 Bob | ${(2000).toLocaleString()} Sats`);
+    expect(rowText(rows[1])).toBe(`#2 Alice | ${(1000).toLocaleString()} Sats`);
+    expect(mockGetUsers).toHaveBeenCalledTimes(1);
+  });
+
+  test('orders equal balances by name so the card is stable', async () => {
+    mockGetWallets.mockResolvedValue([
+      wallet({ id: 'w1', user: 'user-1', balance_msat: 1_000_000 }),
+      wallet({ id: 'w2', user: 'user-2', balance_msat: 1_000_000 }),
+      wallet({ id: 'w3', user: 'user-3', balance_msat: 1_000_000 }),
+    ]);
+    mockGetUsers.mockResolvedValue([
+      user({ id: 'user-1', displayName: 'Carol' }),
+      user({ id: 'user-2', displayName: 'Alice' }),
+      user({ id: 'user-3', displayName: 'Bob' }),
+    ]);
+    const { context, sendActivity } = makeContext();
+
+    await new ShowLeaderboardCommand().execute(context);
+
+    const rows = sentCard(sendActivity).body.slice(1) as any[];
+    expect(rows.map((row: any) => rowText(row).split(' | ')[0])).toEqual([
+      '#1 Alice',
+      '#2 Bob',
+      '#3 Carol',
+    ]);
+  });
+
+  test('never ranks a wallet whose owner is missing from the directory', async () => {
+    const consoleWarn = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+    mockGetWallets.mockResolvedValue([
+      wallet({ id: 'w1', user: 'user-1', balance_msat: 1_000_000 }),
+      wallet({ id: 'w-orphan', user: 'ghost-user', balance_msat: 9_000_000 }),
+    ]);
+    mockGetUsers.mockResolvedValue([
+      user({ id: 'user-1', displayName: 'Alice' }),
+    ]);
+    const { context, sendActivity } = makeContext();
+
+    await new ShowLeaderboardCommand().execute(context);
+
+    const rows = sentCard(sendActivity).body.slice(1) as any[];
+    expect(rows).toHaveLength(1);
+    expect(rowText(rows[0])).toContain('#1 Alice');
+    expect(JSON.stringify(sentCard(sendActivity))).not.toContain(
+      'Unknown user',
+    );
+    expect(consoleWarn).toHaveBeenCalledWith(
+      expect.stringContaining('w-orphan'),
+    );
+    consoleWarn.mockRestore();
+  });
+
+  test('shows the empty-leaderboard card when no wallet can be ranked', async () => {
+    mockGetWallets.mockResolvedValue([]);
+    mockGetUsers.mockResolvedValue([]);
+    const { context, sendActivity } = makeContext();
+
+    await new ShowLeaderboardCommand().execute(context);
+
+    expect(sentCard(sendActivity).body[1]).toMatchObject({
+      text: LEADERBOARD_EMPTY_MESSAGE,
+    });
+  });
+
+  test('tells the user when the wallet directory is unavailable', async () => {
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    mockGetWallets.mockResolvedValue(null);
+    const { context, sendActivity } = makeContext();
+
+    await new ShowLeaderboardCommand().execute(context);
+
+    // Silence would leave the user staring at a command that did nothing.
+    expect(sendActivity).toHaveBeenCalledWith(LEADERBOARD_UNAVAILABLE_MESSAGE);
+    expect(consoleError).toHaveBeenCalled();
+    consoleError.mockRestore();
   });
 });

--- a/src/commands/showLeaderboardCommand.ts
+++ b/src/commands/showLeaderboardCommand.ts
@@ -9,7 +9,7 @@ const adminKey = process.env.LNBITS_ADMINKEY as string;
 // user who has spent or withdrawn from their Private wallet.
 export const LEADERBOARD_TITLE = 'Current leaders (Private wallet balance):';
 export const LEADERBOARD_EMPTY_MESSAGE =
-  'No zaps received yet — be the first to send one!';
+  'No Private wallet balances to rank yet. Send a zap to get things started!';
 export const LEADERBOARD_UNAVAILABLE_MESSAGE =
   'Sorry, I could not load the leaderboard just now. Please try again in a moment.';
 export const LEADERBOARD_LIMIT = 10;
@@ -100,8 +100,10 @@ export class ShowLeaderboardCommand extends SSOCommand {
 
       const globalRewardName = process.env.LNBITS_POINTS_LABEL as string;
 
-      const wallets = await getWallets(adminKey, 'Private');
-      const users = await getUsers(adminKey, null);
+      const [wallets, users] = await Promise.all([
+        getWallets(adminKey, 'Private'),
+        getUsers(adminKey, null),
+      ]);
       // Silence is the wrong answer to a failed lookup: the user typed a
       // command and must be told it did not work.
       if (!wallets || !users) {

--- a/src/commands/showLeaderboardCommand.ts
+++ b/src/commands/showLeaderboardCommand.ts
@@ -1,76 +1,169 @@
 import { SSOCommand } from './SSOCommandMap';
 import { TurnContext, CardFactory } from 'botbuilder';
-import { getWallets, getUser } from '../services/lnbitsService';
+import { getWallets, getUsers } from '../services/lnbitsService';
 
 const adminKey = process.env.LNBITS_ADMINKEY as string;
+
+// Names what the numbers actually are. LNbits exposes a wallet balance, not a
+// received-zaps total, so a title promising "zaps received" would misreport a
+// user who has spent or withdrawn from their Private wallet.
+export const LEADERBOARD_TITLE = 'Current leaders (Private wallet balance):';
+export const LEADERBOARD_EMPTY_MESSAGE =
+  'No zaps received yet — be the first to send one!';
+export const LEADERBOARD_UNAVAILABLE_MESSAGE =
+  'Sorry, I could not load the leaderboard just now. Please try again in a moment.';
+export const LEADERBOARD_LIMIT = 10;
+
+export interface LeaderboardEntry {
+  displayName: string;
+  amount: number;
+}
+
+// Builds the leaderboard card: a title, then one two-column row per leader
+// (rank + name on the left, bold amount on the right), capped at the top
+// LEADERBOARD_LIMIT entries. Entries must already be sorted. With no entries
+// the card says so instead of showing a title over nothing.
+export function buildLeaderboardCard(
+  entries: LeaderboardEntry[],
+  rewardName: string,
+  portalUrl?: string,
+) {
+  const leaders = entries.slice(0, LEADERBOARD_LIMIT);
+  return {
+    type: 'AdaptiveCard',
+    body: [
+      {
+        type: 'TextBlock',
+        text: LEADERBOARD_TITLE,
+        weight: 'Bolder',
+        size: 'Medium',
+        wrap: true,
+      },
+      ...(leaders.length === 0
+        ? [
+            {
+              type: 'TextBlock',
+              text: LEADERBOARD_EMPTY_MESSAGE,
+              wrap: true,
+            },
+          ]
+        : []),
+      ...leaders.map((entry, index) => ({
+        type: 'ColumnSet',
+        columns: [
+          {
+            type: 'Column',
+            width: 'stretch',
+            items: [
+              {
+                type: 'TextBlock',
+                text: `#${index + 1} ${entry.displayName}`,
+                wrap: true,
+              },
+            ],
+          },
+          {
+            type: 'Column',
+            width: 'auto',
+            items: [
+              {
+                type: 'TextBlock',
+                text: `${entry.amount.toLocaleString()} ${rewardName}`,
+                weight: 'Bolder',
+              },
+            ],
+          },
+        ],
+      })),
+    ],
+    ...(portalUrl
+      ? {
+          actions: [
+            {
+              type: 'Action.OpenUrl',
+              title: 'View Wallets',
+              url: `${portalUrl.replace(/\/+$/, '')}/wallet`,
+            },
+          ],
+        }
+      : {}),
+    $schema: 'http://adaptivecards.io/schemas/adaptive-card.json',
+    version: '1.2',
+  };
+}
 
 // New command for showing leaderboard
 export class ShowLeaderboardCommand extends SSOCommand {
   async execute(context: TurnContext): Promise<void> {
     try {
-      //await context.sendActivity('Showing leaderboard...');
       console.log('Showing leaderboard...');
 
       const globalRewardName = process.env.LNBITS_POINTS_LABEL as string;
 
-      // Call the getWallets function
       const wallets = await getWallets(adminKey, 'Private');
-
-      if (wallets) {
-        const filteredWallets = wallets.filter(wallet =>
-          wallet.name.toLowerCase().includes('private'),
+      const users = await getUsers(adminKey, null);
+      // Silence is the wrong answer to a failed lookup: the user typed a
+      // command and must be told it did not work.
+      if (!wallets || !users) {
+        console.error(
+          'Leaderboard unavailable: LNbits returned no wallet or user list.',
         );
-        console.log('Filtered Wallets:', filteredWallets);
+        await context.sendActivity(LEADERBOARD_UNAVAILABLE_MESSAGE);
+        return;
+      }
 
-        // Sort wallets by balance_msat in descending order (sorts in place)
-        filteredWallets.sort((a, b) => b.balance_msat - a.balance_msat);
+      // One getUsers call for every display name instead of a getUser
+      // round-trip per wallet.
+      const nameByUserId = new Map(
+        users.map(individual => [individual.id, individual.displayName]),
+      );
 
-        // The portal shares the PORTAL_URL name with tabs/backend (see
-        // env/.env.dev.example). Without it there is no live portal to link
-        // to, so the button is omitted rather than pointing at a dead URL.
-        const portalUrl = process.env.PORTAL_URL;
-
-        // Format the sorted wallets into an actionable card response
-        const cardResponse = {
-          type: 'AdaptiveCard',
-          body: await Promise.all(
-            filteredWallets.map(async wallet => {
-              const user = await getUser(adminKey, wallet.user);
-              return {
-                type: 'TextBlock',
-                text: `${user.displayName}\n: ${
-                  wallet.balance_msat / 1000
-                } ${globalRewardName}`,
-                weight: 'Bolder',
-                size: 'Medium',
-              };
-            }),
-          ),
-          ...(portalUrl
-            ? {
-                actions: [
-                  {
-                    type: 'Action.OpenUrl',
-                    title: 'View Wallets',
-                    url: `${portalUrl.replace(/\/+$/, '')}/wallet`,
-                  },
-                ],
-              }
-            : {}),
-          $schema: 'http://adaptivecards.io/schemas/adaptive-card.json',
-          version: '1.2',
-        };
-
-        // Send the formatted card as an activity
-        await context.sendActivity({
-          attachments: [CardFactory.adaptiveCard(cardResponse)],
+      const entries: LeaderboardEntry[] = [];
+      for (const candidate of wallets.filter(candidateWallet =>
+        candidateWallet.name.toLowerCase().includes('private'),
+      )) {
+        const displayName = nameByUserId.get(candidate.user);
+        if (!displayName) {
+          // Ranking a wallet we cannot attribute would publish a balance under
+          // a placeholder name. Leave it out and flag it for an operator.
+          console.warn(
+            `Leaderboard: skipping wallet ${candidate.id}; its owner is missing from the LNbits user list.`,
+          );
+          continue;
+        }
+        entries.push({
+          displayName,
+          amount: candidate.balance_msat / 1000,
         });
       }
+
+      // NOTE: the ranking is by Private wallet *balance*, not by a true
+      // "zaps received" total — LNbits only exposes the balance, and a
+      // withdrawal would lower a user's rank. Constraint of the LNbits
+      // data model, which is why the title names the balance.
+      // Equal balances are ordered by name so the card is stable between runs.
+      entries.sort(
+        (first, second) =>
+          second.amount - first.amount ||
+          first.displayName.localeCompare(second.displayName),
+      );
+
+      // The portal shares the PORTAL_URL name with tabs/backend (see
+      // env/.env.dev.example). Without it there is no live portal to link
+      // to, so the button is omitted rather than pointing at a dead URL.
+      const cardResponse = buildLeaderboardCard(
+        entries,
+        globalRewardName,
+        process.env.PORTAL_URL,
+      );
+
+      // Send the formatted card as an activity
+      await context.sendActivity({
+        attachments: [CardFactory.adaptiveCard(cardResponse)],
+      });
     } catch (error) {
       console.error('Error showing leaderboard:', error);
-      await context.sendActivity(
-        'Sorry, something went wrong while showing the leaderboard.',
-      );
+      await context.sendActivity(LEADERBOARD_UNAVAILABLE_MESSAGE);
     }
   }
 }


### PR DESCRIPTION
Fixes #326

Stacked on the receipt-card PR.

## What changed
The leaderboard card had no title, no ranks, unbounded rows, a "\n:" formatting bug, and an N+1 LNbits call per wallet. `buildLeaderboardCard()` now renders the title ("Current leaders based on zaps received are:"), top 10 with #1..#N ranks, two-column rows (name left, bold amount right), and resolves names with a single `getUsers` call. Ordering still ranks by Private-wallet balance (LNbits data-model constraint, noted in code).

## Test plan for QA
- `npx jest`: card shape, top-10 cap, conditional portal button, single `getUsers` call.

**Post-review**: the card title now honestly says it ranks Private-wallet balance (the data model cannot attribute received zaps yet); wallets with unknown owners are filtered with a warning instead of ranked; empty and LNbits-failure states message the user; deterministic tie-break and locale-formatted amounts.
