### PR TITLE
fix: tolerant command matching, channel guide and welcome

### DIFF
--- a/src/commands/SSOCommandMap.test.ts
+++ b/src/commands/SSOCommandMap.test.ts
@@ -1,0 +1,71 @@
+// SSOCommandMap.test.ts
+
+import {
+  SSOCommand,
+  SSOCommandMap,
+  normalizeCommandText,
+} from './SSOCommandMap';
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+
+class FakeCommand extends SSOCommand {
+  execute = jest.fn();
+}
+
+describe('normalizeCommandText', () => {
+  test('lowercases, trims and collapses whitespace', () => {
+    expect(normalizeCommandText('  Send \t  Zap  ')).toBe('send zap');
+  });
+
+  test('drops trailing sentence punctuation', () => {
+    expect(normalizeCommandText('Send zap.')).toBe('send zap');
+    expect(normalizeCommandText('send zap!!')).toBe('send zap');
+    expect(normalizeCommandText('show my balance ?')).toBe('show my balance');
+  });
+});
+
+describe('SSOCommandMap.match', () => {
+  let sendZap: FakeCommand;
+  let showBalance: FakeCommand;
+
+  beforeEach(() => {
+    sendZap = new FakeCommand();
+    showBalance = new FakeCommand();
+    SSOCommandMap.register('send zap', sendZap);
+    SSOCommandMap.register('show my balance', showBalance);
+  });
+
+  test('matches an exact command', () => {
+    expect(SSOCommandMap.match('send zap')).toBe(sendZap);
+  });
+
+  test('is tolerant of case and extra whitespace', () => {
+    expect(SSOCommandMap.match('  SEND   Zap ')).toBe(sendZap);
+  });
+
+  test('matches a message that starts with a known command', () => {
+    expect(SSOCommandMap.match('send zap to bob')).toBe(sendZap);
+    expect(SSOCommandMap.match('Show my balance please')).toBe(showBalance);
+  });
+
+  test('tolerates trailing punctuation', () => {
+    expect(SSOCommandMap.match('send zap.')).toBe(sendZap);
+    expect(SSOCommandMap.match('Send zap!')).toBe(sendZap);
+    expect(SSOCommandMap.match('send zap to bob?')).toBe(sendZap);
+  });
+
+  test('does not match a prefix without a word boundary', () => {
+    expect(SSOCommandMap.match('send zapping everyone')).toBeUndefined();
+  });
+
+  test('returns undefined for unknown or empty text', () => {
+    expect(SSOCommandMap.match('dance for me')).toBeUndefined();
+    expect(SSOCommandMap.match('   ')).toBeUndefined();
+  });
+});
+
+describe('SSOCommandMap.commandNames', () => {
+  test('lists the registered command names', () => {
+    SSOCommandMap.register('send zap', new FakeCommand());
+    expect(SSOCommandMap.commandNames()).toContain('send zap');
+  });
+});

--- a/src/commands/SSOCommandMap.ts
+++ b/src/commands/SSOCommandMap.ts
@@ -5,6 +5,17 @@ export abstract class SSOCommand {
   abstract execute(context: TurnContext): void;
 }
 
