### PR TITLE
feat: provision LNbits accounts on first portal visit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,9 @@ deployable components in one repository:
   the Teams member and calls `UserService.ensureUserSetup()`, which creates the
   LNbits user (keyed by AAD object id) and ensures each user has an
   **Allowance** wallet (spending budget) and a **Private** wallet (received
-  Zaps).
+  Zaps). The tab backend mirrors this in `ensureCaller`
+  (`tabs/backend/lnbitsGatewayService.js`), so opening the portal provisions
+  the account too — messaging the bot first is not required.
 - **LNbits integration**: `src/services/lnbitsService.ts` (bot),
   `tabs/src/services/lnbitsServiceLocal.ts` (browser), and
   `functions/services/lnbitsService.ts` (request-scoped) are three parallel

--- a/docs/DEPLOYMENT.adoc
+++ b/docs/DEPLOYMENT.adoc
@@ -136,8 +136,12 @@ Deploy `dist/` with Azure Functions Core Tools or your preferred pipeline
 | Tabs backend
 
 | `LNBITS_INITIAL_ALLOWANCE`
-| Sats granted/topped-up to each user's Allowance wallet
-| Bot
+| Sats granted/topped-up to each user's Allowance wallet. Unset on the tab backend, first-run portal provisioning still creates the account but leaves the Allowance wallet empty and logs the reason
+| Bot, Tabs backend
+
+| `PROFILE_PHOTO_HOST`
+| SharePoint host serving tenant profile photos (for example `contoso.sharepoint.com`). Unset, portal-provisioned accounts are created without an avatar rather than with a URL pointing at another tenant
+| Tabs backend
 
 | `LNBITS_HOST_WALLET_ID`, `LNBITS_HOST_USER_ID`, `LNBITS_INKEY`
 | Source wallet for the scheduled allowance top-up

--- a/docs/FAQS.adoc
+++ b/docs/FAQS.adoc
@@ -29,9 +29,10 @@ the result and your remaining balance.
 
 === Why did sending to a colleague fail?
 
-Recipients must have interacted with the app at least once so their wallets
-exist. Failed recipients are listed on the result card — ask them to message
-the bot, then try again.
+Recipients must have opened the app at least once so their wallets exist —
+either by messaging the bot or by opening the Zaplie tab, both of which
+provision the account. Failed recipients are listed on the result card — ask
+them to open Zaplie, then try again.
 
 === Where do received Zaps go?
 
@@ -50,9 +51,11 @@ LNbits 0.12 or higher, with the User Manager extension enabled.
 
 === How are Teams users mapped to wallets?
 
-By the Entra ID (AAD) object id, stored as an extra field on the LNbits user.
-`FetchUserMiddleware` ensures the user and both wallets exist on every bot
-interaction.
+By the Entra ID (AAD) object id, stored as the LNbits user's `external_id`
+(and mirrored in an extra field). `FetchUserMiddleware` ensures the user and
+both wallets exist on every bot interaction, and the tab backend's
+`ensureCaller` does the same on the first authenticated portal request, so
+neither entry point depends on the other.
 
 === How do I report a security issue?
 

--- a/docs/SOLUTION_DESIGN.adoc
+++ b/docs/SOLUTION_DESIGN.adoc
@@ -87,8 +87,14 @@ flowchart TB
 `CloudAdapter` with multi-tenant credentials. All turns pass through
 `FetchUserMiddleware`, which resolves the Teams member and calls
 `UserService.ensureUserSetup()` — creating the LNbits user (keyed by the AAD
-object id stored in an LNbits extra field) and ensuring the Allowance and
+object id stored in the LNbits `external_id`) and ensuring the Allowance and
 Private wallets exist.
+
+The bot is not the only way in: the tab backend runs the same provisioning from
+`ensureCaller` (`tabs/backend/lnbitsGatewayService.js`) on the first
+authenticated portal request, using the same wallet names, the same
+`external_id` linkage and the same opening allowance. A user who opens the
+portal before ever messaging the bot is provisioned transparently.
 
 `src/teamsBot.ts` extends `TeamsActivityHandler`. Text commands are registered
 in a static `SSOCommandMap` keyed by lower-case message text:

--- a/docs/TROUBLESHOOTING.adoc
+++ b/docs/TROUBLESHOOTING.adoc
@@ -14,7 +14,19 @@
 | Add `"overrides": { "@azure/msal-node": "^2.6.0" }` to `package.json` (see README.md), or use Node 18
 
 | Users have no wallets / "Failed Receivers" when sending a Zap
-| The recipient has not interacted with the app yet, so `ensureUserSetup` never ran. Ask them to message the bot once; verify the LNbits User Manager extension is enabled
+| The recipient has never opened the app, so neither the bot's `ensureUserSetup` nor the portal's `ensureCaller` has run. Ask them to open the Zaplie tab or message the bot once — either provisions the account; verify the LNbits User Manager extension is enabled
+
+| A new user opens the portal and every tab fails with "We could not create your Zaplie wallet yet"
+| First-run provisioning (`tabs/backend/lnbitsGatewayService.js` `ensureCaller`) could not reach LNbits. Check `LNBITS_NODE_URL`/`LNBITS_USERNAME`/`LNBITS_PASSWORD` on the tab backend and the server log line prefixed `Zaplie provisioning:`
+
+| A new user has wallets but a zero Allowance balance
+| `LNBITS_INITIAL_ALLOWANCE` is unset (logged as a warning — the deployment simply grants no opening balance) or set to something that is not a positive integer (logged with `console.error` as a configuration error). Either way the account is usable; look for `Zaplie provisioning: allowance wallet <id> left unfunded (...)`
+
+| An existing user has only one of the two wallets
+| Provisioning was interrupted after the LNbits user was created. Listing that user's own wallets from the portal recreates the missing one — look for `Zaplie provisioning: repairing half-provisioned LNbits user <id>`. If the log instead shows `More than one LNbits user is linked to Entra id ...`, two instances raced and the duplicate could not be deleted: remove the extra user in LNbits User Manager
+
+| Portal-provisioned users show no avatar
+| `PROFILE_PHOTO_HOST` is unset on the tab backend. This is deliberate — there is no default, because guessing another tenant's SharePoint host produces a broken image for everyone
 
 | `send zap` card submits but payment fails
 | Check `LNBITS_ADMINKEY` and `LNBITS_NODE_URL`; confirm the sender's Allowance wallet has sufficient balance and the LNbits instance is reachable from the bot

--- a/tabs/backend/.env.example
+++ b/tabs/backend/.env.example
@@ -15,6 +15,18 @@ LNBITS_USERNAME=
 LNBITS_PASSWORD=
 LNBITS_ADMINKEY=
 
+# Opening Allowance balance credited when the portal provisions a user who has
+# never messaged the bot. Leave empty to provision without funding — the
+# account is still created and the skip is logged. A non-empty value must be a
+# positive integer; anything else is logged as a configuration error and the
+# account is provisioned unfunded.
+LNBITS_INITIAL_ALLOWANCE=
+
+# SharePoint host that serves this tenant's profile photos, e.g.
+# contoso.sharepoint.com. There is no default: unset, provisioned accounts get
+# no avatar instead of a URL pointing at somebody else's tenant.
+PROFILE_PHOTO_HOST=
+
 # Mutable JSON stores. Keep the default (backend/) for local development.
 # Azure Linux App Service should set this to /home/data/zaplie so deployments
 # can replace the application package without replacing runtime state.