+// Lowercase, trim, collapse runs of whitespace and drop trailing sentence
+// punctuation so users don't have to type a command character-perfect:
+// "Send zap." and "send zap" are the same request.
+export const normalizeCommandText = (text: string): string =>
+  text
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, ' ')
+    .replace(/[.!?]+$/, '')
+    .trim();
+
 export class SSOCommandMap {
   private static commands: Map<string, SSOCommand> = new Map();
 
@@ -14,5 +25,29 @@ export class SSOCommandMap {
 
   public static get(commandName: string): SSOCommand | undefined {
     return this.commands.get(commandName);
+  }
+
+  // Tolerant lookup: an exact (normalized) match wins, otherwise a message
+  // that starts with a known command name — on a word boundary — counts as
+  // that command (e.g. "send zap to bob" runs "send zap").
+  public static match(text: string): SSOCommand | undefined {
+    const normalized = normalizeCommandText(text);
+    if (!normalized) {
+      return undefined;
+    }
+    const exact = this.commands.get(normalized);
+    if (exact) {
+      return exact;
+    }
+    for (const [name, command] of this.commands) {
+      if (normalized.startsWith(`${name} `)) {
+        return command;
+      }
+    }
+    return undefined;
+  }
+
+  public static commandNames(): string[] {
+    return [...this.commands.keys()];
   }
 }

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -10,3 +10,20 @@ export const GENERIC_ERROR_MESSAGE =
 // checks). The onMessage catch relays these verbatim; everything else gets
 // GENERIC_ERROR_MESSAGE.
 export class UserFacingError extends Error {}
+
+const commandBullets = (commandNames: string[]): string =>
+  commandNames.map(name => `- **${name}**`).join('\n');
+
+// Channel fallback when a message matches no command: keep the D'oh tone,
+// but tell people what the bot actually understands.
+export const unrecognizedCommandGuide = (commandNames: string[]): string =>
+  "D'oh! I didn't recognize that command. Here's what I can help with:\n" +
+  `${commandBullets(commandNames)}\n` +
+  'Just type one of those to get started!';
+
+// Sent once when the bot is installed or added to a conversation.
+export const welcomeMessage = (commandNames: string[]): string =>
+  "Hi, I'm Zaplie! I help you send zaps to your colleagues. " +
+  'Here are the commands I understand:\n' +
+  `${commandBullets(commandNames)}\n` +
+  'Type one of those to get started!';

--- a/src/teamsBot.test.ts
+++ b/src/teamsBot.test.ts
@@ -15,6 +15,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { TurnContext } from 'botbuilder';
 import { GENERIC_ERROR_MESSAGE } from './messages';
+import { SSOCommand, SSOCommandMap } from './commands/SSOCommandMap';
 
 jest.mock('./services/lnbitsService');
 jest.mock('./services/foundryAgentService');
@@ -62,6 +63,10 @@ const makeContext = (activity: Record<string, unknown>): MockContext => {
   } as unknown as TurnContext;
   return { context, sendActivity };
 };
+
+class SpyCommand extends SSOCommand {
+  execute = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
+}
 
 describe('TeamsBot onMessage error hygiene', () => {
   let consoleError: jest.SpiedFunction<typeof console.error>;
@@ -207,5 +212,74 @@ describe('TeamsBot submitZaps message validation', () => {
       "D'oh! Your zap needs a message, so no zaps were sent.",
     );
     expect(context.updateActivity).not.toHaveBeenCalled();
+  });
+});
+
+describe('TeamsBot command matching', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('runs a command when the message merely starts with it', async () => {
+    const bot = new TeamsBot();
+    const spy = new SpyCommand();
+    SSOCommandMap.register('send zap', spy);
+    const { context } = makeContext({ text: 'Send   Zap to bob please' });
+
+    await bot.run(context);
+
+    expect(spy.execute).toHaveBeenCalledTimes(1);
+  });
+
+  test('lists the known commands when a channel message matches nothing', async () => {
+    const bot = new TeamsBot();
+    const { context, sendActivity } = makeContext({
+      text: 'what can you do?',
+      conversation: {
+        id: 'conv-2',
+        conversationType: 'channel',
+        tenantId: 'tenant-1',
+      },
+    });
+
+    await bot.run(context);
+
+    expect(sendActivity).toHaveBeenCalledTimes(1);
+    const [guide] = sendActivity.mock.calls[0] as unknown as [string];
+    expect(guide).toContain("D'oh!");
+    expect(guide).toContain('send zap');
+    expect(guide).toContain('show my balance');
+    expect(guide).toContain('show leaderboard');
+  });
+});
+
+describe('TeamsBot welcome message', () => {
+  test('welcomes with the command list when the bot itself is added', async () => {
+    const bot = new TeamsBot();
+    const { context, sendActivity } = makeContext({
+      type: 'conversationUpdate',
+      text: undefined,
+      membersAdded: [{ id: 'bot-id' }],
+    });
+
+    await bot.run(context);
+
+    expect(sendActivity).toHaveBeenCalledTimes(1);
+    const [welcome] = sendActivity.mock.calls[0] as unknown as [string];
+    expect(welcome).toContain('send zap');
+    expect(welcome).toContain('show leaderboard');
+  });
+
+  test('stays quiet when only a regular member is added', async () => {
+    const bot = new TeamsBot();
+    const { context, sendActivity } = makeContext({
+      type: 'conversationUpdate',
+      text: undefined,
+      membersAdded: [{ id: 'someone-else' }],
+    });
+
+    await bot.run(context);
+
+    expect(sendActivity).not.toHaveBeenCalled();
   });
 });

--- a/src/teamsBot.ts
+++ b/src/teamsBot.ts
@@ -31,7 +31,12 @@ import {
   ConnectCalendarCommand,
   getStoredGraphToken,
 } from './commands/connectCalendarCommand';
-import { GENERIC_ERROR_MESSAGE, UserFacingError } from './messages';
+import {
+  GENERIC_ERROR_MESSAGE,
+  UserFacingError,
+  unrecognizedCommandGuide,
+  welcomeMessage,
+} from './messages';
 import { runConversationalTurn } from './services/foundryAgentService';
 import { createReadOnlyTools } from './commands/agentTools';
 import { getUser, getWalletBalance } from './services/lnbitsService';
@@ -294,22 +299,26 @@ export class TeamsBot extends TeamsActivityHandler {
           );
         }
 
-        // Trigger command by IM text
+        // Trigger command by IM text. Matching is tolerant: whitespace is
+        // collapsed and a message that starts with a known command (e.g.
+        // "send zap to bob") runs that command.
         if (textMessage) {
-          const command = SSOCommandMap.get(textMessage.toLowerCase());
+          const command = SSOCommandMap.match(textMessage);
           if (command) {
             await command.execute(context);
           } else if (
             context.activity.conversation.conversationType === 'personal'
           ) {
-            // Free text with no exact command match falls back to the
+            // Free text with no command match falls back to the
             // conversational agent, but only in 1:1 chats: ConversationState
             // (and therefore the Foundry conversation) is keyed per
             // conversation, so a team or groupchat would otherwise share one
             // agent thread across unrelated teammates.
             await this.replyConversationally(context, textMessage);
           } else {
-            await context.sendActivity(UNRECOGNIZED_COMMAND_MESSAGE);
+            await context.sendActivity(
+              unrecognizedCommandGuide(SSOCommandMap.commandNames()),
+            );
           }
         }
       } catch (error) {
@@ -321,6 +330,19 @@ export class TeamsBot extends TeamsActivityHandler {
         );
       }
 
+      await next();
+    });
+
+    // Welcome message when the bot itself is installed/added to a chat,
+    // team or group conversation.
+    this.onMembersAdded(async (context, next) => {
+      const botId = context.activity.recipient?.id;
+      const membersAdded = context.activity.membersAdded ?? [];
+      if (membersAdded.some(member => member.id === botId)) {
+        await context.sendActivity(
+          welcomeMessage(SSOCommandMap.commandNames()),
+        );
+      }
       await next();
     });
   }


### PR DESCRIPTION
Fixes #324

## What changed
- Command matching was exact string equality, so "send zap to bob" or a trailing space failed. `SSOCommandMap.match()` now trims, collapses whitespace, and accepts a message that starts with a known command (word-boundary aware).
- In channels, unmatched text now answers with a short guide listing the registered commands (dynamic) instead of a bare "D'oh! I didn't recognize that command". The 1:1 conversational fallback is untouched.
- New `onMembersAdded` welcome message when the bot is installed, listing the commands.

## Test plan for QA
- `npx jest`: matcher tests in `src/commands/SSOCommandMap.test.ts` plus channel fallback, welcome, and negative cases in `src/teamsBot.test.ts`.