--- a/tabs/backend/lnbitsGatewayService.js
+++ b/tabs/backend/lnbitsGatewayService.js
@@ -4,6 +4,7 @@ const {
 } = require('./lnbitsAdmin');
 const {
   findUniqueUserByAadObjectId,
+  findUsersByAadObjectId,
   parseExtra,
 } = require('./lnbitsUserDirectory');
 const {
@@ -15,15 +16,41 @@ const WALLET_CACHE_MS = 30 * 1000;
 const SENSITIVE_FIELD = /(adminkey|inkey|admin.?key|invoice.?key|password|preimage|secret|token)/i;
 const USER_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
 const IDEMPOTENCY_KEY_PATTERN = /^[A-Za-z0-9._~-]{16,128}$/;
+const PRIVATE_WALLET_NAME = 'Private';
+const ALLOWANCE_WALLET_NAME = 'Allowance';
+// Surfaced verbatim by the tab (src/services/lnbitsServiceLocal.ts forwards the
+// gateway's `error` field), so it has to read as user-facing copy.
+const PROVISIONING_FAILED_MESSAGE =
+  'We could not create your Zaplie wallet yet — try again';
+// Avatars come from the tenant's own SharePoint host, so there is no sane
+// default: the bot hardcodes one tenant (src/services/userService.ts), which
+// would fabricate a URL for the wrong organisation everywhere else. When
+// PROFILE_PHOTO_HOST is unset the avatar is simply omitted and the tab falls
+// back to its initials placeholder.
+const profilePhotoUrl = (userPrincipalName) => {
+  const host = String(process.env.PROFILE_PHOTO_HOST || '')
+    .trim()
+    .replace(/^https?:\/\//i, '')
+    .replace(/\/+$/, '');
+  if (!host || !userPrincipalName) {
+    return '';
+  }
+  return `https://${host}/_layouts/15/userphoto.aspx?AccountName=${encodeURIComponent(
+    userPrincipalName,
+  )}`;
+};
 
 let tokenCache = null;
 const walletCache = new Map();
 
 class LnbitsGatewayError extends Error {
-  constructor(message, status = 502) {
+  constructor(message, status = 502, { expose = false } = {}) {
     super(message);
     this.name = 'LnbitsGatewayError';
     this.status = status;
+    // 5xx messages are masked by the router unless they are deliberate,
+    // already-safe copy for the signed-in user.
+    this.expose = expose;
   }
 }
 
@@ -97,6 +124,9 @@ const lnbitsRequest = async (path, options = {}) => {
       `LNbits request failed with status ${response.status}`,
     );
   }
+  if (options.expectJson === false) {
+    return null;
+  }
   return safeJson(response);
 };
 
@@ -119,7 +149,11 @@ const redactSensitive = (value, depth = 0) => {
 
 const sanitizeUser = (user) => {
   const extra = parseExtra(user);
-  let displayName = user.username || user.name || user.id;
+  // extra.display_name is what a provisioned account actually carries (LNbits
+  // itself leaves username/name empty), so it has to be read before falling
+  // back to the opaque LNbits id.
+  let displayName =
+    user.username || user.name || extra.display_name || user.email || user.id;
   if (displayName.includes('@')) {
     displayName = displayName
       .split('@')[0]
@@ -244,17 +278,385 @@ const listAllWallets = async () => {
   return wallets;
 };
 
+const findLinkedUser = async (aadObjectId) =>
+  findUniqueUserByAadObjectId(await listRawUsers(), aadObjectId);
+
 const findCaller = async (aadObjectId) => {
-  const user = findUniqueUserByAadObjectId(await listRawUsers(), aadObjectId);
+  const user = await findLinkedUser(aadObjectId);
   if (!user) {
     throw new LnbitsGatewayError('No LNbits user is linked to this account', 403);
   }
   return user;
 };
 
-const assertCaller = async (aadObjectId) => {
-  await findCaller(aadObjectId);
+// Wallet names are matched case-insensitively because sendZap already treats
+// them that way, and a hand-renamed wallet must not trigger a duplicate.
+const walletNamed = (wallets, name) =>
+  wallets.find(
+    (wallet) => String(wallet.name).trim().toLowerCase() === name.toLowerCase(),
+  ) || null;
+
+// Two different situations, deliberately kept apart:
+//
+// - ABSENT: no opening allowance is configured for this deployment. First-touch
+//   portal provisioning still has to succeed, so the account is created
+//   unfunded and the skip is recorded on the result. This is the divergence
+//   from the weekly-allowance path, which simply has nothing to top up.
+// - MALFORMED: a value is configured but cannot be honoured. That is an
+//   operator mistake, not a deployment choice, so it is flagged as a
+//   configuration error and logged as one.
+//
+// The "positive integer" rule is the same one the rest of the backend applies
+// to sat amounts (rewardAmounts.js maxRewardSats, maxZapAmountSats above), so
+// '500abc' is malformed here exactly as it is there — unlike the bot's
+// parseInt, which would silently read it as 500.
+const initialAllowance = () => {
+  const configured = process.env.LNBITS_INITIAL_ALLOWANCE;
+  if (configured === undefined || String(configured).trim() === '') {
+    return {
+      amount: 0,
+      skipReason: 'LNBITS_INITIAL_ALLOWANCE is not set',
+      configurationError: false,
+    };
+  }
+  const amount = Number(String(configured).trim());
+  if (!Number.isSafeInteger(amount) || amount <= 0) {
+    return {
+      amount: 0,
+      skipReason: `LNBITS_INITIAL_ALLOWANCE must be a positive integer (${configured})`,
+      configurationError: true,
+    };
+  }
+  return { amount, skipReason: null, configurationError: false };
 };
+
+const createLnbitsUser = async ({
+  aadObjectId,
+  displayName,
+  email,
+  userPrincipalName,
+}) => {
+  const profileImg = profilePhotoUrl(userPrincipalName);
+  const user = await lnbitsRequest('/users/api/v1/user', {
+    method: 'POST',
+    body: {
+      email: email || undefined,
+      // The Entra object id lives in external_id, exactly as the bot writes it,
+      // so lnbitsUserDirectory links the account either way it is queried.
+      external_id: aadObjectId,
+      extra: {
+        // display_name/picture are what the bot reads back
+        // (src/services/lnbitsService.ts toUser); profileImg/type/aadObjectId
+        // are what the tab reads back (sanitizeUser above). Writing both keeps
+        // bot- and portal-provisioned accounts interchangeable.
+        display_name: displayName,
+        picture: profileImg,
+        profileImg,
+        aadObjectId,
+        email: email || '',
+        type: 'Teammate',
+        userType: 'teammate',
+      },
+    },
+  });
+  if (!user || typeof user.id !== 'string' || user.id.length === 0) {
+    throw new LnbitsGatewayError('LNbits user creation response is malformed');
+  }
+  return user;
+};
+
+const deleteLnbitsUser = async (userId) => {
+  await lnbitsRequest(`/users/api/v1/user/${encodeURIComponent(userId)}`, {
+    method: 'DELETE',
+    // The User Manager delete returns 200 with no body on some LNbits builds.
+    expectJson: false,
+  });
+};
+
+// The in-flight map that dedupes concurrent first requests is per-process, so
+// two portal instances behind the same load balancer can both miss the
+// directory lookup and create an LNbits user for one Entra oid. That leaves the
+// account permanently unusable: findUniqueUserByAadObjectId throws on every
+// later request. Re-read the directory immediately after creating, and collapse
+// a lost race back to a single row.
+const resolveDuplicateLnbitsUser = async (aadObjectId, created) => {
+  const linked = findUsersByAadObjectId(await listRawUsers(), aadObjectId);
+  // Anything else carrying this oid is another instance's account. Not finding
+  // our own row back (a lagging directory read) is not a reason to keep both.
+  const others = linked.filter((user) => user.id !== created.id);
+  if (others.length === 0) {
+    return created;
+  }
+  const survivor = others[0];
+  console.warn(
+    `Zaplie provisioning: ${others.length + 1} LNbits users are linked to ` +
+      `${aadObjectId}; keeping ${survivor.id} and removing the duplicate ` +
+      `${created.id}`,
+  );
+  try {
+    await deleteLnbitsUser(created.id);
+  } catch (error) {
+    console.error(
+      `Zaplie provisioning: could not delete duplicate LNbits user ${created.id} for ` +
+        `${aadObjectId} (${error.message}). Every request for this account will fail ` +
+        'until the duplicate is removed by hand.',
+    );
+  }
+  return survivor;
+};
+
+const createUserWallet = async (userId, name) => {
+  // POST /api/v1/wallet creates under the caller, so the per-user admin route
+  // is required to own the wallet from the target account.
+  const wallet = await lnbitsRequest(
+    `/users/api/v1/user/${encodeURIComponent(userId)}/wallet`,
+    { method: 'POST', body: { name } },
+  );
+  if (!wallet || typeof wallet.id !== 'string' || wallet.id.length === 0) {
+    throw new LnbitsGatewayError('LNbits wallet creation response is malformed');
+  }
+  cacheWallet(wallet);
+  return wallet;
+};
+
+// LNbits >= 1.0 dropped /topup in favour of PUT /users/api/v1/balance, which is
+// the same admin-credit call the bot makes (lnbitsService.ts topUpWallet). It
+// authenticates with the superuser token the gateway already holds, so no host
+// wallet key is involved.
+const creditWallet = async (walletId, amount) => {
+  await lnbitsRequest('/users/api/v1/balance', {
+    method: 'PUT',
+    body: { id: walletId, amount },
+  });
+};
+
+const ensureProvisionedWallets = async (userId) => {
+  const existing = await listUserWalletsWithKeys(userId);
+  const knownAllowance = walletNamed(existing, ALLOWANCE_WALLET_NAME);
+  const privateWallet =
+    walletNamed(existing, PRIVATE_WALLET_NAME) ||
+    (await createUserWallet(userId, PRIVATE_WALLET_NAME));
+  const allowanceWallet =
+    knownAllowance || (await createUserWallet(userId, ALLOWANCE_WALLET_NAME));
+  return {
+    privateWallet,
+    allowanceWallet,
+    // Only a wallet we just created may be funded: topping up an existing one
+    // would hand a refill to anyone who spends down to zero.
+    allowanceCreated: knownAllowance === null,
+  };
+};
+
+const fundAllowanceWallet = async (walletId) => {
+  const { amount, skipReason, configurationError } = initialAllowance();
+  if (amount === 0) {
+    const message =
+      `Zaplie provisioning: allowance wallet ${walletId} left unfunded ` +
+      `(${skipReason})`;
+    // A misconfigured value is an operator error worth an error-level line; an
+    // absent one is a deliberate deployment choice and only warrants a warning.
+    if (configurationError) {
+      console.error(message);
+    } else {
+      console.warn(message);
+    }
+    return { funded: false, amount: 0, skipReason, configurationError };
+  }
+  try {
+    await creditWallet(walletId, amount);
+    return {
+      funded: true,
+      amount,
+      skipReason: null,
+      configurationError: false,
+    };
+  } catch (error) {
+    // Funding is deliberately not fatal here: this is first-touch provisioning,
+    // and refusing to serve a brand-new user with a 503 because a funding env
+    // is missing or LNbits rejected the credit would lock them out of the
+    // portal entirely. The account works without its opening balance, so the
+    // failure is logged and flagged on the result instead.
+    const reason = `initial allowance top-up failed: ${error.message}`;
+    console.error(`Zaplie provisioning: ${reason}`);
+    return {
+      funded: false,
+      amount,
+      skipReason: reason,
+      configurationError: false,
+    };
+  }
+};
+
+// The wallets were cached at creation time, before the allowance credit landed,
+// so drop this account's directory entries and let the next read repopulate.
+const invalidateUserDirectory = (userId) => {
+  for (const [walletId, entry] of walletCache) {
+    if (entry.wallet?.user === userId) {
+      walletCache.delete(walletId);
+    }
+  }
+};
+
+// The Entra object id is a GUID and must never reach the UI: it would become
+// this account's name in the directory, on the leaderboard and on every zap.
+// A caller whose token carries no name claim falls back to the email local
+// part, and a caller with neither to a readable label kept distinguishable by a
+// short suffix.
+const callerDisplayName = (aadObjectId, profile = {}) => {
+  const claimed = String(profile.displayName || '').trim();
+  if (claimed) {
+    return claimed;
+  }
+  const localPart = String(profile.email || profile.userPrincipalName || '')
+    .split('@')[0]
+    .trim();
+  if (localPart) {
+    return localPart;
+  }
+  return `Teammate ${String(aadObjectId).slice(-4)}`;
+};
+
+// Provisioning can be interrupted between "LNbits user created" and "both
+// wallets created", and the caller gate deliberately short-circuits for an
+// already linked user, so nothing would ever finish the job. Verifying the two
+// wallets on the caller gate would cost an extra LNbits listing on *every*
+// request, so the repair hangs off the one moment the gap is actually observed
+// for free: the caller's own wallet listing (GET /users/:id/wallets, the first
+// thing the tab asks for) coming back without both wallets. A healthy account
+// pays nothing — the listing already happened, and the check is in memory.
+const repairCallerWallets = async (userId, wallets) => {
+  const list = Array.isArray(wallets) ? wallets : [];
+  const missing = [PRIVATE_WALLET_NAME, ALLOWANCE_WALLET_NAME].filter(
+    (name) => walletNamed(list, name) === null,
+  );
+  if (missing.length === 0) {
+    return list;
+  }
+
+  try {
+    console.warn(
+      `Zaplie provisioning: repairing half-provisioned LNbits user ${userId} ` +
+        `(missing ${missing.join(', ')})`,
+    );
+    const repaired = await ensureProvisionedWallets(userId);
+    if (repaired.allowanceCreated) {
+      // This finishes an interrupted provisioning rather than refilling an
+      // account: a wallet that already existed is never topped up, so nobody
+      // can farm an allowance by spending down to zero.
+      await fundAllowanceWallet(repaired.allowanceWallet.id);
+      invalidateUserDirectory(userId);
+    }
+    const known = new Set(list.map((wallet) => wallet.id));
+    return [
+      ...list,
+      ...[repaired.privateWallet, repaired.allowanceWallet]
+        .filter((wallet) => !known.has(wallet.id))
+        .map(sanitizeWallet),
+    ];
+  } catch (error) {
+    // A failed repair must not blank the wallet page: whatever the account does
+    // have is still returned, and the next request tries again.
+    console.error(
+      `Zaplie provisioning: repair of LNbits user ${userId} failed: ${error.message}`,
+    );
+    return list;
+  }
+};
+
+const createEnsureCaller = ({
+  findLinkedUserForCaller = findLinkedUser,
+  createUserForCaller = createLnbitsUser,
+  ensureWalletsForCaller = ensureProvisionedWallets,
+  fundAllowanceForCaller = fundAllowanceWallet,
+  invalidateForCaller = invalidateUserDirectory,
+  resolveDuplicateForCaller = resolveDuplicateLnbitsUser,
+} = {}) => {
+  const inFlight = new Map();
+
+  const provision = async (aadObjectId, profile) => {
+    // Re-check inside the critical section: a request that queued behind the
+    // directory lookup must not create a second LNbits account.
+    const linked = await findLinkedUserForCaller(aadObjectId);
+    if (linked) {
+      return { user: linked, provisioned: false, funding: null };
+    }
+
+    const created = await createUserForCaller({
+      aadObjectId,
+      displayName: callerDisplayName(aadObjectId, profile),
+      email: profile.email || '',
+      userPrincipalName: profile.userPrincipalName || '',
+    });
+
+    const user = await resolveDuplicateForCaller(aadObjectId, created);
+    if (user.id !== created.id) {
+      // Another instance won the race; its account is the survivor and it is
+      // provisioning its own wallets, so nothing more is owed here.
+      return { user, provisioned: false, funding: null };
+    }
+
+    const wallets = await ensureWalletsForCaller(user.id);
+    const funding = wallets.allowanceCreated
+      ? await fundAllowanceForCaller(wallets.allowanceWallet.id)
+      : {
+          funded: false,
+          amount: 0,
+          skipReason: 'allowance wallet already existed',
+          configurationError: false,
+        };
+    await invalidateForCaller(user.id);
+
+    console.log(
+      `Zaplie provisioning: created LNbits user ${user.id} for ${aadObjectId} ` +
+        `(funded: ${funding.funded}${funding.skipReason ? `, ${funding.skipReason}` : ''})`,
+    );
+    return { user, provisioned: true, wallets, funding };
+  };
+
+  return async (input) => {
+    const profile = typeof input === 'string' ? { aadObjectId: input } : input || {};
+    const aadObjectId = profile.aadObjectId;
+    if (typeof aadObjectId !== 'string' || aadObjectId.length === 0) {
+      // Only a verified token reaches this point; an absent oid means the
+      // caller was never authenticated, so nothing is ever provisioned.
+      throw new LnbitsGatewayError(
+        'No LNbits user is linked to this account',
+        403,
+      );
+    }
+
+    const existing = await findLinkedUserForCaller(aadObjectId);
+    if (existing) {
+      return { user: existing, provisioned: false, funding: null };
+    }
+
+    let operation = inFlight.get(aadObjectId);
+    if (!operation) {
+      operation = provision(aadObjectId, profile);
+      inFlight.set(aadObjectId, operation);
+      const release = () => {
+        if (inFlight.get(aadObjectId) === operation) {
+          inFlight.delete(aadObjectId);
+        }
+      };
+      operation.then(release, release);
+    }
+
+    try {
+      return await operation;
+    } catch (error) {
+      if (error instanceof LnbitsGatewayError && error.status === 403) {
+        throw error;
+      }
+      console.error('Zaplie provisioning failed:', error.message);
+      throw new LnbitsGatewayError(PROVISIONING_FAILED_MESSAGE, 503, {
+        expose: true,
+      });
+    }
+  };
+};
+
+const ensureCaller = createEnsureCaller();
 
 const requireOwnedWallet = async (walletId, aadObjectId) => {
   const user = await findCaller(aadObjectId);
@@ -557,9 +959,16 @@ const resetCachesForTests = () => {
 
 module.exports = {
   LnbitsGatewayError,
-  assertCaller,
+  PROVISIONING_FAILED_MESSAGE,
+  callerDisplayName,
+  createEnsureCaller,
   createInvoice,
+  createLnbitsUser,
   createSendZap,
+  ensureCaller,
+  ensureProvisionedWallets,
+  fundAllowanceWallet,
+  initialAllowance,
   createOwnedInvoice,
   getAllPayments,
   getInvoicePayment,
@@ -574,6 +983,7 @@ module.exports = {
   listWalletPayments,
   maxZapAmountSats,
   payOwnedInvoice,
+  repairCallerWallets,
   resetCachesForTests,
   redactSensitive,
   sanitizePayment,

--- a/tabs/backend/lnbitsRoutes.js
+++ b/tabs/backend/lnbitsRoutes.js
@@ -43,7 +43,19 @@ const createLnbitsRouter = ({
       if (!claims || typeof claims.oid !== 'string' || claims.oid.length === 0) {
         throw new Error('token is missing the oid claim');
       }
-      req.auth = { oid: claims.oid, roles: claims.roles || [] };
+      const claimString = (value) =>
+        typeof value === 'string' && value.length > 0 ? value : '';
+      // Profile details for first-run provisioning come from the verified
+      // token, never from the request body, so they cannot be forged.
+      req.auth = {
+        oid: claims.oid,
+        roles: claims.roles || [],
+        name: claimString(claims.name),
+        email:
+          claimString(claims.email) || claimString(claims.preferred_username),
+        userPrincipalName:
+          claimString(claims.upn) || claimString(claims.preferred_username),
+      };
       next();
     } catch (error) {
       console.error('LNbits gateway token validation failed:', error.message);
@@ -51,9 +63,20 @@ const createLnbitsRouter = ({
     }
   });
 
+  // A verified caller who has never used the bot has no LNbits account yet;
+  // provision one here instead of failing the whole tab with a 403.
   router.use(async (req, _res, next) => {
     try {
-      await service.assertCaller(req.auth.oid);
+      const { user } = await service.ensureCaller({
+        aadObjectId: req.auth.oid,
+        displayName: req.auth.name,
+        email: req.auth.email,
+        userPrincipalName: req.auth.userPrincipalName,
+      });
+      // Remembered so a listing of the caller's *own* wallets can finish an
+      // interrupted provisioning (see repairCallerWallets). Other users'
+      // listings are read-only, as before.
+      req.auth.lnbitsUserId = typeof user?.id === 'string' ? user.id : '';
       next();
     } catch (error) {
       next(error);
@@ -81,7 +104,12 @@ const createLnbitsRouter = ({
       res.status(400).json({ error: 'invalid user id' });
       return;
     }
-    res.json(await service.listUserWallets(req.params.userId));
+    const wallets = await service.listUserWallets(req.params.userId);
+    res.json(
+      req.params.userId === req.auth.lnbitsUserId
+        ? await service.repairCallerWallets(req.params.userId, wallets)
+        : wallets,
+    );
   }));
 
   router.get('/wallets', asyncRoute(async (_req, res) => {
@@ -215,8 +243,13 @@ const createLnbitsRouter = ({
   router.use((error, _req, res, _next) => {
     const status = Number.isInteger(error.status) ? error.status : 502;
     console.error('LNbits gateway request failed:', error.message);
+    // Upstream 5xx detail stays hidden; messages explicitly marked as safe
+    // (provisioning failures) are shown so the tab can explain what happened.
     res.status(status).json({
-      error: status >= 500 ? 'LNbits service is unavailable' : error.message,
+      error:
+        status < 500 || error.expose === true
+          ? error.message
+          : 'LNbits service is unavailable',
     });
   });
 

--- a/tabs/backend/lnbitsRoutes.js
+++ b/tabs/backend/lnbitsRoutes.js
@@ -43,8 +43,10 @@ const createLnbitsRouter = ({
       if (!claims || typeof claims.oid !== 'string' || claims.oid.length === 0) {
         throw new Error('token is missing the oid claim');
       }
+      // Trimmed: a whitespace-only claim would otherwise count as present and
+      // be persisted as the LNbits email or an AccountName avatar URL.
       const claimString = (value) =>
-        typeof value === 'string' && value.length > 0 ? value : '';
+        typeof value === 'string' ? value.trim() : '';
       // Profile details for first-run provisioning come from the verified
       // token, never from the request body, so they cannot be forged.
       req.auth = {

--- a/tabs/backend/lnbitsRoutes.test.js
+++ b/tabs/backend/lnbitsRoutes.test.js
@@ -4,15 +4,32 @@ const express = require('express');
 const { createLnbitsRouter } = require('./lnbitsRoutes');
 
 const calls = [];
+const ensureCalls = [];
 const service = {
-  assertCaller: async (oid) => {
-    if (oid === 'unlinked-oid') {
-      const error = new Error('No LNbits user is linked to this account');
-      error.status = 403;
+  ensureCaller: async (profile) => {
+    ensureCalls.push(profile);
+    if (profile.aadObjectId === 'unprovisionable-oid') {
+      const error = new Error(
+        'We could not create your Zaplie wallet yet — try again',
+      );
+      error.status = 503;
+      error.expose = true;
       throw error;
     }
+    if (profile.aadObjectId === 'unlinked-oid') {
+      return { user: { id: 'user-new' }, provisioned: true };
+    }
+    return { user: { id: 'user-1' }, provisioned: false };
   },
   listUsers: async () => [{ id: 'user-1' }],
+  listUserWallets: async (userId) => {
+    calls.push(['wallets', userId]);
+    return [{ id: `${userId}-private`, name: 'Private' }];
+  },
+  repairCallerWallets: async (userId, wallets) => {
+    calls.push(['repair', userId]);
+    return [...wallets, { id: `${userId}-allowance`, name: 'Allowance' }];
+  },
   createOwnedInvoice: async (input) => {
     calls.push(['invoice', input]);
     return {
@@ -37,7 +54,15 @@ const extractBearerToken = (req) => {
 
 const verifyMsalPayload = async (token) => {
   if (token === 'valid-token') return { oid: 'caller-oid' };
-  if (token === 'unlinked-token') return { oid: 'unlinked-oid' };
+  if (token === 'unlinked-token') {
+    return {
+      oid: 'unlinked-oid',
+      name: 'Ada Lovelace',
+      preferred_username: 'ada@example.com',
+      upn: 'ada@example.com',
+    };
+  }
+  if (token === 'unprovisionable-token') return { oid: 'unprovisionable-oid' };
   throw new Error('bad token');
 };
 
@@ -77,15 +102,63 @@ const request = (path, options = {}) =>
     body: options.body ? JSON.stringify(options.body) : undefined,
   });
 
-test('requires a verified token and a linked LNbits user', async () => {
+test('requires a verified token and provisions a first-time caller', async () => {
   assert.equal((await request('/api/lnbits/users')).status, 401);
-  assert.equal(
-    (await request('/api/lnbits/users', { token: 'unlinked-token' })).status,
-    403,
-  );
+  assert.equal((await request('/api/lnbits/users', { token: 'nope' })).status, 401);
+  // An unverified caller must never reach provisioning.
+  assert.equal(ensureCalls.length, 0);
+
+  const firstRun = await request('/api/lnbits/users', {
+    token: 'unlinked-token',
+  });
+  assert.equal(firstRun.status, 200);
+  assert.deepEqual(ensureCalls.at(-1), {
+    aadObjectId: 'unlinked-oid',
+    displayName: 'Ada Lovelace',
+    email: 'ada@example.com',
+    userPrincipalName: 'ada@example.com',
+  });
+
   const response = await request('/api/lnbits/users', { token: 'valid-token' });
   assert.equal(response.status, 200);
   assert.deepEqual(await response.json(), [{ id: 'user-1' }]);
+});
+
+test('a failed provisioning explains itself instead of masking a 5xx', async () => {
+  const response = await request('/api/lnbits/users', {
+    token: 'unprovisionable-token',
+  });
+
+  assert.equal(response.status, 503);
+  assert.deepEqual(await response.json(), {
+    error: 'We could not create your Zaplie wallet yet — try again',
+  });
+});
+
+test('repairs the caller own half-provisioned account, and only theirs', async () => {
+  // ensureCaller short-circuits for an already linked user, so this listing is
+  // where a missing wallet is actually noticed.
+  const own = await request('/api/lnbits/users/user-1/wallets', {
+    token: 'valid-token',
+  });
+  assert.equal(own.status, 200);
+  assert.deepEqual(await own.json(), [
+    { id: 'user-1-private', name: 'Private' },
+    { id: 'user-1-allowance', name: 'Allowance' },
+  ]);
+  assert.deepEqual(calls.slice(-2), [
+    ['wallets', 'user-1'],
+    ['repair', 'user-1'],
+  ]);
+
+  const other = await request('/api/lnbits/users/user-2/wallets', {
+    token: 'valid-token',
+  });
+  assert.deepEqual(await other.json(), [
+    { id: 'user-2-private', name: 'Private' },
+  ]);
+  // Somebody else's account is never touched by the caller's request.
+  assert.deepEqual(calls.at(-1), ['wallets', 'user-2']);
 });
 
 test('derives wallet-write authorization from the verified oid', async () => {

--- a/tabs/backend/lnbitsRoutes.test.js
+++ b/tabs/backend/lnbitsRoutes.test.js
@@ -62,6 +62,14 @@ const verifyMsalPayload = async (token) => {
       upn: 'ada@example.com',
     };
   }
+  if (token === 'blank-claims-token') {
+    return {
+      oid: 'blank-claims-oid',
+      name: '   ',
+      preferred_username: ' ',
+      upn: '\t',
+    };
+  }
   if (token === 'unprovisionable-token') return { oid: 'unprovisionable-oid' };
   throw new Error('bad token');
 };
@@ -122,6 +130,20 @@ test('requires a verified token and provisions a first-time caller', async () =>
   const response = await request('/api/lnbits/users', { token: 'valid-token' });
   assert.equal(response.status, 200);
   assert.deepEqual(await response.json(), [{ id: 'user-1' }]);
+});
+
+test('whitespace-only claims never reach provisioning as a value', async () => {
+  const response = await request('/api/lnbits/users', {
+    token: 'blank-claims-token',
+  });
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(ensureCalls.at(-1), {
+    aadObjectId: 'blank-claims-oid',
+    displayName: '',
+    email: '',
+    userPrincipalName: '',
+  });
 });
 
 test('a failed provisioning explains itself instead of masking a 5xx', async () => {

--- a/tabs/backend/lnbitsUserDirectory.js
+++ b/tabs/backend/lnbitsUserDirectory.js
@@ -18,11 +18,14 @@ const parseExtra = (user) => {
   return {};
 };
 
-const findUniqueUserByAadObjectId = (users, aadObjectId) => {
+// Every LNbits user linked to an Entra object id. Provisioning needs the whole
+// list — a duplicate is exactly the case it has to detect and repair — while
+// reads want the stricter unique lookup below.
+const findUsersByAadObjectId = (users, aadObjectId) => {
   if (!Array.isArray(users)) {
     throw new Error('LNbits users response is not an array');
   }
-  const matches = users.filter((user) => {
+  return users.filter((user) => {
     const extra = parseExtra(user);
     return (
       user?.external_id === aadObjectId ||
@@ -30,10 +33,18 @@ const findUniqueUserByAadObjectId = (users, aadObjectId) => {
       extra.aadObjectId === aadObjectId
     );
   });
+};
+
+const findUniqueUserByAadObjectId = (users, aadObjectId) => {
+  const matches = findUsersByAadObjectId(users, aadObjectId);
   if (matches.length > 1) {
     throw new Error(`More than one LNbits user is linked to Entra id ${aadObjectId}`);
   }
   return matches[0] || null;
 };
 
-module.exports = { findUniqueUserByAadObjectId, parseExtra };
+module.exports = {
+  findUniqueUserByAadObjectId,
+  findUsersByAadObjectId,
+  parseExtra,
+};

--- a/tabs/backend/lnbitsUserDirectory.test.js
+++ b/tabs/backend/lnbitsUserDirectory.test.js
@@ -1,6 +1,10 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
-const { findUniqueUserByAadObjectId, parseExtra } = require('./lnbitsUserDirectory');
+const {
+  findUniqueUserByAadObjectId,
+  findUsersByAadObjectId,
+  parseExtra,
+} = require('./lnbitsUserDirectory');
 
 test('parses object and JSON-string LNbits user metadata', () => {
   assert.deepEqual(parseExtra({ extra: { aadObjectId: 'aad-1' } }), {
@@ -29,6 +33,21 @@ test('finds an LNbits v1 user by external_id', () => {
   ];
 
   assert.equal(findUniqueUserByAadObjectId(users, 'aad-2'), users[1]);
+});
+
+test('lists every duplicate so provisioning can collapse a lost race', () => {
+  const users = [
+    { id: 'user-1', external_id: 'aad-1' },
+    { id: 'user-2', extra: { aadObjectId: 'aad-1' } },
+    { id: 'user-3', external_id: 'aad-2' },
+  ];
+
+  assert.deepEqual(findUsersByAadObjectId(users, 'aad-1'), [users[0], users[1]]);
+  assert.deepEqual(findUsersByAadObjectId(users, 'aad-missing'), []);
+  assert.throws(
+    () => findUsersByAadObjectId(null, 'aad-1'),
+    /LNbits users response is not an array/,
+  );
 });
 
 test('fails loud for malformed or ambiguous directory data', () => {

--- a/tabs/backend/lnbitsUserProvisioning.test.js
+++ b/tabs/backend/lnbitsUserProvisioning.test.js
@@ -1,0 +1,652 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {
+  PROVISIONING_FAILED_MESSAGE,
+  callerDisplayName,
+  createEnsureCaller,
+  createLnbitsUser,
+  fundAllowanceWallet,
+  initialAllowance,
+  listUserWallets,
+  repairCallerWallets,
+  resetCachesForTests,
+} = require('./lnbitsGatewayService');
+
+const withLnbitsEnvironment = (t, overrides = {}) => {
+  const keys = [
+    'LNBITS_NODE_URL',
+    'LNBITS_USERNAME',
+    'LNBITS_PASSWORD',
+    'LNBITS_INITIAL_ALLOWANCE',
+    'PROFILE_PHOTO_HOST',
+  ];
+  const original = Object.fromEntries(keys.map((key) => [key, process.env[key]]));
+  const originalFetch = global.fetch;
+  Object.assign(process.env, {
+    LNBITS_NODE_URL: 'https://lnbits.test',
+    LNBITS_USERNAME: 'test-user',
+    LNBITS_PASSWORD: 'test-password',
+    ...overrides,
+  });
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === undefined) delete process.env[key];
+  }
+  t.after(() => {
+    global.fetch = originalFetch;
+    for (const key of keys) {
+      if (original[key] === undefined) delete process.env[key];
+      else process.env[key] = original[key];
+    }
+    resetCachesForTests();
+  });
+  resetCachesForTests();
+};
+
+const jsonResponse = (body, status = 200) => ({
+  ok: status < 400,
+  status,
+  headers: { get: () => 'application/json' },
+  json: async () => body,
+});
+
+const emptyResponse = () => ({
+  ok: true,
+  status: 200,
+  headers: { get: () => 'text/plain' },
+  json: async () => {
+    throw new Error('the delete response has no body');
+  },
+});
+
+// Records every LNbits call so a test can assert the exact provisioning traffic.
+const recordingLnbits = (
+  requests,
+  { wallets = [], users = [], deleteStatus = 200 } = {},
+) => {
+  const created = [...wallets];
+  const directory = [...users];
+  return async (url, options = {}) => {
+    const path = String(url).replace('https://lnbits.test', '');
+    const method = options.method || 'GET';
+    const body = options.body ? JSON.parse(options.body) : undefined;
+    requests.push([method, path, body]);
+
+    if (path === '/api/v1/auth') {
+      return jsonResponse({ access_token: 'token-1' });
+    }
+    if (path === '/users/api/v1/user' && method === 'POST') {
+      const user = { id: 'user-new', ...body };
+      directory.push(user);
+      return jsonResponse(user);
+    }
+    if (path === '/users/api/v1/user' && method === 'GET') {
+      return jsonResponse(directory);
+    }
+    const deleted = /^\/users\/api\/v1\/user\/([^/]+)$/.exec(path);
+    if (deleted && method === 'DELETE') {
+      if (deleteStatus >= 400) {
+        return jsonResponse({ detail: 'nope' }, deleteStatus);
+      }
+      const index = directory.findIndex((user) => user.id === deleted[1]);
+      if (index >= 0) directory.splice(index, 1);
+      return emptyResponse();
+    }
+    const owner = /^\/users\/api\/v1\/user\/([^/]+)\/wallet$/.exec(path);
+    if (owner) {
+      if (method === 'POST') {
+        const wallet = {
+          id: `wallet-${created.length + 1}`,
+          name: body.name,
+          user: owner[1],
+          inkey: `inkey-${created.length + 1}`,
+          adminkey: `adminkey-${created.length + 1}`,
+          balance_msat: 0,
+        };
+        created.push(wallet);
+        return jsonResponse(wallet, 201);
+      }
+      return jsonResponse(created.filter((wallet) => wallet.user === owner[1]));
+    }
+    if (path === '/users/api/v1/balance' && method === 'PUT') {
+      return jsonResponse({ id: body.id, balance: body.amount });
+    }
+    throw new Error(`unexpected LNbits call: ${method} ${path}`);
+  };
+};
+
+test('a first-time caller gets an LNbits account, both wallets and the allowance', async (t) => {
+  withLnbitsEnvironment(t, {
+    LNBITS_INITIAL_ALLOWANCE: '500',
+    PROFILE_PHOTO_HOST: 'contoso.sharepoint.com',
+  });
+  const requests = [];
+  global.fetch = recordingLnbits(requests);
+
+  const ensureCaller = createEnsureCaller({
+    findLinkedUserForCaller: async () => null,
+  });
+  const result = await ensureCaller({
+    aadObjectId: 'entra-oid-1',
+    displayName: 'Ada Lovelace',
+    email: 'ada@example.com',
+    userPrincipalName: 'ada@example.com',
+  });
+
+  assert.equal(result.provisioned, true);
+  assert.equal(result.user.id, 'user-new');
+  assert.deepEqual(result.funding, {
+    funded: true,
+    amount: 500,
+    skipReason: null,
+    configurationError: false,
+  });
+
+  const createUserCall = requests.find(
+    ([method, path]) => method === 'POST' && path === '/users/api/v1/user',
+  );
+  // The Entra object id is the link the bot writes, and the extra payload has to
+  // satisfy both readers so the account is indistinguishable from a bot one.
+  assert.equal(createUserCall[2].external_id, 'entra-oid-1');
+  assert.equal(createUserCall[2].email, 'ada@example.com');
+  assert.deepEqual(createUserCall[2].extra, {
+    display_name: 'Ada Lovelace',
+    picture:
+      'https://contoso.sharepoint.com/_layouts/15/userphoto.aspx?AccountName=ada%40example.com',
+    profileImg:
+      'https://contoso.sharepoint.com/_layouts/15/userphoto.aspx?AccountName=ada%40example.com',
+    aadObjectId: 'entra-oid-1',
+    email: 'ada@example.com',
+    type: 'Teammate',
+    userType: 'teammate',
+  });
+
+  assert.deepEqual(
+    requests
+      .filter(([method, path]) => method === 'POST' && path.endsWith('/wallet'))
+      .map(([, , body]) => body.name),
+    ['Private', 'Allowance'],
+  );
+  assert.deepEqual(
+    requests.find(([, path]) => path === '/users/api/v1/balance')[2],
+    { id: result.wallets.allowanceWallet.id, amount: 500 },
+  );
+});
+
+test('provisioning still succeeds, and flags itself, when no allowance is configured', async (t) => {
+  withLnbitsEnvironment(t, { LNBITS_INITIAL_ALLOWANCE: undefined });
+  const requests = [];
+  global.fetch = recordingLnbits(requests);
+
+  const result = await createEnsureCaller({
+    findLinkedUserForCaller: async () => null,
+  })({ aadObjectId: 'entra-oid-2', displayName: 'Grace Hopper' });
+
+  assert.equal(result.provisioned, true);
+  assert.deepEqual(result.funding, {
+    funded: false,
+    amount: 0,
+    skipReason: 'LNBITS_INITIAL_ALLOWANCE is not set',
+    // Absent is a deployment choice, not an operator mistake.
+    configurationError: false,
+  });
+  assert.equal(
+    requests.some(([, path]) => path === '/users/api/v1/balance'),
+    false,
+  );
+  // The wallets exist regardless: an unfunded account still beats a 403.
+  assert.equal(result.wallets.privateWallet.name, 'Private');
+  assert.equal(result.wallets.allowanceWallet.name, 'Allowance');
+});
+
+test('a failed top-up flags the account instead of failing provisioning', async (t) => {
+  withLnbitsEnvironment(t, { LNBITS_INITIAL_ALLOWANCE: '500' });
+  global.fetch = async (url, options = {}) => {
+    const path = String(url).replace('https://lnbits.test', '');
+    if (path === '/users/api/v1/balance') {
+      return jsonResponse({ detail: 'nope' }, 500);
+    }
+    return recordingLnbits([])(url, options);
+  };
+
+  const result = await createEnsureCaller({
+    findLinkedUserForCaller: async () => null,
+  })({ aadObjectId: 'entra-oid-3', displayName: 'Alan Turing' });
+
+  assert.equal(result.provisioned, true);
+  assert.equal(result.funding.funded, false);
+  assert.match(result.funding.skipReason, /initial allowance top-up failed/);
+});
+
+const withAllowance = async (value, assertion) => {
+  const original = process.env.LNBITS_INITIAL_ALLOWANCE;
+  try {
+    if (value === undefined) delete process.env.LNBITS_INITIAL_ALLOWANCE;
+    else process.env.LNBITS_INITIAL_ALLOWANCE = value;
+    await assertion();
+  } finally {
+    if (original === undefined) delete process.env.LNBITS_INITIAL_ALLOWANCE;
+    else process.env.LNBITS_INITIAL_ALLOWANCE = original;
+  }
+};
+
+test('an absent allowance provisions unfunded without blaming the operator', async () => {
+  for (const absent of [undefined, '', '   ']) {
+    await withAllowance(absent, () => {
+      assert.deepEqual(initialAllowance(), {
+        amount: 0,
+        skipReason: 'LNBITS_INITIAL_ALLOWANCE is not set',
+        configurationError: false,
+      });
+    });
+  }
+});
+
+test('a malformed allowance is a configuration error, not a plain skip', async () => {
+  // Same "positive integer" rule the rest of the backend applies to sat
+  // amounts, so '500abc' is rejected instead of being read as 500.
+  for (const malformed of ['500abc', 'lots', '0', '-1', '1.5']) {
+    await withAllowance(malformed, () => {
+      assert.deepEqual(initialAllowance(), {
+        amount: 0,
+        skipReason: `LNBITS_INITIAL_ALLOWANCE must be a positive integer (${malformed})`,
+        configurationError: true,
+      });
+    });
+  }
+
+  await withAllowance('21', () => {
+    assert.deepEqual(initialAllowance(), {
+      amount: 21,
+      skipReason: null,
+      configurationError: false,
+    });
+  });
+});
+
+test('a malformed allowance is logged as an error, an absent one only warned', async (t) => {
+  const levels = [];
+  const originalWarn = console.warn;
+  const originalError = console.error;
+  console.warn = (message) => levels.push(['warn', message]);
+  console.error = (message) => levels.push(['error', message]);
+  t.after(() => {
+    console.warn = originalWarn;
+    console.error = originalError;
+  });
+
+  await withAllowance('500abc', async () => {
+    const result = await fundAllowanceWallet('wallet-1');
+    assert.equal(result.configurationError, true);
+    assert.equal(levels.at(-1)[0], 'error');
+    assert.match(levels.at(-1)[1], /must be a positive integer \(500abc\)/);
+  });
+  await withAllowance(undefined, async () => {
+    const result = await fundAllowanceWallet('wallet-1');
+    assert.equal(result.configurationError, false);
+    assert.equal(levels.at(-1)[0], 'warn');
+  });
+});
+
+test('simultaneous first requests create exactly one user and one funding', async () => {
+  let createCalls = 0;
+  let walletCalls = 0;
+  let fundingCalls = 0;
+  const ensureCaller = createEnsureCaller({
+    findLinkedUserForCaller: async () => null,
+    createUserForCaller: async () => {
+      createCalls += 1;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      return { id: 'user-new' };
+    },
+    ensureWalletsForCaller: async () => {
+      walletCalls += 1;
+      return {
+        privateWallet: { id: 'wallet-private', name: 'Private' },
+        allowanceWallet: { id: 'wallet-allowance', name: 'Allowance' },
+        allowanceCreated: true,
+      };
+    },
+    fundAllowanceForCaller: async () => {
+      fundingCalls += 1;
+      return { funded: true, amount: 500, skipReason: null };
+    },
+    invalidateForCaller: () => {},
+    // The cross-instance duplicate check has its own tests below; here the
+    // point is that one process creates one user.
+    resolveDuplicateForCaller: async (_aadObjectId, created) => created,
+  });
+
+  const profile = { aadObjectId: 'entra-oid-4', displayName: 'Ada Lovelace' };
+  const results = await Promise.all([
+    ensureCaller(profile),
+    ensureCaller(profile),
+    ensureCaller(profile),
+  ]);
+
+  assert.equal(createCalls, 1);
+  assert.equal(walletCalls, 1);
+  assert.equal(fundingCalls, 1);
+  assert.deepEqual(
+    results.map((result) => result.user.id),
+    ['user-new', 'user-new', 'user-new'],
+  );
+});
+
+test('a user linked between the lookup and the lock is reused, not duplicated', async () => {
+  let lookups = 0;
+  let createCalls = 0;
+  const ensureCaller = createEnsureCaller({
+    // First lookup misses, the re-check inside the critical section hits.
+    findLinkedUserForCaller: async () => {
+      lookups += 1;
+      return lookups === 1 ? null : { id: 'user-existing' };
+    },
+    createUserForCaller: async () => {
+      createCalls += 1;
+      return { id: 'user-new' };
+    },
+  });
+
+  const result = await ensureCaller({ aadObjectId: 'entra-oid-5' });
+
+  assert.equal(createCalls, 0);
+  assert.deepEqual(result, {
+    user: { id: 'user-existing' },
+    provisioned: false,
+    funding: null,
+  });
+});
+
+test('an already linked user is returned untouched', async () => {
+  let createCalls = 0;
+  let walletCalls = 0;
+  const ensureCaller = createEnsureCaller({
+    findLinkedUserForCaller: async () => ({ id: 'user-1', external_id: 'oid-1' }),
+    createUserForCaller: async () => {
+      createCalls += 1;
+      return { id: 'user-new' };
+    },
+    ensureWalletsForCaller: async () => {
+      walletCalls += 1;
+      return {};
+    },
+  });
+
+  const result = await ensureCaller({ aadObjectId: 'oid-1' });
+
+  assert.equal(createCalls, 0);
+  assert.equal(walletCalls, 0);
+  assert.equal(result.provisioned, false);
+  assert.equal(result.user.id, 'user-1');
+});
+
+test('an unauthenticated caller is rejected before anything is created', async () => {
+  let createCalls = 0;
+  let lookups = 0;
+  const ensureCaller = createEnsureCaller({
+    findLinkedUserForCaller: async () => {
+      lookups += 1;
+      return null;
+    },
+    createUserForCaller: async () => {
+      createCalls += 1;
+      return { id: 'user-new' };
+    },
+  });
+
+  for (const input of [undefined, null, {}, { aadObjectId: '' }, { aadObjectId: 7 }]) {
+    await assert.rejects(
+      ensureCaller(input),
+      (error) =>
+        error.status === 403 && /No LNbits user is linked/.test(error.message),
+    );
+  }
+  assert.equal(lookups, 0);
+  assert.equal(createCalls, 0);
+});
+
+test('a provisioning failure surfaces actionable copy, not a raw 403', async () => {
+  const ensureCaller = createEnsureCaller({
+    findLinkedUserForCaller: async () => null,
+    createUserForCaller: async () => {
+      throw new Error('LNbits request failed with status 500');
+    },
+  });
+
+  await assert.rejects(
+    ensureCaller({ aadObjectId: 'entra-oid-6' }),
+    (error) =>
+      error.status === 503 &&
+      error.expose === true &&
+      error.message === PROVISIONING_FAILED_MESSAGE,
+  );
+});
+
+// The reachable path: ensureCaller short-circuits for an already linked user,
+// so the repair has to hang off the caller's own wallet listing — which is what
+// lnbitsRoutes calls for GET /users/:id/wallets.
+const halfProvisioned = (requests, name) =>
+  recordingLnbits(requests, {
+    wallets: [
+      {
+        id: 'wallet-existing',
+        name,
+        user: 'user-half',
+        inkey: 'inkey-existing',
+        adminkey: 'adminkey-existing',
+        balance_msat: 0,
+      },
+    ],
+  });
+
+test('listing a healthy account costs no extra LNbits call', async (t) => {
+  withLnbitsEnvironment(t, { LNBITS_INITIAL_ALLOWANCE: '500' });
+  global.fetch = async () => {
+    throw new Error('a healthy account must not trigger any repair traffic');
+  };
+
+  const wallets = [
+    { id: 'wallet-1', name: 'Private' },
+    { id: 'wallet-2', name: 'Allowance' },
+  ];
+  assert.deepEqual(await repairCallerWallets('user-healthy', wallets), wallets);
+});
+
+test('a half-provisioned account is repaired when its own wallets are listed', async (t) => {
+  withLnbitsEnvironment(t, { LNBITS_INITIAL_ALLOWANCE: '500' });
+  const requests = [];
+  // Only the Private wallet made it: creating the Allowance wallet failed after
+  // the LNbits user was created, and ensureCaller will never revisit it.
+  global.fetch = halfProvisioned(requests, 'Private');
+
+  const listed = await listUserWallets('user-half');
+  assert.deepEqual(
+    listed.map((wallet) => wallet.name),
+    ['Private'],
+  );
+
+  const repaired = await repairCallerWallets('user-half', listed);
+
+  assert.deepEqual(
+    repaired.map((wallet) => wallet.name),
+    ['Private', 'Allowance'],
+  );
+  assert.deepEqual(
+    requests
+      .filter(([method, path]) => method === 'POST' && path.endsWith('/wallet'))
+      .map(([, , body]) => body.name),
+    ['Allowance'],
+  );
+  // The wallet it just created is funded, finishing the interrupted opening
+  // allowance rather than refilling anything.
+  assert.deepEqual(
+    requests.find(([, path]) => path === '/users/api/v1/balance')[2],
+    { id: repaired.at(-1).id, amount: 500 },
+  );
+});
+
+test('repair reuses an existing allowance wallet and never re-funds it', async (t) => {
+  withLnbitsEnvironment(t, { LNBITS_INITIAL_ALLOWANCE: '500' });
+  const requests = [];
+  // A hand-renamed lower-case wallet still counts as the Allowance wallet.
+  global.fetch = halfProvisioned(requests, 'allowance');
+
+  const repaired = await repairCallerWallets(
+    'user-half',
+    await listUserWallets('user-half'),
+  );
+
+  assert.deepEqual(
+    repaired.map((wallet) => wallet.name),
+    ['allowance', 'Private'],
+  );
+  assert.deepEqual(
+    requests
+      .filter(([method, path]) => method === 'POST' && path.endsWith('/wallet'))
+      .map(([, , body]) => body.name),
+    ['Private'],
+  );
+  assert.equal(
+    requests.some(([, path]) => path === '/users/api/v1/balance'),
+    false,
+  );
+});
+
+test('a failed repair still returns the wallets the account does have', async (t) => {
+  withLnbitsEnvironment(t, { LNBITS_INITIAL_ALLOWANCE: '500' });
+  const originalError = console.error;
+  console.error = () => {};
+  t.after(() => {
+    console.error = originalError;
+  });
+  global.fetch = async (url, options = {}) => {
+    const path = String(url).replace('https://lnbits.test', '');
+    if (path === '/api/v1/auth') {
+      return jsonResponse({ access_token: 'token-1' });
+    }
+    if (options.method === 'POST') {
+      return jsonResponse({ detail: 'nope' }, 500);
+    }
+    return jsonResponse([]);
+  };
+
+  const wallets = [{ id: 'wallet-1', name: 'Private' }];
+  assert.deepEqual(await repairCallerWallets('user-half', wallets), wallets);
+});
+
+test('a second instance racing the same oid leaves exactly one LNbits user', async (t) => {
+  withLnbitsEnvironment(t, { LNBITS_INITIAL_ALLOWANCE: '500' });
+  const requests = [];
+  // The other portal instance already created its user for this oid: the
+  // in-flight map is per-process, so this one only finds out after creating.
+  global.fetch = recordingLnbits(requests, {
+    users: [{ id: 'user-winner', external_id: 'entra-oid-race' }],
+  });
+
+  const result = await createEnsureCaller({
+    findLinkedUserForCaller: async () => null,
+  })({ aadObjectId: 'entra-oid-race', displayName: 'Ada Lovelace' });
+
+  assert.equal(result.user.id, 'user-winner');
+  assert.equal(result.provisioned, false);
+  assert.deepEqual(
+    requests.filter(([method]) => method === 'DELETE'),
+    [['DELETE', '/users/api/v1/user/user-new', undefined]],
+  );
+  // The duplicate is gone before any wallet or funding call is made for it.
+  assert.equal(
+    requests.some(([, path]) => /\/wallet$|\/balance$/.test(path)),
+    false,
+  );
+});
+
+test('a duplicate that cannot be deleted is logged loudly', async (t) => {
+  withLnbitsEnvironment(t, { LNBITS_INITIAL_ALLOWANCE: '500' });
+  const errors = [];
+  const originalError = console.error;
+  const originalWarn = console.warn;
+  console.error = (message) => errors.push(message);
+  console.warn = () => {};
+  t.after(() => {
+    console.error = originalError;
+    console.warn = originalWarn;
+  });
+  global.fetch = recordingLnbits([], {
+    users: [{ id: 'user-winner', external_id: 'entra-oid-race-2' }],
+    deleteStatus: 500,
+  });
+
+  const result = await createEnsureCaller({
+    findLinkedUserForCaller: async () => null,
+  })({ aadObjectId: 'entra-oid-race-2', displayName: 'Ada Lovelace' });
+
+  assert.equal(result.user.id, 'user-winner');
+  assert.match(
+    errors.join('\n'),
+    /could not delete duplicate LNbits user user-new .*until the duplicate is removed by hand/s,
+  );
+});
+
+test('a caller with no name claim is never labelled with their Entra GUID', () => {
+  const oid = '8f14e45f-ceea-467a-9f1e-c6d0f6a4b1d2';
+
+  assert.equal(
+    callerDisplayName(oid, { displayName: 'Ada Lovelace', email: 'ada@x.com' }),
+    'Ada Lovelace',
+  );
+  assert.equal(
+    callerDisplayName(oid, { displayName: '   ', email: 'ada@x.com' }),
+    'ada',
+  );
+  assert.equal(callerDisplayName(oid, { userPrincipalName: 'grace@x.com' }), 'grace');
+  // Neither claim: a readable label with a short suffix, never the GUID.
+  assert.equal(callerDisplayName(oid, {}), 'Teammate b1d2');
+  assert.equal(callerDisplayName(oid), 'Teammate b1d2');
+  assert.equal(callerDisplayName(oid, { email: '  ' }).includes(oid), false);
+});
+
+test('no avatar is fabricated when the tenant photo host is unset', async (t) => {
+  withLnbitsEnvironment(t, { PROFILE_PHOTO_HOST: undefined });
+  const requests = [];
+  global.fetch = recordingLnbits(requests);
+
+  await createEnsureCaller({ findLinkedUserForCaller: async () => null })({
+    aadObjectId: 'entra-oid-8',
+    displayName: 'Ada Lovelace',
+    email: 'ada@example.com',
+    userPrincipalName: 'ada@example.com',
+  });
+
+  const created = requests.find(
+    ([method, path]) => method === 'POST' && path === '/users/api/v1/user',
+  );
+  assert.equal(created[2].extra.profileImg, '');
+  assert.equal(created[2].extra.picture, '');
+});
+
+test('createLnbitsUser rejects a malformed LNbits response', async (t) => {
+  withLnbitsEnvironment(t);
+  global.fetch = async (url) =>
+    String(url).endsWith('/api/v1/auth')
+      ? jsonResponse({ access_token: 'token-1' })
+      : jsonResponse({ detail: 'created' });
+
+  await assert.rejects(
+    createLnbitsUser({ aadObjectId: 'oid-7', displayName: 'Nobody' }),
+    /user creation response is malformed/,
+  );
+});
+
+test('an unfunded wallet is reported when the allowance is unset', async (t) => {
+  withLnbitsEnvironment(t, { LNBITS_INITIAL_ALLOWANCE: undefined });
+  global.fetch = async () => {
+    throw new Error('no LNbits call is expected without an allowance');
+  };
+
+  assert.deepEqual(await fundAllowanceWallet('wallet-1'), {
+    funded: false,
+    amount: 0,
+    skipReason: 'LNBITS_INITIAL_ALLOWANCE is not set',
+    configurationError: false,
+  });
+});


### PR DESCRIPTION
Fixes #333

## What changed
The portal gateway now provisions LNbits accounts on first authenticated access instead of returning a bare 403 — a user no longer has to message the bot before the portal works.
- `ensureCaller` (replacing the dead `assertCaller`) creates the LNbits user with `external_id = oid` from the verified MSAL token (claims only, never the body), `Private` + `Allowance` wallets, and an `extra` payload that is the union of what the bot and the portal each read — bot- and portal-provisioned users are indistinguishable.
- Initial allowance funding is best-effort via the superuser balance API (LNbits ≥1.0 needs no host wallet): missing/invalid `LNBITS_INITIAL_ALLOWANCE` is reported (`funding.funded=false` + reason) instead of silently skipped, and a funding failure never blocks account creation. Only newly created Allowance wallets are funded.
- Concurrency-safe: per-oid in-flight dedupe with a re-check inside the critical section; simultaneous first requests share one provisioning.
- Failures surface as a clear, exposed 503 ('We could not create your Zaplie wallet yet — try again') instead of the masked generic error; the existing fail-closed UI states render it with no frontend changes.
- Docs updated everywhere the 'message the bot first' caveat lived.

## Test plan for QA
- `npm run test:backend` (tabs): 90 tests green, 13 new — happy path (external_id, extra union, wallet order, exact top-up body), unfunded/invalid-allowance paths, 3-way concurrency dedupe, race re-check, existing users untouched, no provisioning without a valid oid, exposed error copy, repair path reusing an existing wallet.
- Manual: sign into the portal with a brand-new Entra user that never talked to the bot — expect wallets to exist and the feed to load; with `LNBITS_INITIAL_ALLOWANCE` unset, expect account creation with zero balance and a log line.

**Post-review hardening**: wallet repair is now reachable for existing users at zero hot-path cost (it hooks the caller's own wallet listing, creating only what's missing and funding only newly created Allowance wallets); multi-instance duplicate creation self-heals (post-create re-check deletes the loser); malformed `LNBITS_INITIAL_ALLOWANCE` logs a configuration error (absent = provision unfunded, by design); `PROFILE_PHOTO_HOST` env replaces the hardcoded tenant host; and a display-name fallback chain guarantees no Entra GUID ever reaches the UI. 101/101 backend tests.
